### PR TITLE
fix: stop flipping pod spec hash when vpa annotation toggles

### DIFF
--- a/internal/controllers/chainnode/vpa.go
+++ b/internal/controllers/chainnode/vpa.go
@@ -406,34 +406,40 @@ func getVpaLastAppliedResourcesOrFallback(chainNode *appsv1.ChainNode) corev1.Re
 		return chainNode.GetResources()
 	}
 
-	// Merge VPA resources with fallback, preserving non-CPU/Memory resources
-	fallback := chainNode.GetResources()
+	// Merge VPA resources with fallback, preserving non-CPU/Memory resources.
+	// Note: we deliberately do NOT pre-allocate empty Requests/Limits maps. If
+	// the user spec has no Limits and VPA has no Limits override either, we want
+	// to return a ResourceRequirements with Limits=nil — identical to what the
+	// no-annotation code path returns and to what chainNode.Spec.Resources looks
+	// like. Pre-allocating an empty map flips the field from nil to {} which
+	// produces a different pod spec serialization on some reconciles, causing
+	// spurious pod restarts (issue #26).
+	merged := chainNode.GetResources()
 
-	// Start with fallback as base
-	merged := fallback
-
-	// Override CPU and Memory from VPA
-	if merged.Requests == nil {
-		merged.Requests = corev1.ResourceList{}
+	setRequest := func(name corev1.ResourceName, q resource.Quantity) {
+		if merged.Requests == nil {
+			merged.Requests = corev1.ResourceList{}
+		}
+		merged.Requests[name] = q
 	}
-	if merged.Limits == nil {
-		merged.Limits = corev1.ResourceList{}
+	setLimit := func(name corev1.ResourceName, q resource.Quantity) {
+		if merged.Limits == nil {
+			merged.Limits = corev1.ResourceList{}
+		}
+		merged.Limits[name] = q
 	}
 
-	// Copy VPA CPU/Memory to requests
 	if q, ok := vpaResources.Requests[corev1.ResourceCPU]; ok {
-		merged.Requests[corev1.ResourceCPU] = q
+		setRequest(corev1.ResourceCPU, q)
 	}
 	if q, ok := vpaResources.Requests[corev1.ResourceMemory]; ok {
-		merged.Requests[corev1.ResourceMemory] = q
+		setRequest(corev1.ResourceMemory, q)
 	}
-
-	// Copy VPA CPU/Memory to limits
 	if q, ok := vpaResources.Limits[corev1.ResourceCPU]; ok {
-		merged.Limits[corev1.ResourceCPU] = q
+		setLimit(corev1.ResourceCPU, q)
 	}
 	if q, ok := vpaResources.Limits[corev1.ResourceMemory]; ok {
-		merged.Limits[corev1.ResourceMemory] = q
+		setLimit(corev1.ResourceMemory, q)
 	}
 
 	return merged


### PR DESCRIPTION
## Summary

Fixes #26.

`getVpaLastAppliedResourcesOrFallback` unconditionally initialised the `Requests` and `Limits` maps to an empty `corev1.ResourceList` whenever the VPA annotation was present, even when there were no CPU or Memory values to copy. The no-annotation code path returned the bare `chainNode.GetResources()` instead, which leaves those fields as `nil` when the spec does not set them.

The two paths therefore returned semantically equivalent but byte-wise different `ResourceRequirements`. With `AnnotationVPAResources` oscillating between present and absent (for example after a manual upgrade where `resetVpaAfterUpgrade` clears it, or after a user manually removes the annotations) the pod spec hash kept alternating between two values and archive nodes ended up in an infinite restart loop.

The fix allocates the maps lazily, only when there is a value to write, so both code paths produce identical output for ChainNodes that do not declare `Requests`/`Limits`.

## Test plan

- [ ] Existing VPA unit tests pass.
- [ ] On an archive node, manually clear `cosmopilot.voluzi.com/vpa-resources` (with VPA enabled, no `Limits` in spec) and confirm the pod is not restarted by an alternating hash.
- [ ] Manually trigger an upgrade with `resetVpaAfterUpgrade: true` and confirm at most one extra restart after the upgrade pod becomes Running.

## Notes

The reported scenario also hints at a separate concern around `chainNode.GetResources()` returning different resources depending on `Status.Phase` (see `api/v1/chainnode_helper.go:298-312`). If the phase oscillates between `{InitData, Starting, StateSyncing}` and the running states, the desired pod spec still flips between `Spec.StateSyncResources` and `Spec.Resources`. That is a deeper design question (when should a node return to its sync-time resource profile after it has been Running once?) and is out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents pod spec hash flips when the VPA annotation toggles by lazily allocating `Requests`/`Limits` in `getVpaLastAppliedResourcesOrFallback`, avoiding unnecessary restarts on archive nodes. Fixes #26.

- **Bug Fixes**
  - Use `chainNode.GetResources()` as the base and allocate `Requests`/`Limits` only when writing VPA CPU/Memory, avoiding nil → `{}` diffs.
  - Preserve non-CPU/memory resources and match the no-annotation path, preventing restart loops after `resetVpaAfterUpgrade` or manual annotation removal.

<sup>Written for commit cbe4b706a4f59a8062ab5cf6efb7fcf52ca19261. Summary will update on new commits. <a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

