### PR TITLE
feat: add gcs workload identity export

### DIFF
--- a/api/v1/chainnode_webhook.go
+++ b/api/v1/chainnode_webhook.go
@@ -177,5 +177,10 @@ func validateSnapshotsConfig(config *VolumeSnapshotsConfig, path string) error {
 	if config.Retention != nil && config.Retain != nil {
 		return fmt.Errorf("%s.retention and %s.retain are mutually exclusive", path, path)
 	}
+	if config.ExportTarball != nil && config.ExportTarball.GCS != nil {
+		if err := config.ExportTarball.GCS.Validate(fmt.Sprintf("%s.exportTarball.gcs", path)); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/api/v1/chainnode_webhook_test.go
+++ b/api/v1/chainnode_webhook_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -83,6 +84,58 @@ func TestChainNodeValidateGenesisValidators(t *testing.T) {
 		_, err = cn.Validate(nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicit-priv-key")
+	})
+}
+
+// TestChainNodeValidateGcsExportCredentials verifies that a ChainNode's GCS tarball export config must
+// set exactly one of credentialsSecret or serviceAccountName (Workload Identity): both set or neither
+// set is rejected, while either one alone is accepted.
+func TestChainNodeValidateGcsExportCredentials(t *testing.T) {
+	credsSecret := &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: "gcs-credentials"},
+		Key:                  "credentials.json",
+	}
+	chainNode := func(gcs *GcsExportConfig) *ChainNode {
+		return &ChainNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "cn"},
+			Spec: ChainNodeSpec{
+				Genesis: &GenesisConfig{Url: ptr.To("https://example.com/genesis.json")},
+				Persistence: &Persistence{
+					Snapshots: &VolumeSnapshotsConfig{
+						Frequency:     "24h",
+						ExportTarball: &ExportTarballConfig{GCS: gcs},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("credentialsSecret only is allowed", func(t *testing.T) {
+		_, err := chainNode(&GcsExportConfig{Bucket: "b", CredentialsSecret: credsSecret}).Validate(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("serviceAccountName only is allowed", func(t *testing.T) {
+		_, err := chainNode(&GcsExportConfig{Bucket: "b", ServiceAccountName: ptr.To("gcs-uploader")}).Validate(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("both set is rejected", func(t *testing.T) {
+		_, err := chainNode(&GcsExportConfig{Bucket: "b", CredentialsSecret: credsSecret, ServiceAccountName: ptr.To("gcs-uploader")}).Validate(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("neither set is rejected", func(t *testing.T) {
+		_, err := chainNode(&GcsExportConfig{Bucket: "b"}).Validate(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be set")
+	})
+
+	t.Run("empty serviceAccountName is rejected", func(t *testing.T) {
+		_, err := chainNode(&GcsExportConfig{Bucket: "b", ServiceAccountName: ptr.To("")}).Validate(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serviceAccountName must not be empty")
 	})
 }
 

--- a/api/v1/chainnodeset_webhook_test.go
+++ b/api/v1/chainnodeset_webhook_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -93,6 +94,65 @@ func TestChainNodeSetValidateGenesis(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+// TestChainNodeSetValidateGcsExportCredentials verifies a ChainNodeSet rejects a GCS tarball export
+// config unless exactly one of credentialsSecret or serviceAccountName (Workload Identity) is set. The
+// config lives on a node group's persistence snapshots, which is validated the same way for every
+// group and validator persistence block.
+func TestChainNodeSetValidateGcsExportCredentials(t *testing.T) {
+	credsSecret := &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: "gcs-credentials"},
+		Key:                  "credentials.json",
+	}
+	nodeSet := func(gcs *GcsExportConfig) *ChainNodeSet {
+		return &ChainNodeSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "cns"},
+			Spec: ChainNodeSetSpec{
+				Genesis: &GenesisConfig{Url: ptr.To("https://example.com/genesis.json")},
+				Nodes: []NodeGroupSpec{
+					{
+						Name:      "fullnodes",
+						Instances: ptr.To(1),
+						Persistence: &Persistence{
+							Snapshots: &VolumeSnapshotsConfig{
+								Frequency:     "24h",
+								ExportTarball: &ExportTarballConfig{GCS: gcs},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("credentialsSecret only is allowed", func(t *testing.T) {
+		_, err := nodeSet(&GcsExportConfig{Bucket: "b", CredentialsSecret: credsSecret}).Validate(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("serviceAccountName only is allowed", func(t *testing.T) {
+		_, err := nodeSet(&GcsExportConfig{Bucket: "b", ServiceAccountName: ptr.To("gcs-uploader")}).Validate(nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("both set is rejected", func(t *testing.T) {
+		_, err := nodeSet(&GcsExportConfig{Bucket: "b", CredentialsSecret: credsSecret, ServiceAccountName: ptr.To("gcs-uploader")}).Validate(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("neither set is rejected", func(t *testing.T) {
+		_, err := nodeSet(&GcsExportConfig{Bucket: "b"}).Validate(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be set")
+	})
+
+	t.Run("empty serviceAccountName is rejected", func(t *testing.T) {
+		_, err := nodeSet(&GcsExportConfig{Bucket: "b", ServiceAccountName: ptr.To("")}).Validate(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serviceAccountName must not be empty")
+	})
 }
 
 func TestChainNodeSetValidateDuplicateGroupNames(t *testing.T) {

--- a/api/v1/common_helper.go
+++ b/api/v1/common_helper.go
@@ -572,6 +572,27 @@ func (e *ExportTarballConfig) DeleteWhenExpired() bool {
 
 // GcsExporter helper methods
 
+// Validate ensures exactly one authentication method is configured for uploading to GCS: either a
+// credentials secret (`credentialsSecret`) or a Kubernetes ServiceAccount for Workload Identity / ADC
+// (`serviceAccountName`). Having both set or neither set is rejected. path is the field path reported
+// in the returned error.
+func (gcs *GcsExportConfig) Validate(path string) error {
+	if gcs == nil {
+		return nil
+	}
+	hasCredentialsSecret := gcs.CredentialsSecret != nil
+	hasServiceAccount := gcs.ServiceAccountName != nil
+	switch {
+	case hasCredentialsSecret && hasServiceAccount:
+		return fmt.Errorf("%s: credentialsSecret and serviceAccountName are mutually exclusive", path)
+	case !hasCredentialsSecret && !hasServiceAccount:
+		return fmt.Errorf("%s: one of credentialsSecret or serviceAccountName must be set", path)
+	case hasServiceAccount && *gcs.ServiceAccountName == "":
+		return fmt.Errorf("%s.serviceAccountName must not be empty", path)
+	}
+	return nil
+}
+
 func (gcs *GcsExportConfig) GetSizeLimit() string {
 	if gcs != nil && gcs.SizeLimit != nil {
 		return *gcs.SizeLimit

--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -934,8 +934,19 @@ type GcsExportConfig struct {
 	// Name of the bucket to upload tarballs to.
 	Bucket string `json:"bucket"`
 
-	// Secret with the JSON credentials to upload to bucket.
-	CredentialsSecret *corev1.SecretKeySelector `json:"credentialsSecret"`
+	// Secret with the JSON credentials to upload to bucket. Exactly one of `credentialsSecret` or
+	// `serviceAccountName` must be set. When set, the snapshot Jobs mount this secret and use it as
+	// `GOOGLE_APPLICATION_CREDENTIALS`.
+	// +optional
+	CredentialsSecret *corev1.SecretKeySelector `json:"credentialsSecret,omitempty"`
+
+	// ServiceAccountName is the name of the Kubernetes ServiceAccount that the snapshot Jobs run as,
+	// so they authenticate to GCS through Workload Identity / Application Default Credentials (ADC)
+	// instead of a credentials secret. Exactly one of `credentialsSecret` or `serviceAccountName`
+	// must be set.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
 
 	// Size limit at which the file will be split into multiple parts. Defaults to `5TB`.
 	SizeLimit *string `json:"sizeLimit,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -987,6 +987,11 @@ func (in *GcsExportConfig) DeepCopyInto(out *GcsExportConfig) {
 		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ServiceAccountName != nil {
+		in, out := &in.ServiceAccountName, &out.ServiceAccountName
+		*out = new(string)
+		**out = **in
+	}
 	if in.SizeLimit != nil {
 		in, out := &in.SizeLimit, &out.SizeLimit
 		*out = new(string)

--- a/docs/docs/reference/crds/crds.md
+++ b/docs/docs/reference/crds/crds.md
@@ -648,7 +648,8 @@ GcsExportConfig holds required settings to upload to GCS.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | bucket | Name of the bucket to upload tarballs to. | string | true |
-| credentialsSecret | Secret with the JSON credentials to upload to bucket. | *corev1.SecretKeySelector | true |
+| credentialsSecret | Secret with the JSON credentials to upload to bucket. Exactly one of `credentialsSecret` or `serviceAccountName` must be set. When set, the snapshot Jobs mount this secret and use it as `GOOGLE_APPLICATION_CREDENTIALS`. | *corev1.SecretKeySelector | false |
+| serviceAccountName | ServiceAccountName is the name of the Kubernetes ServiceAccount that the snapshot Jobs run as, so they authenticate to GCS through Workload Identity / Application Default Credentials (ADC) instead of a credentials secret. Exactly one of `credentialsSecret` or `serviceAccountName` must be set. | *string | false |
 | sizeLimit | Size limit at which the file will be split into multiple parts. Defaults to `5TB`. | *string | false |
 | partSize | Size of each part when size-limit is crossed. Defaults to `500GB`. | *string | false |
 | chunkSize | Size of each chunk uploaded in parallel to GCS. Defaults to `250MB`. | *string | false |

--- a/docs/docs/usage/persistence-and-backup.md
+++ b/docs/docs/usage/persistence-and-backup.md
@@ -110,7 +110,7 @@ When configured on `ChainNodeSet`group, `snapshots` are only taken on one of the
 
 ```yaml
 persistence:
-  snapshot:
+  snapshots:
     frequency: 24h # Take a snapshot every 24 hours
     retention: 72h # Retain snapshots of the last 3 days
 ```
@@ -124,7 +124,7 @@ Delete snapshots after a specified duration:
 
 ```yaml
 persistence:
-  snapshot:
+  snapshots:
     frequency: 24h
     retention: 72h # Delete snapshots older than 3 days
 ```
@@ -134,7 +134,7 @@ Keep only the N most recent snapshots:
 
 ```yaml
 persistence:
-  snapshot:
+  snapshots:
     frequency: 24h
     retain: 5 # Keep only the 5 most recent snapshots
 ```
@@ -149,7 +149,7 @@ By default, `Cosmopilot` uses the default `VolumeSnapshotClass` configured in yo
 
 ```yaml {5}
 persistence:
-  snapshot:
+  snapshots:
     frequency: 24h # Take a snapshot every 24 hours
     retention: 72h # Retain snapshots of the last 3 days
     snapshotClass: my-custom-snapshot-class
@@ -165,7 +165,7 @@ You can enable this behavior with:
 
 ```yaml {3}
 persistence:
-  snapshot:
+  snapshots:
     stopNode: true
 ```
 
@@ -184,11 +184,11 @@ In some cases, it may be beneficial to disable snapshots while the node is synci
 
 #### Configuration
 
-To disable snapshots during sync, set the `.persistence.snapshot.disableWhileSyncing` option to `true`:
+To disable snapshots during sync, set the `.persistence.snapshots.disableWhileSyncing` option to `true`:
 
 ```yaml
 persistence:
-  snapshot:
+  snapshots:
     disableWhileSyncing: true
 ```
 
@@ -198,11 +198,11 @@ persistence:
 
 ### Configuration
 
-To enable integrity checks, set the `.persistence.snapshot.verify` option to `true`:
+To enable integrity checks, set the `.persistence.snapshots.verify` option to `true`:
 
 ```yaml
 persistence:
-  snapshot:
+  snapshots:
     verify: true
 ```
 
@@ -218,7 +218,7 @@ persistence:
 
 `Cosmopilot` provides an option to export data from a volume snapshot as a tarball file and upload it to external storage. Currently, this feature supports uploading to Google Cloud Storage (GCS) buckets. 
 
-To enable this functionality, configure the `.persistence.snapshot.exportTarball` field.
+To enable this functionality, configure the `.persistence.snapshots.exportTarball` field.
 
 ### Configuration
 
@@ -226,7 +226,7 @@ Here’s an example configuration for exporting tarballs:
 
 ```yaml
 persistence:
-  snapshot:
+  snapshots:
     exportTarball:
       suffix: "-archive" # Optional. Default: empty.
       deleteOnExpire: false # Optional. Default: false.
@@ -244,14 +244,66 @@ persistence:
     - Specify database backend (e.g., `-goleveldb` or `-pebbledb`).
 - **`deleteOnExpire`**:
   - Optional. Defaults to `false`.
-  - Indicates whether the tarball should also be deleted when the associated volume snapshot is removed due to expiration (`.persistence.snapshot.retention`).
+  - Indicates whether the tarball should also be deleted when the associated volume snapshot is removed due to expiration (`.persistence.snapshots.retention`).
 
 ### Provider-Specific Fields
-Currently, `Cosmopilot` supports exporting tarballs to **Google Cloud Storage (`GCS`)**. The following fields are required for `GCS` configuration:
+Currently, `Cosmopilot` supports exporting tarballs to **Google Cloud Storage (`GCS`)**. The following fields are available for `GCS` configuration:
 - **`bucket`**:
   - The name of the `GCS` bucket where the tarball will be uploaded.
 - **`credentialsSecret`**:
   - A Kubernetes secret containing the JSON credentials with permissions to upload and delete objects in the specified bucket.
+- **`serviceAccountName`**:
+  - The name of a Kubernetes `ServiceAccount` that the snapshot upload/delete Jobs run as, so they authenticate to `GCS` through [Workload Identity](#authenticating-with-workload-identity) / Application Default Credentials (ADC) instead of a credentials secret.
+
+:::warning[NOTE]
+Exactly one of `credentialsSecret` or `serviceAccountName` must be set. Setting both — or neither — is rejected by the admission webhook.
+:::
+
+### Authenticating with Workload Identity
+
+On `GKE`, you can avoid managing a long-lived JSON key entirely by using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). Instead of a `credentialsSecret`, you reference a Kubernetes `ServiceAccount` that is bound to a Google Service Account (`GSA`) with permissions on the bucket. The snapshot Jobs then obtain credentials automatically via Application Default Credentials.
+
+#### GKE Example
+
+1. Grant the Google Service Account permissions on the bucket (for example `roles/storage.objectAdmin`, which allows both uploading and deleting objects):
+
+```bash
+gcloud storage buckets add-iam-policy-binding gs://my-backup-bucket \
+  --member="serviceAccount:gcs-uploader@my-project.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+```
+
+2. Create a Kubernetes `ServiceAccount` in the node's namespace and annotate it with the `GSA` it should impersonate:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcs-uploader
+  namespace: my-namespace
+  annotations:
+    iam.gke.io/gcp-service-account: gcs-uploader@my-project.iam.gserviceaccount.com
+```
+
+3. Allow the Kubernetes `ServiceAccount` to impersonate the `GSA`:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  gcs-uploader@my-project.iam.gserviceaccount.com \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:my-project.svc.id.goog[my-namespace/gcs-uploader]"
+```
+
+4. Reference the `ServiceAccount` in the export config, without a `credentialsSecret`:
+
+```yaml
+persistence:
+  snapshots:
+    exportTarball:
+      gcs:
+        bucket: my-backup-bucket
+        serviceAccountName: gcs-uploader
+```
 
 
 ## Restoring Data from Snapshot

--- a/helm/cosmopilot/Chart.yaml
+++ b/helm/cosmopilot/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: cosmopilot
-version: 0.0.0
+version: 2.3.1
 appVersion: 0.0.0

--- a/helm/cosmopilot/crds/cosmopilot.voluzi.com_chainnodes.yaml
+++ b/helm/cosmopilot/crds/cosmopilot.voluzi.com_chainnodes.yaml
@@ -4182,8 +4182,10 @@ spec:
                                   jobs. Defaults to `10`.
                                 type: integer
                               credentialsSecret:
-                                description: Secret with the JSON credentials to upload
-                                  to bucket.
+                                description: |-
+                                  Secret with the JSON credentials to upload to bucket. Exactly one of `credentialsSecret` or
+                                  `serviceAccountName` must be set. When set, the snapshot Jobs mount this secret and use it as
+                                  `GOOGLE_APPLICATION_CREDENTIALS`.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -4210,13 +4212,20 @@ spec:
                                 description: Size of each part when size-limit is
                                   crossed. Defaults to `500GB`.
                                 type: string
+                              serviceAccountName:
+                                description: |-
+                                  ServiceAccountName is the name of the Kubernetes ServiceAccount that the snapshot Jobs run as,
+                                  so they authenticate to GCS through Workload Identity / Application Default Credentials (ADC)
+                                  instead of a credentials secret. Exactly one of `credentialsSecret` or `serviceAccountName`
+                                  must be set.
+                                minLength: 1
+                                type: string
                               sizeLimit:
                                 description: Size limit at which the file will be
                                   split into multiple parts. Defaults to `5TB`.
                                 type: string
                             required:
                             - bucket
-                            - credentialsSecret
                             type: object
                           suffix:
                             description: Suffix to add to archive name. The name of

--- a/helm/cosmopilot/crds/cosmopilot.voluzi.com_chainnodesets.yaml
+++ b/helm/cosmopilot/crds/cosmopilot.voluzi.com_chainnodesets.yaml
@@ -4681,8 +4681,10 @@ spec:
                                         delete jobs. Defaults to `10`.
                                       type: integer
                                     credentialsSecret:
-                                      description: Secret with the JSON credentials
-                                        to upload to bucket.
+                                      description: |-
+                                        Secret with the JSON credentials to upload to bucket. Exactly one of `credentialsSecret` or
+                                        `serviceAccountName` must be set. When set, the snapshot Jobs mount this secret and use it as
+                                        `GOOGLE_APPLICATION_CREDENTIALS`.
                                       properties:
                                         key:
                                           description: The key of the secret to select
@@ -4709,6 +4711,14 @@ spec:
                                       description: Size of each part when size-limit
                                         is crossed. Defaults to `500GB`.
                                       type: string
+                                    serviceAccountName:
+                                      description: |-
+                                        ServiceAccountName is the name of the Kubernetes ServiceAccount that the snapshot Jobs run as,
+                                        so they authenticate to GCS through Workload Identity / Application Default Credentials (ADC)
+                                        instead of a credentials secret. Exactly one of `credentialsSecret` or `serviceAccountName`
+                                        must be set.
+                                      minLength: 1
+                                      type: string
                                     sizeLimit:
                                       description: Size limit at which the file will
                                         be split into multiple parts. Defaults to
@@ -4716,7 +4726,6 @@ spec:
                                       type: string
                                   required:
                                   - bucket
-                                  - credentialsSecret
                                   type: object
                                 suffix:
                                   description: Suffix to add to archive name. The
@@ -9306,8 +9315,10 @@ spec:
                                             or delete jobs. Defaults to `10`.
                                           type: integer
                                         credentialsSecret:
-                                          description: Secret with the JSON credentials
-                                            to upload to bucket.
+                                          description: |-
+                                            Secret with the JSON credentials to upload to bucket. Exactly one of `credentialsSecret` or
+                                            `serviceAccountName` must be set. When set, the snapshot Jobs mount this secret and use it as
+                                            `GOOGLE_APPLICATION_CREDENTIALS`.
                                           properties:
                                             key:
                                               description: The key of the secret to
@@ -9335,6 +9346,14 @@ spec:
                                           description: Size of each part when size-limit
                                             is crossed. Defaults to `500GB`.
                                           type: string
+                                        serviceAccountName:
+                                          description: |-
+                                            ServiceAccountName is the name of the Kubernetes ServiceAccount that the snapshot Jobs run as,
+                                            so they authenticate to GCS through Workload Identity / Application Default Credentials (ADC)
+                                            instead of a credentials secret. Exactly one of `credentialsSecret` or `serviceAccountName`
+                                            must be set.
+                                          minLength: 1
+                                          type: string
                                         sizeLimit:
                                           description: Size limit at which the file
                                             will be split into multiple parts. Defaults
@@ -9342,7 +9361,6 @@ spec:
                                           type: string
                                       required:
                                       - bucket
-                                      - credentialsSecret
                                       type: object
                                     suffix:
                                       description: Suffix to add to archive name.
@@ -14653,8 +14671,10 @@ spec:
                                       jobs. Defaults to `10`.
                                     type: integer
                                   credentialsSecret:
-                                    description: Secret with the JSON credentials
-                                      to upload to bucket.
+                                    description: |-
+                                      Secret with the JSON credentials to upload to bucket. Exactly one of `credentialsSecret` or
+                                      `serviceAccountName` must be set. When set, the snapshot Jobs mount this secret and use it as
+                                      `GOOGLE_APPLICATION_CREDENTIALS`.
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -14681,13 +14701,20 @@ spec:
                                     description: Size of each part when size-limit
                                       is crossed. Defaults to `500GB`.
                                     type: string
+                                  serviceAccountName:
+                                    description: |-
+                                      ServiceAccountName is the name of the Kubernetes ServiceAccount that the snapshot Jobs run as,
+                                      so they authenticate to GCS through Workload Identity / Application Default Credentials (ADC)
+                                      instead of a credentials secret. Exactly one of `credentialsSecret` or `serviceAccountName`
+                                      must be set.
+                                    minLength: 1
+                                    type: string
                                   sizeLimit:
                                     description: Size limit at which the file will
                                       be split into multiple parts. Defaults to `5TB`.
                                     type: string
                                 required:
                                 - bucket
-                                - credentialsSecret
                                 type: object
                               suffix:
                                 description: Suffix to add to archive name. The name

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -26,14 +26,14 @@ const (
 )
 
 type GCS struct {
-	Client        *kubernetes.Clientset
+	Client        kubernetes.Interface
 	Scheme        *runtime.Scheme
 	Owner         metav1.Object
 	priorityClass string
 	Config        *appsv1.GcsExportConfig
 }
 
-func NewGcsSnapshotProvider(client *kubernetes.Clientset, scheme *runtime.Scheme, owner metav1.Object, priorityClass string, cfg *appsv1.GcsExportConfig) SnapshotProvider {
+func NewGcsSnapshotProvider(client kubernetes.Interface, scheme *runtime.Scheme, owner metav1.Object, priorityClass string, cfg *appsv1.GcsExportConfig) SnapshotProvider {
 	return &GCS{
 		Client:        client,
 		Config:        cfg,
@@ -41,6 +41,69 @@ func NewGcsSnapshotProvider(client *kubernetes.Clientset, scheme *runtime.Scheme
 		Scheme:        scheme,
 		priorityClass: priorityClass,
 	}
+}
+
+// usesCredentialsSecret reports whether the snapshot Jobs authenticate to GCS using the mounted
+// credentials secret. When false, the Jobs run as the configured ServiceAccount and rely on Workload
+// Identity / Application Default Credentials instead.
+func (gcs *GCS) usesCredentialsSecret() bool {
+	return gcs.Config.CredentialsSecret != nil
+}
+
+// credentialsVolume returns the secret volume holding the GCS credentials, or nil when authenticating
+// through Workload Identity.
+func (gcs *GCS) credentialsVolume() []corev1.Volume {
+	if !gcs.usesCredentialsSecret() {
+		return nil
+	}
+	return []corev1.Volume{
+		{
+			Name: "credentials",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: gcs.Config.CredentialsSecret.Name,
+				},
+			},
+		},
+	}
+}
+
+// credentialsVolumeMount returns the mount for the credentials secret at /creds, or nil when
+// authenticating through Workload Identity.
+func (gcs *GCS) credentialsVolumeMount() []corev1.VolumeMount {
+	if !gcs.usesCredentialsSecret() {
+		return nil
+	}
+	return []corev1.VolumeMount{
+		{
+			Name:      "credentials",
+			MountPath: "/creds",
+		},
+	}
+}
+
+// credentialsEnv returns the GOOGLE_APPLICATION_CREDENTIALS environment variable pointing at the
+// mounted credentials secret, or nil when authenticating through Workload Identity.
+func (gcs *GCS) credentialsEnv() []corev1.EnvVar {
+	if !gcs.usesCredentialsSecret() {
+		return nil
+	}
+	return []corev1.EnvVar{
+		{
+			Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+			Value: fmt.Sprintf("/creds/%s", gcs.Config.CredentialsSecret.Key),
+		},
+	}
+}
+
+// serviceAccountName returns the ServiceAccount the Job pods should run as. It is only set when
+// authenticating through Workload Identity (no credentials secret); otherwise it is empty and the
+// namespace default ServiceAccount is used, preserving the previous behavior.
+func (gcs *GCS) serviceAccountName() string {
+	if gcs.usesCredentialsSecret() || gcs.Config.ServiceAccountName == nil {
+		return ""
+	}
+	return *gcs.Config.ServiceAccountName
 }
 
 func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.VolumeSnapshot) error {
@@ -69,9 +132,10 @@ func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.
 			BackoffLimit:            ptr.To[int32](0),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:     corev1.RestartPolicyNever,
-					PriorityClassName: gcs.priorityClass,
-					Volumes: []corev1.Volume{
+					RestartPolicy:      corev1.RestartPolicyNever,
+					PriorityClassName:  gcs.priorityClass,
+					ServiceAccountName: gcs.serviceAccountName(),
+					Volumes: append([]corev1.Volume{
 						{
 							Name: "data",
 							VolumeSource: corev1.VolumeSource{
@@ -80,15 +144,7 @@ func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.
 								},
 							},
 						},
-						{
-							Name: "credentials",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: gcs.Config.CredentialsSecret.Name,
-								},
-							},
-						},
-					},
+					}, gcs.credentialsVolume()...),
 					Containers: []corev1.Container{
 						{
 							Name:            "dataexporter",
@@ -97,42 +153,34 @@ func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.
 							SecurityContext: k8s.RestrictedSecurityContext(),
 							Args:            []string{"gcs", "upload", "data", gcs.Config.Bucket, name},
 							WorkingDir:      "/home/app",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-									Value: fmt.Sprintf("/creds/%s", gcs.Config.CredentialsSecret.Key),
-								},
-								{
+							Env: append(gcs.credentialsEnv(),
+								corev1.EnvVar{
 									Name:  "SIZE_LIMIT",
 									Value: gcs.Config.GetSizeLimit(),
 								},
-								{
+								corev1.EnvVar{
 									Name:  "PART_SIZE",
 									Value: gcs.Config.GetPartSize(),
 								},
-								{
+								corev1.EnvVar{
 									Name:  "CHUNK_SIZE",
 									Value: gcs.Config.GetChunkSize(),
 								},
-								{
+								corev1.EnvVar{
 									Name:  "BUFFER_SIZE",
 									Value: gcs.Config.GetBufferSize(),
 								},
-								{
+								corev1.EnvVar{
 									Name:  "CONCURRENT_JOBS",
 									Value: strconv.Itoa(gcs.Config.GetConcurrentJobs()),
 								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "credentials",
-									MountPath: "/creds",
-								},
-								{
+							),
+							VolumeMounts: append(gcs.credentialsVolumeMount(),
+								corev1.VolumeMount{
 									Name:      "data",
 									MountPath: "/home/app/data",
 								},
-							},
+							),
 						},
 					},
 				},
@@ -246,18 +294,10 @@ func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) error {
 			BackoffLimit:            ptr.To[int32](5),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:     corev1.RestartPolicyNever,
-					PriorityClassName: gcs.priorityClass,
-					Volumes: []corev1.Volume{
-						{
-							Name: "credentials",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: gcs.Config.CredentialsSecret.Name,
-								},
-							},
-						},
-					},
+					RestartPolicy:      corev1.RestartPolicyNever,
+					PriorityClassName:  gcs.priorityClass,
+					ServiceAccountName: gcs.serviceAccountName(),
+					Volumes:            gcs.credentialsVolume(),
 					Containers: []corev1.Container{
 						{
 							Name:            "dataexporter",
@@ -266,22 +306,13 @@ func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) error {
 							SecurityContext: k8s.RestrictedSecurityContext(),
 							Args:            []string{"gcs", "delete", gcs.Config.Bucket, name},
 							WorkingDir:      "/home/app",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-									Value: fmt.Sprintf("/creds/%s", gcs.Config.CredentialsSecret.Key),
-								},
-								{
+							Env: append(gcs.credentialsEnv(),
+								corev1.EnvVar{
 									Name:  "CONCURRENT_JOBS",
 									Value: strconv.Itoa(gcs.Config.GetConcurrentJobs()),
 								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "credentials",
-									MountPath: "/creds",
-								},
-							},
+							),
+							VolumeMounts: gcs.credentialsVolumeMount(),
 						},
 					},
 				},

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -1,0 +1,178 @@
+package datasnapshot
+
+import (
+	"context"
+	"testing"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGCSCreateSnapshotAuthModes(t *testing.T) {
+	tests := []struct {
+		name                 string
+		config               *appsv1.GcsExportConfig
+		wantServiceAccount   string
+		wantCredentialsEnv   bool
+		wantCredentialsVol   bool
+		wantCredentialsMount bool
+	}{
+		{
+			name: "credentials secret",
+			config: &appsv1.GcsExportConfig{
+				Bucket: "snapshots",
+				CredentialsSecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "gcs-creds"},
+					Key:                  "credentials.json",
+				},
+			},
+			wantCredentialsEnv:   true,
+			wantCredentialsVol:   true,
+			wantCredentialsMount: true,
+		},
+		{
+			name: "workload identity service account",
+			config: &appsv1.GcsExportConfig{
+				Bucket:             "snapshots",
+				ServiceAccountName: ptrTo("snapshot-publisher"),
+			},
+			wantServiceAccount: "snapshot-publisher",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newTestGCSProvider(t, tt.config)
+			vs := &snapshotv1.VolumeSnapshot{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot"},
+				ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"},
+				Status: &snapshotv1.VolumeSnapshotStatus{
+					RestoreSize: resource.NewQuantity(1024, resource.BinarySI),
+				},
+			}
+
+			err := provider.CreateSnapshot(context.Background(), "snapshot", vs)
+			require.NoError(t, err)
+
+			job := getJob(t, provider, "snapshot-upload")
+			podSpec := job.Spec.Template.Spec
+			container := podSpec.Containers[0]
+			assert.Equal(t, tt.wantServiceAccount, podSpec.ServiceAccountName)
+			assert.Equal(t, tt.wantCredentialsVol, hasVolume(podSpec.Volumes, "credentials"))
+			assert.Equal(t, tt.wantCredentialsMount, hasVolumeMount(container.VolumeMounts, "credentials"))
+			assert.Equal(t, tt.wantCredentialsEnv, hasEnv(container.Env, "GOOGLE_APPLICATION_CREDENTIALS"))
+		})
+	}
+}
+
+func TestGCSDeleteSnapshotAuthModes(t *testing.T) {
+	tests := []struct {
+		name                 string
+		config               *appsv1.GcsExportConfig
+		wantServiceAccount   string
+		wantCredentialsEnv   bool
+		wantCredentialsVol   bool
+		wantCredentialsMount bool
+	}{
+		{
+			name: "credentials secret",
+			config: &appsv1.GcsExportConfig{
+				Bucket: "snapshots",
+				CredentialsSecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "gcs-creds"},
+					Key:                  "credentials.json",
+				},
+			},
+			wantCredentialsEnv:   true,
+			wantCredentialsVol:   true,
+			wantCredentialsMount: true,
+		},
+		{
+			name: "workload identity service account",
+			config: &appsv1.GcsExportConfig{
+				Bucket:             "snapshots",
+				ServiceAccountName: ptrTo("snapshot-publisher"),
+			},
+			wantServiceAccount: "snapshot-publisher",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newTestGCSProvider(t, tt.config)
+
+			err := provider.DeleteSnapshot(context.Background(), "snapshot")
+			require.NoError(t, err)
+
+			job := getJob(t, provider, "snapshot-delete")
+			podSpec := job.Spec.Template.Spec
+			container := podSpec.Containers[0]
+			assert.Equal(t, tt.wantServiceAccount, podSpec.ServiceAccountName)
+			assert.Equal(t, tt.wantCredentialsVol, hasVolume(podSpec.Volumes, "credentials"))
+			assert.Equal(t, tt.wantCredentialsMount, hasVolumeMount(container.VolumeMounts, "credentials"))
+			assert.Equal(t, tt.wantCredentialsEnv, hasEnv(container.Env, "GOOGLE_APPLICATION_CREDENTIALS"))
+		})
+	}
+}
+
+func newTestGCSProvider(t *testing.T, cfg *appsv1.GcsExportConfig) *GCS {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	owner := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"},
+	}
+
+	return NewGcsSnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", cfg).(*GCS)
+}
+
+func getJob(t *testing.T, provider *GCS, name string) *batchv1.Job {
+	t.Helper()
+
+	job, err := provider.Client.BatchV1().Jobs(provider.Owner.GetNamespace()).Get(context.Background(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	return job
+}
+
+func hasVolume(volumes []corev1.Volume, name string) bool {
+	for _, volume := range volumes {
+		if volume.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeMount(mounts []corev1.VolumeMount, name string) bool {
+	for _, mount := range mounts {
+		if mount.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEnv(envs []corev1.EnvVar, name string) bool {
+	for _, env := range envs {
+		if env.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
## Summary
- Adds optional `serviceAccountName` auth for GCS snapshot tarball export so Jobs can use GKE Workload Identity / ADC.
- Keeps existing `credentialsSecret` JSON-key flow backwards compatible and validates exactly one auth mode.
- Regenerates CRDs/deepcopy, bumps chart to 2.3.1, and documents the GKE Workload Identity setup.

## Test plan
- `make manifests generate`
- `make docs`
- `go test ./api/v1 ./internal/datasnapshot ./internal/controllers/chainnode ./internal/controllers/chainnodeset`
- `git diff --check`
- `cd docs && bun install --frozen-lockfile && bun run build && bun run typecheck`

Linear: VLZ-776

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Service Account auth for GCS snapshot tarball export so Jobs can use GKE Workload Identity/ADC while keeping JSON key auth. Admission enforces exactly one auth mode; satisfies Linear VLZ-776.

- **New Features**
  - Added `serviceAccountName` to `GcsExportConfig` to run upload/delete Jobs with Workload Identity.
  - Admission validates exactly one of `credentialsSecret` or `serviceAccountName` for ChainNode/ChainNodeSet export configs; rejects empty `serviceAccountName`.
  - Jobs set `ServiceAccountName` and only mount credentials/`GOOGLE_APPLICATION_CREDENTIALS` when needed; GCS provider supports both modes and now uses `kubernetes.Interface`.
  - CRDs regenerated (make `credentialsSecret` optional; add `serviceAccountName` with min length); docs include GKE Workload Identity setup and clarify `snapshots` key; chart bumped to `2.3.1`; tests added for webhooks and GCS provider auth modes.

- **Migration**
  - No changes for existing `credentialsSecret` configs.
  - To use Workload Identity: set `serviceAccountName` and remove `credentialsSecret`.

<sup>Written for commit d04820f0fff5a898a0f017b23f0b12eee9a43f3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

