### PR TITLE
docs: expand usage guides for new features

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,6 +48,9 @@ export default defineConfig({
           { text: 'Initializing new Network', link: '10-initializing-new-network' },
           { text: 'Using TmKMS', link: '11-tmkms' },
           { text: 'Using CosmoGuard', link: '12-cosmoguard' },
+          { text: 'Using Cosmoseed', link: '13-cosmoseed' },
+          { text: 'Pod Disruption Budgets', link: '14-pod-disruption-budgets' },
+          { text: 'Vertical Pod Autoscaling', link: '15-vertical-pod-autoscaling' },
         ]
       },
       {

--- a/docs/01-getting-started/02-installation.md
+++ b/docs/01-getting-started/02-installation.md
@@ -31,7 +31,7 @@ $ helm install \
 
 ---
 
-If you opted for not installing cert-manager (one of the recommended controllers in [Prerequisites](01-prerequisites) page), you need to disable both webhooks:
+If you opted for not installing cert-manager (one of the recommended controllers in [Prerequisites](01-prerequisites) page), you need to disable webhooks:
 
 ```bash
 $ helm install \

--- a/docs/01-getting-started/03-configuration.md
+++ b/docs/01-getting-started/03-configuration.md
@@ -36,6 +36,10 @@ $ helm show values oci://ghcr.io/nibiruchain/helm/cosmopilot
 - **Description**: The container image of [CosmoGuard](https://github.com/NibiruChain/cosmoguard) (with version tag included).
 - **Default**: `ghcr.io/nibiruchain/cosmoguard`
 
+### `cosmoseedImage`
+- **Description**: The container image of [Cosmoseed](https://github.com/NibiruChain/cosmoseed) (with version tag included). Used when deploying seed nodes.
+- **Default**: `ghcr.io/nibiruchain/cosmoseed`
+
 ### `imagePullSecrets`
 - **Description**: Secrets for pulling images from private repositories.
 - **Default**: `[]`

--- a/docs/02-usage/07-exposing-endpoints.md
+++ b/docs/02-usage/07-exposing-endpoints.md
@@ -1,8 +1,8 @@
 # Exposing Endpoints
 
-This page provides guidance on exposing endpoints for nodes managed by `Cosmopilot`. Exposing `API` endpoints relies on the creation of ingress resources, which are designed to work exclusively with `NGINX` (and `cert-manager` for securing the endpoints). For this reason, `NGINX` and `cert-manager` are included in the requirements listed in the [Prerequisites](/01-getting-started/01-prerequisites) page.
+This page provides guidance on exposing endpoints for nodes managed by `Cosmopilot`. Exposing `API` endpoints relies on the creation of ingress resources. By default, these ingresses are created for the `nginx` ingress controller and secured using `cert-manager`. You can target a different ingress controller by setting the `ingressClass` field in your manifests.
 
-The only exception is the `P2P` port, which can be exposed without `NGINX` and `cert-manager`.
+The only exception is the `P2P` port, which can be exposed without any ingress controller.
 
 ## Exposing the P2P Port
 
@@ -28,12 +28,28 @@ expose:
 ## Exposing API Endpoints
 
 API endpoints can be enabled either:
-1. **Per Group of Nodes**: Configure under `.spec.nodes[].ingress`.
-2. **Global Ingress**: Configure under `.spec.ingresses` to target multiple groups of nodes (this is the recommended approach, as per-group ingress configuration might be deprecated in the future).
+1. **Per ChainNode**: Configure under `.spec.ingress` on the `ChainNode` resource.
+2. **Per Group of Nodes**: Configure under `.spec.nodes[].ingress` on a `ChainNodeSet`.
+3. **Global Ingress**: Configure under `.spec.ingresses` to target multiple groups of nodes (this is the recommended approach, as per-group ingress configuration might be deprecated in the future).
+
+### ChainNode Ingress Example
+
+To expose API endpoints for a single `ChainNode`, use the following configuration under `.spec.ingress`:
+
+```yaml
+ingress:
+  host: node.example.com
+  enableRPC: true # optional. Defaults to `false`.
+  enableGRPC: true # optional. Defaults to `false`.
+  enableLCD: true # optional. Defaults to `false`.
+  ingressClass: traefik # optional. Defaults to `nginx`.
+  disableTLS: false # optional. Defaults to `false`.
+  tlsSecretName: node-tls # optional. Defaults to `<service-name>-tls`.
+```
 
 ### Per Group Ingress Example
 
-To expose API endpoints for a specific group of nodes, use the following configuration under `.spec.nodes[].ingress`:
+To expose API endpoints for a specific group of nodes within a `ChainNodeSet`, use the following configuration under `.spec.nodes[].ingress`:
 
 ```yaml
 ingress:
@@ -43,6 +59,7 @@ ingress:
   enableLCD: true # optional. Defaults to `false`.
   enableEvmRPC: false # optional. Defaults to `false`.
   enableEvmRpcWS: false # optional. Defaults to `false`.
+  ingressClass: nginx # optional. Defaults to `nginx`.
   annotations: # optional annotations to ingress resource
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
   disableTLS: false # optional. Defaults to `false`.
@@ -65,10 +82,23 @@ ingresses:
     enableLCD: true # optional. Defaults to `false`.
     enableEvmRPC: true # optional. Defaults to `false`.
     enableEvmRpcWS: true # optional. Defaults to `false`.
+    ingressClass: nginx # optional. Defaults to `nginx`.
     annotations: # optional annotations to ingress resource
       nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     disableTLS: false # optional. Defaults to `false`.
     tlsSecretName: global-tls-secret # optional. Defaults to `<service-name>-tls`.
+```
+
+### Internal Services Only
+
+If you only need internal `Service` resources (for example, when another controller manages ingress creation), set `servicesOnly` to `true` on a global ingress:
+
+```yaml
+ingresses:
+  - name: internal-only
+    groups: [fullnode]
+    host: api.nodes.internal
+    servicesOnly: true
 ```
 
 ::: info NOTE

--- a/docs/02-usage/13-cosmoseed.md
+++ b/docs/02-usage/13-cosmoseed.md
@@ -1,0 +1,28 @@
+# Using Cosmoseed
+
+`Cosmoseed` provides lightweight seed nodes for Cosmos networks. `Cosmopilot` can deploy and manage these seed nodes alongside your regular nodes.
+
+## Enabling Cosmoseed
+
+Enable Cosmoseed in a `ChainNodeSet` by configuring the `cosmoseed` section:
+
+```yaml
+cosmoseed:
+  enabled: true
+  instances: 2            # optional, defaults to 1
+  allowNonRoutable: true  # optional, defaults to false
+  expose:                 # optional P2P exposure
+    p2p: true
+    p2pServiceType: LoadBalancer
+  ingress:                # optional HTTP ingress for monitoring
+    host: seeds.example.com
+    ingressClass: nginx   # optional, defaults to nginx
+```
+
+This configuration deploys two seed nodes, exposes their P2P ports and creates an ingress reachable at `seeds.example.com`.
+
+## Notes
+
+- `allowNonRoutable` can be enabled for private networks or testing environments.
+- If `ingress` is omitted, the seed nodes will not be reachable via HTTP.
+

--- a/docs/02-usage/14-pod-disruption-budgets.md
+++ b/docs/02-usage/14-pod-disruption-budgets.md
@@ -1,0 +1,28 @@
+# Pod Disruption Budgets
+
+Pod Disruption Budgets (PDBs) ensure that a minimum number of pods remain available during voluntary disruptions such as node upgrades or evictions. `Cosmopilot` allows you to configure PDBs for validator and node groups within a `ChainNodeSet`.
+
+## Example
+
+```yaml
+spec:
+  nodes:
+    - name: fullnode
+      instances: 3
+      pdb:
+        enabled: true
+        minAvailable: 2   # optional, defaults to instances - 1
+  validator:
+    pdb:
+      enabled: true
+      minAvailable: 3    # meaningful only when other validators exist
+```
+
+With this configuration, Kubernetes will ensure that at least two fullnode pods remain running and, when multiple validators exist in the namespace, at least three validator pods stay available during maintenance operations.
+
+## Notes
+
+- PDBs are currently supported only on `ChainNodeSet` resources.
+- `minAvailable` defaults to the number of instances minus one for node groups.
+- A validator PDB only has an effect when multiple validators run in the same namespace; otherwise the default `minAvailable: 0` leaves it ineffective.
+

--- a/docs/02-usage/15-vertical-pod-autoscaling.md
+++ b/docs/02-usage/15-vertical-pod-autoscaling.md
@@ -1,0 +1,47 @@
+# Vertical Pod Autoscaling
+
+Vertical Pod Autoscaling (VPA) automatically adjusts CPU and memory requests based on actual usage. This helps keep pods right-sized without manual tuning.
+
+`Cosmopilot` can configure VPA for a `ChainNode` or the validator within a `ChainNodeSet`.
+
+## Example
+
+```yaml
+spec:
+  vpa:
+    enabled: true
+    cpu:
+      cooldown: 30m
+      min: 750m
+      max: 8000m
+      rules:
+        - direction: up
+          usagePercent: 90
+          duration: 5m
+          stepPercent: 50
+        - direction: down
+          usagePercent: 40
+          duration: 30m
+          stepPercent: 50
+    memory:
+      cooldown: 30m
+      min: 4Gi
+      max: 32Gi
+      rules:
+        - direction: up
+          usagePercent: 90
+          duration: 5m
+          stepPercent: 75
+        - direction: down
+          usagePercent: 40
+          duration: 30m
+          stepPercent: 50
+```
+
+In this example the `ChainNode` defines CPU and memory scaling rules for its pods.
+
+## Notes
+
+- VPA requires a Vertical Pod Autoscaler controller running in the cluster.
+- If `enabled` is set to `false`, pods keep their configured CPU and memory requests without vertical autoscaling.
+


### PR DESCRIPTION
## Summary
- add Cosmoseed usage guide
- document Pod Disruption Budgets configuration, including validator guidance
- document Vertical Pod Autoscaling with detailed CPU/memory rules
- expand ingress docs for ChainNode, internal services, and custom ingress classes
- clarify that disabling VPA leaves pods with fixed resource requests
- remove "both" from cert-manager installation note
- document `cosmoseedImage` Helm value in configuration

## Testing
- `go test ./...` *(no output; command interrupted)*
- `npm --prefix docs run docs:build`


------
https://chatgpt.com/codex/tasks/task_b_68aeeb418dfc83308b35df8a494c1baf