### PR TITLE
fix(chainnode): bound RPC probes in setNodePhase to avoid wedged reconciles

### DIFF
--- a/.github/workflows/data-exporter-docker.yaml
+++ b/.github/workflows/data-exporter-docker.yaml
@@ -68,7 +68,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-dataexporter-docker-${{ hashFiles('go.sum') }}
 
       - name: Inject cache
-        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
         with:
           cache-map: |
             {

--- a/.github/workflows/node-utils-docker.yaml
+++ b/.github/workflows/node-utils-docker.yaml
@@ -68,7 +68,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-nodeutils-docker-${{ hashFiles('go.sum') }}
 
       - name: Inject cache
-        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
         with:
           cache-map: |
             {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cosmopilot-docker-${{ hashFiles('go.sum') }}
 
       - name: Inject cache
-        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
         with:
           cache-map: |
             {

--- a/.github/workflows/vault-renewer-docker.yaml
+++ b/.github/workflows/vault-renewer-docker.yaml
@@ -68,7 +68,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-vaultrenewer-docker-${{ hashFiles('go.sum') }}
 
       - name: Inject cache
-        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
         with:
           cache-map: |
             {

--- a/internal/controllers/chainnode/constant.go
+++ b/internal/controllers/chainnode/constant.go
@@ -20,6 +20,7 @@ const (
 	timeoutPodDeleted              = 2 * time.Minute
 	timeoutWaitServiceIP           = 5 * time.Minute
 	minimumTimeBeforeFirstSnapshot = 1 * time.Minute
+	rpcProbeTimeout                = 10 * time.Second
 
 	// Probe configuration constants
 	startupProbePeriodSeconds      = 5

--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -1157,8 +1157,14 @@ func (r *Reconciler) setNodePhase(ctx context.Context, chainNode *appsv1.ChainNo
 		return fmt.Errorf("failed to get chain node client for %s: %w", chainNode.GetName(), err)
 	}
 
-	// Check if its state-sync first
-	stateSyncing, err := nodeutils.NewClient(chainNode.GetNodeFQDN()).IsStateSyncing(ctx)
+	// Probe the node's HTTP and gRPC endpoints with a bounded context. The gRPC
+	// client has no dial timeout and runs straight after createPod when the
+	// endpoint may not be reachable yet; without a deadline an unreachable pod
+	// hangs the reconcile worker indefinitely (controller-runtime serializes
+	// reconciles per key, so the whole ChainNode silently stops progressing).
+	stateSyncCtx, cancelStateSync := context.WithTimeout(ctx, rpcProbeTimeout)
+	stateSyncing, err := nodeutils.NewClient(chainNode.GetNodeFQDN()).IsStateSyncing(stateSyncCtx)
+	cancelStateSync()
 	if err != nil {
 		return fmt.Errorf("failed to check state-sync status for %s: %w", chainNode.GetName(), err)
 	}
@@ -1178,7 +1184,9 @@ func (r *Reconciler) setNodePhase(ctx context.Context, chainNode *appsv1.ChainNo
 	}
 
 	logger.V(1).Info("check if node is syncing")
-	syncing, err := c.IsNodeSyncing(ctx)
+	syncCtx, cancelSync := context.WithTimeout(ctx, rpcProbeTimeout)
+	syncing, err := c.IsNodeSyncing(syncCtx)
+	cancelSync()
 	if err != nil {
 		return fmt.Errorf("failed to check if node %s is syncing: %w", chainNode.GetName(), err)
 	}


### PR DESCRIPTION
## Summary

`setNodePhase` calls `IsStateSyncing` (HTTP via `nodeutils`) and `IsNodeSyncing` (gRPC via `chainutils`) with the unbounded reconcile context. The gRPC client created in `chainutils.NewClient` has no dial timeout, and this code path runs straight after `createPod` when the pod's gRPC port may not be reachable yet. If the endpoint never becomes reachable — e.g. the pod is deleted while gRPC is still warming up — the call hangs forever. controller-runtime serializes reconciles per object key, so the wedged goroutine silently stops all further reconciles of that ChainNode (no logs after `updating .status.phase: Starting`, the `Owns(Pod)` watch never gets to re-enqueue, and `GenerationChangedPredicate` filters out any annotation-based nudge).

Hit in voluzi-gcp: `allora-fullnodes-0` was deleted manually, the pod was never recreated, and only an operator restart unblocked it.

This wraps each external probe with a 10s `context.WithTimeout` so a single unreachable pod can't wedge the worker.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Deploy to voluzi-gcp; delete a running pod and confirm the controller recreates it without an operator restart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the HTTP and gRPC probes in `setNodePhase` with a 10s timeout to prevent reconciles from hanging when a node endpoint is unreachable. Allows pod recreation without restarting the operator.

- **Bug Fixes**
  - Added `rpcProbeTimeout` (10s); wrapped `nodeutils.IsStateSyncing` and `chainutils.IsNodeSyncing` with `context.WithTimeout` to avoid indefinite gRPC dials after `createPod`.

- **Dependencies**
  - Bumped `reproducible-containers/buildkit-cache-dance` to `v3.4.0` in CI workflows.

<sup>Written for commit 0e95523be43521f946f6a10590047fd81445b9ad. Summary will update on new commits. <a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/32?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

