### PR TITLE
cmd/nodeutils: clarify create-fifo flag

### DIFF
--- a/cmd/nodeutils/config.go
+++ b/cmd/nodeutils/config.go
@@ -44,7 +44,7 @@ func init() {
 
 	flag.BoolVar(&createFifo, "create-fifo",
 		environ.GetBool("CREATE_FIFO", false),
-		"log level",
+		"create FIFO for trace store",
 	)
 
 	flag.BoolVar(&enableTmkmsProxy, "tmkms-proxy",


### PR DESCRIPTION
## Summary
- clarify `create-fifo` flag description

## Testing
- `go fmt cmd/nodeutils/config.go`
- `go build ./cmd/nodeutils` *(fails: command stalled and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68aeece302e48330be23dfeb631c2838