### PR TITLE
fix: clean up snapshot integrity-check and upload pvcs eagerly

### DIFF
--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -145,12 +145,15 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 
 			case snapshotIntegrityOk:
 				logger.Info("data integrity check finished successfully. Data is ok.", "snapshot", snapshot.GetName())
-				if err = r.cleanUpSnapshotIntegrityCheck(ctx, &snapshot); err != nil {
-					return fmt.Errorf("failed to clean up integrity check resources: %w", err)
-				}
 				snapshot.ObjectMeta.Annotations[controllers.AnnotationSnapshotIntegrityStatus] = string(snapshotIntegrityOk)
 				if err = r.Update(ctx, &snapshot); err != nil {
 					return err
+				}
+				// Persist the result first; clean up is best-effort so that a
+				// transient delete failure does not lose the integrity status
+				// and force the next reconcile to restart the check.
+				if err = r.cleanUpSnapshotIntegrityCheck(ctx, &snapshot); err != nil {
+					logger.Error(err, "failed to clean up integrity check resources", "snapshot", snapshot.GetName())
 				}
 
 				// Let's start the tarball export right now if it is enabled
@@ -172,12 +175,15 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 
 			case snapshotIntegrityCorrupted:
 				logger.Info("data integrity check finished. Data is corrupted.", "snapshot", snapshot.GetName())
-				if err = r.cleanUpSnapshotIntegrityCheck(ctx, &snapshot); err != nil {
-					return fmt.Errorf("failed to clean up integrity check resources: %w", err)
-				}
 				snapshot.ObjectMeta.Annotations[controllers.AnnotationSnapshotIntegrityStatus] = string(snapshotIntegrityCorrupted)
 				if err = r.Update(ctx, &snapshot); err != nil {
 					return err
+				}
+				// Persist the result first; clean up is best-effort so that a
+				// transient delete failure does not lose the integrity status
+				// and force the next reconcile to restart the check.
+				if err = r.cleanUpSnapshotIntegrityCheck(ctx, &snapshot); err != nil {
+					logger.Error(err, "failed to clean up integrity check resources", "snapshot", snapshot.GetName())
 				}
 				logger.Info("re-creating snapshot")
 				if err = r.Delete(ctx, &snapshot); err != nil {

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -145,6 +145,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 
 			case snapshotIntegrityOk:
 				logger.Info("data integrity check finished successfully. Data is ok.", "snapshot", snapshot.GetName())
+				if err = r.cleanUpSnapshotIntegrityCheck(ctx, &snapshot); err != nil {
+					return fmt.Errorf("failed to clean up integrity check resources: %w", err)
+				}
 				snapshot.ObjectMeta.Annotations[controllers.AnnotationSnapshotIntegrityStatus] = string(snapshotIntegrityOk)
 				if err = r.Update(ctx, &snapshot); err != nil {
 					return err
@@ -169,6 +172,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 
 			case snapshotIntegrityCorrupted:
 				logger.Info("data integrity check finished. Data is corrupted.", "snapshot", snapshot.GetName())
+				if err = r.cleanUpSnapshotIntegrityCheck(ctx, &snapshot); err != nil {
+					return fmt.Errorf("failed to clean up integrity check resources: %w", err)
+				}
 				snapshot.ObjectMeta.Annotations[controllers.AnnotationSnapshotIntegrityStatus] = string(snapshotIntegrityCorrupted)
 				if err = r.Update(ctx, &snapshot); err != nil {
 					return err
@@ -839,6 +845,28 @@ func (r *Reconciler) startSnapshotIntegrityCheck(ctx context.Context, chainNode 
 
 	snapshot.ObjectMeta.Annotations[controllers.AnnotationSnapshotIntegrityStatus] = string(snapshotIntegrityChecking)
 	return r.Update(ctx, snapshot)
+}
+
+// cleanUpSnapshotIntegrityCheck deletes the integrity-check Job and PVC eagerly
+// (Foreground propagation + explicit PVC delete) so the underlying disk is
+// released as soon as the check finishes. Relying solely on
+// TTLSecondsAfterFinished + Kubernetes garbage collection has been observed to
+// leave orphaned PVCs/PVs intermittently (issue #27).
+func (r *Reconciler) cleanUpSnapshotIntegrityCheck(ctx context.Context, snapshot *snapshotv1.VolumeSnapshot) error {
+	jobName := fmt.Sprintf("%s-ichk", snapshot.GetName())
+	pvcName := fmt.Sprintf("%s-ichk", snapshot.GetName())
+
+	propagation := metav1.DeletePropagationForeground
+	if err := r.ClientSet.BatchV1().Jobs(snapshot.GetNamespace()).Delete(ctx, jobName, metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+	}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := r.ClientSet.CoreV1().PersistentVolumeClaims(snapshot.GetNamespace()).Delete(ctx, pvcName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func (r *Reconciler) getSnapshotIntegrityCheckStatus(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) (SnapshotIntegrityStatus, error) {

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -207,10 +207,27 @@ func (gcs *GCS) GetSnapshotStatus(ctx context.Context, name string) (SnapshotSta
 }
 
 func (gcs *GCS) cleanUp(ctx context.Context, name string) error {
-	propagation := metav1.DeletePropagationBackground
-	return gcs.Client.BatchV1().Jobs(gcs.Owner.GetNamespace()).Delete(ctx, fmt.Sprintf("%s-upload", name), metav1.DeleteOptions{
+	// Use Foreground propagation so the api-server waits for the owned PVC to be
+	// removed before the Job goes away. With Background propagation the cascade
+	// is handed off to the garbage collector and the PVC (and its underlying PV
+	// and disk) can be left behind intermittently. See issue #27.
+	propagation := metav1.DeletePropagationForeground
+	err := gcs.Client.BatchV1().Jobs(gcs.Owner.GetNamespace()).Delete(ctx, fmt.Sprintf("%s-upload", name), metav1.DeleteOptions{
 		PropagationPolicy: &propagation,
 	})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	// Belt-and-braces: explicitly delete the PVC in case the Job was already
+	// gone (e.g. reaped by TTLSecondsAfterFinished) which leaves the PVC with a
+	// dangling owner reference that the garbage collector won't always clean up
+	// before the underlying disk is released.
+	err = gcs.Client.CoreV1().PersistentVolumeClaims(gcs.Owner.GetNamespace()).Delete(ctx, fmt.Sprintf("%s-upload", name), metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) error {


### PR DESCRIPTION
## Summary

Fixes #27.

Both the integrity-check (`ichk`) and the GCS upload flows created a PVC whose only owner reference was the side `Job` and then relied on `TTLSecondsAfterFinished` plus Kubernetes garbage collection to remove the PVC (and the underlying PV/disk) when the Job finished. In practice this left orphaned disks behind intermittently — likely because the TTL controller deletes the Job with Background propagation, which hands the PVC cleanup off to the GC asynchronously and races with disk release on some clusters.

This PR:

- Switches `internal/datasnapshot/gcs.go::cleanUp` from `DeletePropagationBackground` to `DeletePropagationForeground` so the api-server waits for the owned PVC to be removed before the Job is gone, and explicitly deletes the PVC as a belt-and-braces step in case the Job was already reaped by its own TTL.
- Adds a new `cleanUpSnapshotIntegrityCheck` helper for the integrity-check flow and calls it on both the `Ok` and `Corrupted` outcomes. Previously the integrity-check flow had no explicit cleanup at all and relied entirely on TTL plus GC.

## Test plan

- [ ] Trigger a snapshot with `shouldVerify: true` and confirm the `*-ichk` Job and PVC are deleted right after the check finishes (not 60s later via TTL).
- [ ] Trigger a snapshot with `exportTarball.gcs` configured and confirm the `*-upload` Job, PVC, PV, and underlying disk are all released after the upload Job succeeds.
- [ ] Repeat several times to confirm no intermittent orphans on either path.
- [ ] Confirm that simulating a failed integrity check (`Corrupted`) still triggers snapshot recreation and cleans up the PVC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eagerly clean up PVCs created by snapshot integrity-check and GCS upload jobs to prevent orphaned PVs/disks. Deletes jobs with foreground propagation, explicitly deletes PVCs, and persists integrity status before cleanup. Addresses #27.

- **Bug Fixes**
  - Upload flow: switch to foreground deletion in `internal/datasnapshot/gcs.go` and explicitly delete the `*-upload` PVC; ignore NotFound errors.
  - Integrity-check flow: add `cleanUpSnapshotIntegrityCheck` in `internal/controllers/chainnode/snapshots.go` and call it on both Ok and Corrupted outcomes to delete the `*-ichk` Job (foreground) and its PVC; persist integrity status before cleanup to avoid restarting the check on transient delete failures.

<sup>Written for commit f958dc03c311c1c5c77480277c65b03b2ccab18e. Summary will update on new commits. <a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/29?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

