### PR TITLE
fix(chainnode): only set external_address when public address is known

### DIFF
--- a/internal/controllers/chainnode/configmap.go
+++ b/internal/controllers/chainnode/configmap.go
@@ -122,14 +122,18 @@ func (r *Reconciler) ensureConfigs(ctx context.Context, app *chainutils.App, cha
 		}
 	}
 
-	// Set external address to internal service FQDN for reliable P2P reconnection.
-	configs[configTomlFilename], err = utils.Merge(configs[configTomlFilename], map[string]interface{}{
-		kf.P2P(): map[string]interface{}{
-			kf.ExternalAddress(): getExternalAddress(chainNode),
-		},
-	})
-	if err != nil {
-		return "", err
+	// Set external_address only when we know a publicly reachable address.
+	// Defaulting to the internal cluster.local FQDN causes public peers to drop
+	// the handshake (NodeInfo address fails their dial-back validation).
+	if extAddr, ok := getExternalAddress(chainNode); ok {
+		configs[configTomlFilename], err = utils.Merge(configs[configTomlFilename], map[string]interface{}{
+			kf.P2P(): map[string]interface{}{
+				kf.ExternalAddress(): extAddr,
+			},
+		})
+		if err != nil {
+			return "", err
+		}
 	}
 
 	// Apply state-sync config
@@ -508,17 +512,25 @@ func getMostRecentHeightFromServicesAnnotations(annotationsList []map[string]str
 	return trustHeight, trustHash
 }
 
-// getExternalAddress returns the address this node advertises to peers.
-// For public nodes (with PublicAddress set), it returns the public address so
-// the node is correctly advertised on the network for PEX discovery.
-// For non-public nodes, it returns the internal service FQDN which resolves to
-// a stable ClusterIP, ensuring reliable P2P reconnection after pod reschedules.
-func getExternalAddress(chainNode *appsv1.ChainNode) string {
-	if chainNode.Status.PublicAddress != "" {
-		parts := strings.Split(chainNode.Status.PublicAddress, "@")
-		if len(parts) == 2 {
-			return parts[1]
-		}
+// getExternalAddress returns the address this node should advertise to peers
+// via config.toml's [p2p].external_address.
+//
+// It returns (addr, true) only when the node has a publicly reachable address
+// (populated in Status.PublicAddress by the service/gateway reconciler once an
+// expose.p2p Gateway/Service materialises a routable endpoint).
+//
+// When no public address is known it returns ("", false) and the caller must
+// skip writing the field. Advertising the internal service FQDN (or any
+// cluster-local address) breaks the CometBFT handshake with public peers,
+// which validate that the advertised address is reachable from their side
+// before staying connected.
+func getExternalAddress(chainNode *appsv1.ChainNode) (string, bool) {
+	if chainNode.Status.PublicAddress == "" {
+		return "", false
 	}
-	return fmt.Sprintf("%s:%d", chainNode.GetNodeFQDN(), chainutils.P2pPort)
+	parts := strings.Split(chainNode.Status.PublicAddress, "@")
+	if len(parts) != 2 || parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
 }

--- a/internal/controllers/chainnode/configmap_test.go
+++ b/internal/controllers/chainnode/configmap_test.go
@@ -1,14 +1,12 @@
 package chainnode
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
 	"github.com/voluzi/cosmopilot/v2/internal/controllers"
 )
 
@@ -192,6 +190,7 @@ func TestGetExternalAddress(t *testing.T) {
 		name        string
 		chainNode   *appsv1.ChainNode
 		wantAddress string
+		wantOK      bool
 	}{
 		{
 			name: "returns public address when PublicAddress is set",
@@ -205,9 +204,10 @@ func TestGetExternalAddress(t *testing.T) {
 				},
 			},
 			wantAddress: "example.com:26656",
+			wantOK:      true,
 		},
 		{
-			name: "returns internal FQDN without PublicAddress",
+			name: "returns false without PublicAddress",
 			chainNode: &appsv1.ChainNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mynode",
@@ -217,10 +217,11 @@ func TestGetExternalAddress(t *testing.T) {
 					PublicAddress: "",
 				},
 			},
-			wantAddress: fmt.Sprintf("mynode-internal.cosmos.svc.cluster.local:%d", chainutils.P2pPort),
+			wantAddress: "",
+			wantOK:      false,
 		},
 		{
-			name: "returns internal FQDN when PublicAddress has invalid format",
+			name: "returns false when PublicAddress has no @",
 			chainNode: &appsv1.ChainNode{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mynode",
@@ -230,38 +231,36 @@ func TestGetExternalAddress(t *testing.T) {
 					PublicAddress: "invalid-no-at-sign",
 				},
 			},
-			wantAddress: fmt.Sprintf("mynode-internal.cosmos.svc.cluster.local:%d", chainutils.P2pPort),
+			wantAddress: "",
+			wantOK:      false,
+		},
+		{
+			name: "returns false when PublicAddress has empty host",
+			chainNode: &appsv1.ChainNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mynode",
+					Namespace: "cosmos",
+				},
+				Status: appsv1.ChainNodeStatus{
+					PublicAddress: "nodeid@",
+				},
+			},
+			wantAddress: "",
+			wantOK:      false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			address := getExternalAddress(tt.chainNode)
+			address, ok := getExternalAddress(tt.chainNode)
 			assert.Equal(t, tt.wantAddress, address)
+			assert.Equal(t, tt.wantOK, ok)
 		})
 	}
 }
 
-func TestGetExternalAddress_FQDNFormat(t *testing.T) {
-	// Verify non-public nodes get FQDN following the expected pattern:
-	// <name>-internal.<namespace>.svc.cluster.local:26656
-	chainNode := &appsv1.ChainNode{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gaia-validator-0",
-			Namespace: "mainnet",
-		},
-	}
-
-	address := getExternalAddress(chainNode)
-	assert.Equal(t, "gaia-validator-0-internal.mainnet.svc.cluster.local:26656", address)
-
-	// Verify it matches GetNodeFQDN + P2P port
-	expectedFQDN := chainNode.GetNodeFQDN()
-	assert.Equal(t, fmt.Sprintf("%s:%d", expectedFQDN, chainutils.P2pPort), address)
-}
-
 func TestGetExternalAddress_PublicNodeFormat(t *testing.T) {
-	// Verify public nodes advertise their public address
+	// Public nodes advertise their public address (host:port stripped of the node id).
 	chainNode := &appsv1.ChainNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gaia-sentry-0",
@@ -272,7 +271,8 @@ func TestGetExternalAddress_PublicNodeFormat(t *testing.T) {
 		},
 	}
 
-	address := getExternalAddress(chainNode)
+	address, ok := getExternalAddress(chainNode)
+	assert.True(t, ok)
 	assert.Equal(t, "203.0.113.50:26656", address)
 }
 


### PR DESCRIPTION
## Summary
- Skip writing `[p2p].external_address` to `config.toml` unless the node has a publicly reachable address (`Status.PublicAddress` populated by the service/gateway reconciler).
- Reverts the fallback to the in-cluster FQDN that was introduced in #15 (commit `fb46820`).

## Why
The internal default `<name>-internal.<ns>.svc.cluster.local:26656` is not routable from outside the cluster. CometBFT advertises this in its NodeInfo handshake; public peers validate the advertised address by attempting a dial-back. The dial-back fails, the peer logs `addr_book_lookup`/`PeerSentInvalidAddr` and drops us, so a fullnode without exposed P2P never holds outbound peers (observed live on allora mainnet — the chain only started syncing after overriding `external_address: ""` via `config.override`).

When a node has no public exposure, the right behaviour is to leave `external_address` empty and let CometBFT auto-derive from the listen address — exactly what cosmopilot did before #15.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/controllers/chainnode/...` (313 pass)
- [ ] Deploy to voluzi-gcp and confirm allora fullnode (no `expose.p2p`) keeps sustained outbound peers without needing the `config.override` workaround
- [ ] Verify a ChainNode with `expose.p2p` still writes the LB address into `external_address` once `Status.PublicAddress` is set

## Notes
The original goal of #15 (reliable in-cluster P2P reconnection after pod reschedule) is preserved for nodes that *do* set `Status.PublicAddress` — they continue to advertise their LB/Gateway address. The regression only affected nodes without exposed P2P.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `[p2p].external_address` only when a public address is known to prevent dial-back failures and dropped peers on non-public nodes. Public nodes keep advertising their LB/Gateway address as before.

- **Bug Fixes**
  - Skip writing `external_address` unless `Status.PublicAddress` is a valid `nodeID@host:port`; otherwise leave it unset.
  - Refactor `getExternalAddress` to return `(addr, ok)`, strip `nodeID@`, and reject missing/empty host.
  - Update controller logic and tests; non-public nodes rely on CometBFT defaults, public nodes advertise a routable `host:port`.

<sup>Written for commit 3608d975426153e38b203ac2452516bac990cf8d. Summary will update on new commits. <a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

