### PR TITLE
fix(node-utils): parse concatenated store traces

### DIFF
--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -4,6 +4,8 @@ package tracer
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"strings"
 	"syscall"
 
@@ -80,13 +82,21 @@ func (t *StoreTracer) Start() {
 			continue
 		}
 
-		if strings.TrimSpace(line.Text) != "" {
+		text := strings.TrimSpace(line.Text)
+		if text == "" {
+			continue
+		}
+
+		decoder := json.NewDecoder(strings.NewReader(text))
+		for {
 			trace := Trace{}
-			if err := json.Unmarshal([]byte(line.Text), &trace); err != nil {
-				t.Traces <- &Trace{Err: err}
-			} else {
-				t.Traces <- &trace
+			if err := decoder.Decode(&trace); err != nil {
+				if err != io.EOF {
+					t.Traces <- &Trace{Err: fmt.Errorf("failed to parse trace %q: %w", text, err)}
+				}
+				break
 			}
+			t.Traces <- &trace
 		}
 	}
 }

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -15,7 +15,13 @@ import (
 	"github.com/nxadm/tail"
 )
 
-const traceErrorExcerptLength = 96
+const (
+	// Keep enough of the current JSON object to identify the trace without
+	// dumping potentially large base64 key/value payloads into logs.
+	traceErrorObjectPrefixLength = 64
+	// Keep a separate bounded window around parse failures outside the prefix.
+	traceErrorNearWindowLength = 64
+)
 
 // StoreTracer reads and parses store operation traces from a file or FIFO pipe.
 type StoreTracer struct {
@@ -91,11 +97,23 @@ func (t *StoreTracer) Start() {
 
 		decoder := json.NewDecoder(strings.NewReader(text))
 		for {
+			objectOffset := decoder.InputOffset()
 			trace := Trace{}
 			if err := decoder.Decode(&trace); err != nil {
 				if err != io.EOF {
-					offset := decoder.InputOffset()
-					t.Traces <- &Trace{Err: fmt.Errorf("failed to parse trace near byte %d (%q): %w", offset, traceErrorExcerpt(text, offset), err)}
+					errorOffset := decoder.InputOffset()
+					objectPrefix, nearError := traceErrorContext(text, objectOffset, errorOffset)
+					if nearError == "" {
+						t.Traces <- &Trace{Err: fmt.Errorf(
+							"failed to parse trace at byte %d of %d (object=%q): %w",
+							errorOffset, len(text), objectPrefix, err,
+						)}
+					} else {
+						t.Traces <- &Trace{Err: fmt.Errorf(
+							"failed to parse trace at byte %d of %d (object=%q near=%q): %w",
+							errorOffset, len(text), objectPrefix, nearError, err,
+						)}
+					}
 				}
 				break
 			}
@@ -104,34 +122,57 @@ func (t *StoreTracer) Start() {
 	}
 }
 
-func traceErrorExcerpt(text string, offset int64) string {
-	if len(text) <= traceErrorExcerptLength {
-		return text
+func traceErrorContext(text string, objectOffset, errorOffset int64) (string, string) {
+	objectStart := clampOffset(objectOffset, len(text))
+	for objectStart < len(text) && isJSONWhitespace(text[objectStart]) {
+		objectStart++
+	}
+	objectEnd := min(objectStart+traceErrorObjectPrefixLength, len(text))
+
+	nearCenter := clampOffset(errorOffset, len(text))
+	nearStart := nearCenter - traceErrorNearWindowLength/2
+	if nearStart < objectStart {
+		nearStart = objectStart
+	}
+	nearEnd := nearStart + traceErrorNearWindowLength
+	if nearEnd > len(text) {
+		nearEnd = len(text)
+		nearStart = max(objectStart, nearEnd-traceErrorNearWindowLength)
+	}
+	if nearStart < objectEnd {
+		objectEnd = min(max(objectEnd, nearEnd), objectStart+traceErrorObjectPrefixLength+traceErrorNearWindowLength)
+		objectPrefix := text[objectStart:objectEnd]
+		if objectEnd < len(text) {
+			objectPrefix += "..."
+		}
+		return objectPrefix, ""
 	}
 
-	center := int(offset)
-	if center < 0 {
-		center = 0
-	} else if center > len(text) {
-		center = len(text)
+	objectPrefix := text[objectStart:objectEnd]
+	if objectEnd < len(text) {
+		objectPrefix += "..."
 	}
 
-	start := center - traceErrorExcerptLength/2
-	if start < 0 {
-		start = 0
+	nearError := text[nearStart:nearEnd]
+	if nearStart > objectStart {
+		nearError = "..." + nearError
 	}
-	end := start + traceErrorExcerptLength
-	if end > len(text) {
-		end = len(text)
-		start = end - traceErrorExcerptLength
+	if nearEnd < len(text) {
+		nearError += "..."
 	}
+	return objectPrefix, nearError
+}
 
-	excerpt := text[start:end]
-	if start > 0 {
-		excerpt = "..." + excerpt
+func isJSONWhitespace(value byte) bool {
+	return value == ' ' || value == '	' || value == '\r' || value == '\n'
+}
+
+func clampOffset(offset int64, length int) int {
+	if offset < 0 {
+		return 0
 	}
-	if end < len(text) {
-		excerpt += "..."
+	if offset > int64(length) {
+		return length
 	}
-	return excerpt
+	return int(offset)
 }

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -15,6 +15,8 @@ import (
 	"github.com/nxadm/tail"
 )
 
+const traceErrorExcerptLength = 96
+
 // StoreTracer reads and parses store operation traces from a file or FIFO pipe.
 type StoreTracer struct {
 	tail   *tail.Tail
@@ -92,11 +94,44 @@ func (t *StoreTracer) Start() {
 			trace := Trace{}
 			if err := decoder.Decode(&trace); err != nil {
 				if err != io.EOF {
-					t.Traces <- &Trace{Err: fmt.Errorf("failed to parse trace %q: %w", text, err)}
+					offset := decoder.InputOffset()
+					t.Traces <- &Trace{Err: fmt.Errorf("failed to parse trace near byte %d (%q): %w", offset, traceErrorExcerpt(text, offset), err)}
 				}
 				break
 			}
 			t.Traces <- &trace
 		}
 	}
+}
+
+func traceErrorExcerpt(text string, offset int64) string {
+	if len(text) <= traceErrorExcerptLength {
+		return text
+	}
+
+	center := int(offset)
+	if center < 0 {
+		center = 0
+	} else if center > len(text) {
+		center = len(text)
+	}
+
+	start := center - traceErrorExcerptLength/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + traceErrorExcerptLength
+	if end > len(text) {
+		end = len(text)
+		start = end - traceErrorExcerptLength
+	}
+
+	excerpt := text[start:end]
+	if start > 0 {
+		excerpt = "..." + excerpt
+	}
+	if end < len(text) {
+		excerpt += "..."
+	}
+	return excerpt
 }

--- a/pkg/tracer/tracer_test.go
+++ b/pkg/tracer/tracer_test.go
@@ -3,6 +3,7 @@ package tracer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -153,9 +154,70 @@ func TestStoreTracer_ParseInvalidJSON(t *testing.T) {
 	case trace := <-tracesReceived:
 		if trace.Err == nil {
 			t.Error("expected error for invalid JSON, got nil")
+		} else if !strings.Contains(trace.Err.Error(), "not valid json") {
+			t.Errorf("expected error to include invalid trace input, got %q", trace.Err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for trace")
+	}
+
+	f.Close()
+	_ = tracer.Stop()
+	<-done
+}
+
+func TestStoreTracer_ParseMultipleTracesOnOneLine(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "trace.log")
+
+	f, err := os.Create(tracePath)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	tracer, err := NewStoreTracer(tracePath, false)
+	if err != nil {
+		f.Close()
+		t.Fatalf("NewStoreTracer() error = %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tracer.Start()
+	}()
+
+	tracesReceived := make(chan *Trace, 2)
+	go func() {
+		for trace := range tracer.Traces {
+			tracesReceived <- trace
+		}
+	}()
+
+	traceJSON := `{"operation":"write","key":"first"}{"operation":"read","key":"second"}`
+	if _, err = f.WriteString(traceJSON + "\n"); err != nil {
+		t.Fatalf("failed to write traces: %v", err)
+	}
+	_ = f.Sync()
+
+	for i, expected := range []struct {
+		operation string
+		key       string
+	}{
+		{operation: "write", key: "first"},
+		{operation: "read", key: "second"},
+	} {
+		select {
+		case trace := <-tracesReceived:
+			if trace.Err != nil {
+				t.Fatalf("trace %d returned unexpected error: %v", i, trace.Err)
+			}
+			if trace.Operation != expected.operation || trace.Key != expected.key {
+				t.Errorf("trace %d = operation %q, key %q; want operation %q, key %q", i, trace.Operation, trace.Key, expected.operation, expected.key)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for trace %d", i)
+		}
 	}
 
 	f.Close()

--- a/pkg/tracer/tracer_test.go
+++ b/pkg/tracer/tracer_test.go
@@ -200,11 +200,20 @@ func TestStoreTracer_TruncatesLongInvalidTraceInError(t *testing.T) {
 			t.Fatal("expected error for invalid JSON, got nil")
 		}
 		errorText := trace.Err.Error()
-		if len(errorText) > 512 {
+		if len(errorText) > 384 {
 			t.Errorf("expected bounded error, got %d characters", len(errorText))
 		}
 		if !strings.Contains(errorText, "...") {
 			t.Errorf("expected truncated error to contain ellipsis, got %q", errorText)
+		}
+		if !strings.Contains(errorText, `object="{\"operation\":\"write\",\"value\":\"`) {
+			t.Errorf("expected current object prefix, got %q", errorText)
+		}
+		if !strings.Contains(errorText, `near="...aaaaaaaa`) {
+			t.Errorf("expected context near the parse error, got %q", errorText)
+		}
+		if !strings.Contains(errorText, "of 4126") {
+			t.Errorf("expected error to include total length, got %q", errorText)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for trace")
@@ -259,8 +268,11 @@ func TestStoreTracer_EmitsValidTraceBeforeMalformedSuffix(t *testing.T) {
 		if trace.Err == nil {
 			t.Fatal("expected error for malformed suffix, got nil")
 		}
-		if !strings.Contains(trace.Err.Error(), "{invalid}") {
-			t.Errorf("expected error context near malformed suffix, got %q", trace.Err)
+		if !strings.Contains(trace.Err.Error(), `object="{invalid}"`) {
+			t.Errorf("expected current object context for malformed suffix, got %q", trace.Err)
+		}
+		if strings.Contains(trace.Err.Error(), "near=") {
+			t.Errorf("expected overlapping context to be collapsed, got %q", trace.Err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for malformed suffix error")

--- a/pkg/tracer/tracer_test.go
+++ b/pkg/tracer/tracer_test.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -187,7 +188,7 @@ func TestStoreTracer_TruncatesLongInvalidTraceInError(t *testing.T) {
 		tracer.Start()
 	}()
 
-	longValue := strings.Repeat("a", 4096)
+	longValue := strings.Repeat("a", 1024)
 	invalidTrace := `{"operation":"write","value":"` + longValue
 	if _, err = f.WriteString(invalidTrace + "\n"); err != nil {
 		t.Fatalf("failed to write trace: %v", err)
@@ -212,7 +213,7 @@ func TestStoreTracer_TruncatesLongInvalidTraceInError(t *testing.T) {
 		if !strings.Contains(errorText, `near="...aaaaaaaa`) {
 			t.Errorf("expected context near the parse error, got %q", errorText)
 		}
-		if !strings.Contains(errorText, "of 4126") {
+		if !strings.Contains(errorText, fmt.Sprintf("of %d", len(invalidTrace))) {
 			t.Errorf("expected error to include total length, got %q", errorText)
 		}
 	case <-time.After(2 * time.Second):

--- a/pkg/tracer/tracer_test.go
+++ b/pkg/tracer/tracer_test.go
@@ -166,6 +166,111 @@ func TestStoreTracer_ParseInvalidJSON(t *testing.T) {
 	<-done
 }
 
+func TestStoreTracer_TruncatesLongInvalidTraceInError(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "trace.log")
+
+	f, err := os.Create(tracePath)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	tracer, err := NewStoreTracer(tracePath, false)
+	if err != nil {
+		f.Close()
+		t.Fatalf("NewStoreTracer() error = %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tracer.Start()
+	}()
+
+	longValue := strings.Repeat("a", 4096)
+	invalidTrace := `{"operation":"write","value":"` + longValue
+	if _, err = f.WriteString(invalidTrace + "\n"); err != nil {
+		t.Fatalf("failed to write trace: %v", err)
+	}
+	_ = f.Sync()
+
+	select {
+	case trace := <-tracer.Traces:
+		if trace.Err == nil {
+			t.Fatal("expected error for invalid JSON, got nil")
+		}
+		errorText := trace.Err.Error()
+		if len(errorText) > 512 {
+			t.Errorf("expected bounded error, got %d characters", len(errorText))
+		}
+		if !strings.Contains(errorText, "...") {
+			t.Errorf("expected truncated error to contain ellipsis, got %q", errorText)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for trace")
+	}
+
+	f.Close()
+	_ = tracer.Stop()
+	<-done
+}
+
+func TestStoreTracer_EmitsValidTraceBeforeMalformedSuffix(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "trace.log")
+
+	f, err := os.Create(tracePath)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	tracer, err := NewStoreTracer(tracePath, false)
+	if err != nil {
+		f.Close()
+		t.Fatalf("NewStoreTracer() error = %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tracer.Start()
+	}()
+
+	traceLine := `{"operation":"write","key":"valid"}{invalid}`
+	if _, err = f.WriteString(traceLine + "\n"); err != nil {
+		t.Fatalf("failed to write traces: %v", err)
+	}
+	_ = f.Sync()
+
+	select {
+	case trace := <-tracer.Traces:
+		if trace.Err != nil {
+			t.Fatalf("valid trace returned unexpected error: %v", trace.Err)
+		}
+		if trace.Key != "valid" {
+			t.Errorf("expected valid trace key, got %q", trace.Key)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for valid trace")
+	}
+
+	select {
+	case trace := <-tracer.Traces:
+		if trace.Err == nil {
+			t.Fatal("expected error for malformed suffix, got nil")
+		}
+		if !strings.Contains(trace.Err.Error(), "{invalid}") {
+			t.Errorf("expected error context near malformed suffix, got %q", trace.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for malformed suffix error")
+	}
+
+	f.Close()
+	_ = tracer.Stop()
+	<-done
+}
+
 func TestStoreTracer_ParseMultipleTracesOnOneLine(t *testing.T) {
 	tmpDir := t.TempDir()
 	tracePath := filepath.Join(tmpDir, "trace.log")


### PR DESCRIPTION
## Summary
- decode every JSON trace value present in a tailed line instead of assuming one object per line
- bound parse diagnostics to a 64-byte current-object prefix and a separate 64-byte near-error window
- include the error offset and total line length without logging full base64 payloads
- add regression coverage for concatenated traces, bounded diagnostics, and valid-prefix/malformed-suffix input

## Test plan
- [x] `go test ./pkg/tracer -count=1`
- [x] `go test ./pkg/nodeutils ./pkg/tracer -count=1`
- [x] `make test.unit`

Closes #52
