### PR TITLE
chore: refactor account tests with subtests and error case

### DIFF
--- a/internal/chainutils/account_test.go
+++ b/internal/chainutils/account_test.go
@@ -12,10 +12,13 @@ const testMnemonic = "upset promote follow flag you way eagle plunge scorpion oi
 
 func TestAccountFromMnemonic(t *testing.T) {
 	tests := []struct {
+		name     string
 		provided string
 		expected *Account
+		wantErr  bool
 	}{
 		{
+			name:     "valid mnemonic",
 			provided: testMnemonic,
 			expected: &Account{
 				Mnemonic:         testMnemonic,
@@ -23,31 +26,47 @@ func TestAccountFromMnemonic(t *testing.T) {
 				ValidatorAddress: "nibivaloper1ll3njapxnyqqvfz65puwvmmya23a0xcq7jcdfk",
 			},
 		},
+		{
+			name:     "invalid mnemonic",
+			provided: "invalid mnemonic",
+			wantErr:  true,
+		},
 	}
 
-	for _, test := range tests {
-		result, err := AccountFromMnemonic(test.provided, appsv1.DefaultAccountPrefix, appsv1.DefaultValPrefix, appsv1.DefaultHDPath)
-		assert.NoError(t, err)
-		assert.Equal(t, test.expected.Mnemonic, result.Mnemonic)
-		assert.Equal(t, test.expected.ValidatorAddress, result.ValidatorAddress)
-		assert.Equal(t, test.expected.Address, result.Address)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := AccountFromMnemonic(tt.provided, appsv1.DefaultAccountPrefix, appsv1.DefaultValPrefix, appsv1.DefaultHDPath)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected.Mnemonic, result.Mnemonic)
+			assert.Equal(t, tt.expected.ValidatorAddress, result.ValidatorAddress)
+			assert.Equal(t, tt.expected.Address, result.Address)
+		})
 	}
 }
 
 func TestAccountAddressFromValidatorAddress(t *testing.T) {
 	tests := []struct {
+		name     string
 		provided string
 		expected string
 	}{
 		{
+			name:     "validator to account",
 			provided: "nibivaloper1efeydq3s4wgrv5yslxcevsstwtrkmkel5zkqgx",
 			expected: "nibi1efeydq3s4wgrv5yslxcevsstwtrkmkelaecmum",
 		},
 	}
 
-	for _, test := range tests {
-		result, err := AccountAddressFromValidatorAddress(test.provided, appsv1.DefaultValPrefix, appsv1.DefaultAccountPrefix)
-		assert.NoError(t, err)
-		assert.Equal(t, test.expected, result)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := AccountAddressFromValidatorAddress(tt.provided, appsv1.DefaultValPrefix, appsv1.DefaultAccountPrefix)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- refactor account utility tests to use named subtests
- cover invalid mnemonic case in AccountFromMnemonic

## Testing
- `go test ./internal/chainutils` *(fails: command produced no output, likely environment limitation)*

------
https://chatgpt.com/codex/tasks/task_b_68aeecee261c83309257bc47e2d44867