### PR TITLE
fix(chainnode): set external_address for reliable P2P peer reconnection

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2024 MTRX Services Ltd.
+Copyright (c) 2022-2025 MTRX Services Ltd.
+Copyright (c) 2025-present Voluzi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Problem

When two CometBFT nodes have each other as `persistent_peers`, both dial simultaneously at startup. One connection "wins" (outbound), the other gets deduplicated as inbound. When a pod reschedules and the connection breaks, CometBFT's reconnect logic diverges:

- **Outbound connections** use `peer.SocketAddr()` — the originally dialed address (service name → ClusterIP). ClusterIP is stable → reconnect works ✅
- **Inbound connections** use `peer.NodeInfo().NetAddress()` — the peer's **self-reported address** from the P2P handshake ❌

The self-reported address comes from `nodeInfo.ListenAddr`, which is set to `ExternalAddress` if configured, otherwise `ListenAddress`. Without `external_address` set, CometBFT falls back to `ListenAddress` = `tcp://0.0.0.0:26656`. It then tries to reconnect to `0.0.0.0`, which is not routable, and **gives up entirely**.

This explains the symptoms in #12:
- Restarting the **failing** node doesn't help → the healthy node holds the inbound connection and can't reconnect to `0.0.0.0`
- Restarting the **healthy** node works → fresh start, both re-dial via service names

## Root Cause in CometBFT v0.37.4

| File | What it does |
|------|-------------|
| [`p2p/switch.go:338-355`](https://github.com/cometbft/cometbft/blob/v0.37.4/p2p/switch.go#L338-L355) | `StopPeerForError()` — chooses reconnect address based on `peer.IsOutbound()` |
| [`p2p/switch.go`](https://github.com/cometbft/cometbft/blob/v0.37.4/p2p/switch.go) | `reconnectToPeer()` — retry loop with exponential backoff |
| [`node/node.go:1527-1533`](https://github.com/cometbft/cometbft/blob/v0.37.4/node/node.go#L1527-L1533) | `nodeInfo.ListenAddr = ExternalAddress \|\| ListenAddress` |
| [`p2p/node_info.go:221-224`](https://github.com/cometbft/cometbft/blob/v0.37.4/p2p/node_info.go#L221-L224) | `NetAddress()` returns parsed `ListenAddr` |

Related: [tendermint/tendermint#3304](https://github.com/tendermint/tendermint/issues/3304)

## Fix

Always set `external_address` to the node's internal service FQDN (`<name>-internal.<namespace>.svc.cluster.local:26656`). The function no longer conditionally uses `PublicAddress` — it **always** returns the internal FQDN.

**Why not use PublicAddress for nodes that have one?** Because `external_address` is only relevant for *inbound* connection reconnection — when a peer needs to reconnect to us after our pod reschedules. External peers that have us as `persistent_peers` will have an *outbound* connection to us, and CometBFT reconnects outbound connections via `peer.SocketAddr()` (the address they originally dialed — our public IP). They never use our `external_address`. Internal peers need the FQDN (resolves to stable ClusterIP). So the internal FQDN is always the correct value.

CometBFT resolves this FQDN to the stable ClusterIP at startup. When a peer needs to reconnect to what was an inbound connection, it now has a valid, routable address instead of `0.0.0.0`.

**Minimal change. Zero restarts, zero watches, zero sidecars.**

## Changes

- `internal/controllers/chainnode/configmap.go` — `getExternalAddress()` simplified to always return FQDN:P2pPort; call site unconditional
- `internal/controllers/chainnode/configmap_test.go` — tests updated to verify FQDN is always returned regardless of PublicAddress

Closes #12