### PR TITLE
fix(chainnode): restart peer pods on peer reschedule

### DIFF
--- a/internal/controllers/chainnode/peer_watch_test.go
+++ b/internal/controllers/chainnode/peer_watch_test.go
@@ -1,0 +1,145 @@
+package chainnode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+)
+
+func TestPeerPodPredicate_Create(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "pod with chain-id label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+					Labels: map[string]string{
+						controllers.LabelChainID: "test-chain",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod without chain-id label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "unrelated-pod",
+					Labels: map[string]string{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod with no labels",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-labels-pod",
+				},
+			},
+			want: false,
+		},
+	}
+
+	p := peerPodPredicate{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.Create(event.CreateEvent{Object: tt.pod})
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestPeerPodPredicate_Create_NilObject(t *testing.T) {
+	p := peerPodPredicate{}
+	result := p.Create(event.CreateEvent{Object: nil})
+	assert.False(t, result)
+}
+
+func TestPeerPodPredicate_Update(t *testing.T) {
+	p := peerPodPredicate{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Labels: map[string]string{
+				controllers.LabelChainID: "test-chain",
+			},
+		},
+	}
+
+	// Update events should always return false — only create/delete matter for UID tracking
+	result := p.Update(event.UpdateEvent{
+		ObjectOld: pod,
+		ObjectNew: pod,
+	})
+	assert.False(t, result)
+}
+
+func TestPeerPodPredicate_Delete(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "pod with chain-id label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+					Labels: map[string]string{
+						controllers.LabelChainID: "test-chain",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod without chain-id label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "unrelated-pod",
+					Labels: map[string]string{},
+				},
+			},
+			want: false,
+		},
+	}
+
+	p := peerPodPredicate{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.Delete(event.DeleteEvent{Object: tt.pod})
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestPeerPodPredicate_Delete_NilObject(t *testing.T) {
+	p := peerPodPredicate{}
+	result := p.Delete(event.DeleteEvent{Object: nil})
+	assert.False(t, result)
+}
+
+func TestPeerPodPredicate_Generic(t *testing.T) {
+	p := peerPodPredicate{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Labels: map[string]string{
+				controllers.LabelChainID: "test-chain",
+			},
+		},
+	}
+
+	result := p.Generic(event.GenericEvent{Object: pod})
+	assert.False(t, result)
+}

--- a/internal/controllers/constant.go
+++ b/internal/controllers/constant.go
@@ -36,6 +36,7 @@ const (
 	AnnotationVPALastMemoryScale      = "cosmopilot.voluzi.com/last-memory-scale"
 	AnnotationVPAOOMRecoveryHistory   = "cosmopilot.voluzi.com/oom-recovery-history"
 	AnnotationStatefulSetPodName      = "statefulset.kubernetes.io/pod-name"
+	AnnotationPeerPodsHash            = "cosmopilot.voluzi.com/peer-pods-hash"
 
 	LabelNodeID                = "node-id"
 	LabelChainID               = "chain-id"

--- a/test/e2e/chainnode_peer_reconnect_test.go
+++ b/test/e2e/chainnode_peer_reconnect_test.go
@@ -1,0 +1,115 @@
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+)
+
+var _ = Describe("ChainNode Peer Reconnect", func() {
+	Context("Peer pod reschedule triggers peer restart", func() {
+		apps.ForEachApp("should restart peer pods when a peer pod is rescheduled",
+			WithNamespace(func(app apps.TestApp, ns *corev1.Namespace) {
+				ctx := Framework().Context()
+
+				// Create two ChainNodes that will auto-discover each other as peers.
+				// We use a ChainNodeSet with 1 fullnode to get a validator + fullnode pair.
+				chainNodeSet := app.BuildChainNodeSet(ns.Name, 1)
+				err := Framework().Client().Create(ctx, chainNodeSet)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Wait for ChainNodeSet to reach running phase
+				WaitForChainNodeSetRunning(chainNodeSet)
+
+				// Verify ChainNodes were created (validator + 1 fullnode = 2)
+				Expect(CountChainNodes(ns.Name)).To(Equal(2))
+
+				// Wait for nodes to reach height > 2 to confirm they're producing blocks
+				WaitForChainNodeSetHeight(chainNodeSet, 2)
+
+				// Get the fullnode pod name and its current UID
+				RefreshChainNodeSet(chainNodeSet)
+				fullnodeName := fmt.Sprintf("%s-fullnodes-0", chainNodeSet.Name)
+				validatorName := fmt.Sprintf("%s-validator", chainNodeSet.Name)
+
+				fullnodePod := &corev1.Pod{}
+				err = Framework().Client().Get(ctx, types.NamespacedName{
+					Namespace: ns.Name,
+					Name:      fullnodeName,
+				}, fullnodePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Record the validator pod's UID before the fullnode reschedule
+				validatorPod := &corev1.Pod{}
+				err = Framework().Client().Get(ctx, types.NamespacedName{
+					Namespace: ns.Name,
+					Name:      validatorName,
+				}, validatorPod)
+				Expect(err).NotTo(HaveOccurred())
+				validatorUIDBeforeReschedule := validatorPod.UID
+
+				// Record the peer-pods-hash annotation on the validator's ConfigMap before reschedule
+				validatorCM := &corev1.ConfigMap{}
+				err = Framework().Client().Get(ctx, types.NamespacedName{
+					Namespace: ns.Name,
+					Name:      validatorName,
+				}, validatorCM)
+				Expect(err).NotTo(HaveOccurred())
+				hashBefore := validatorCM.Annotations[controllers.AnnotationPeerPodsHash]
+
+				// Delete the fullnode pod to simulate a reschedule
+				By("Deleting fullnode pod to simulate reschedule")
+				err = Framework().Client().Delete(ctx, fullnodePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Wait for the fullnode pod to come back with a new UID
+				By("Waiting for fullnode pod to be recreated with new UID")
+				Eventually(func() bool {
+					newPod := &corev1.Pod{}
+					if err := Framework().Client().Get(ctx, client.ObjectKeyFromObject(fullnodePod), newPod); err != nil {
+						return false
+					}
+					// Pod must exist with a different UID (rescheduled)
+					return newPod.UID != fullnodePod.UID
+				}).Should(BeTrue())
+
+				// Wait for the validator's ConfigMap peer-pods-hash to change
+				By("Waiting for validator ConfigMap peer-pods-hash annotation to change")
+				Eventually(func() string {
+					cm := &corev1.ConfigMap{}
+					if err := Framework().Client().Get(ctx, types.NamespacedName{
+						Namespace: ns.Name,
+						Name:      validatorName,
+					}, cm); err != nil {
+						return hashBefore
+					}
+					return cm.Annotations[controllers.AnnotationPeerPodsHash]
+				}).ShouldNot(Equal(hashBefore))
+
+				// Wait for the validator pod to be recreated (new UID due to changed peer-pods-hash)
+				By("Waiting for validator pod to be recreated due to peer-pods-hash change")
+				Eventually(func() bool {
+					newValidatorPod := &corev1.Pod{}
+					if err := Framework().Client().Get(ctx, types.NamespacedName{
+						Namespace: ns.Name,
+						Name:      validatorName,
+					}, newValidatorPod); err != nil {
+						return false
+					}
+					return newValidatorPod.UID != validatorUIDBeforeReschedule
+				}).Should(BeTrue())
+
+				// Verify both nodes reconnect and continue producing blocks
+				By("Verifying both nodes continue producing blocks after reconnect")
+				WaitForChainNodeSetHeight(chainNodeSet, 5)
+			}),
+		)
+	})
+})


### PR DESCRIPTION
## Problem

CometBFT v0.37.4 has a race condition in `stopAndRemovePeer()` (p2p/switch.go). When a peer pod is rescheduled:

1. Healthy node detects broken TCP (up to 105s)
2. `stopAndRemovePeer()` removes peer from reactors BEFORE removing from PeerSet
3. Rescheduled peer tries to reconnect → rejected as "duplicate ID"
4. Healthy node's reconnect loop enters exponential backoff (up to 16 hours)

Restarting the failing node doesn't help (healthy node still has stale entry). Only restarting the healthy node clears the stale PeerSet state.

See tendermint/tendermint#3304.

## Solution

Track peer pod UIDs and restart peer pods when a peer is rescheduled:

1. **Peer pods hash** — Compute a deterministic SHA-256 hash of all peer pod UIDs and store it as a `cosmopilot.voluzi.com/peer-pods-hash` annotation on the ConfigMap
2. **Hash propagation** — Copy the hash to pod annotations so pod spec hash changes when a peer reschedules
3. **Peer pod watch** — Watch for pod create/delete events with `chain-id` labels and trigger reconciliation of OTHER ChainNodes with the same chain-id
4. **Minimal disruption** — Only peers of the rescheduled pod are restarted, not the whole cluster

## Changes

- `internal/controllers/constant.go` — New `AnnotationPeerPodsHash` constant
- `internal/controllers/chainnode/configmap.go` — `getPeerPodsHash()` computes hash from peer pod UIDs
- `internal/controllers/chainnode/controller.go` — `Watches()` for peer pods with `peerPodPredicate` and `mapPeerPodToChainNodes`
- `internal/controllers/chainnode/pod.go` — Propagate peer-pods-hash from ConfigMap to pod annotations
- Unit tests for hash determinism, predicate behavior
- E2E test: `chainnode_peer_reconnect_test.go`

Closes #12