### PR TITLE
fix(helm): avoid duplicate priority classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ docs: crd-to-markdown ## Generate markdown docs of CRD spec.
 
 .PHONY: test.unit
 test.unit: manifests generate fmt vet ## Run unit tests.
-	go test ./api/... ./cmd/... ./internal/... ./pkg/... -coverprofile cover.out
+	go test ./api/... ./cmd/... ./helm/... ./internal/... ./pkg/... -coverprofile cover.out
 
 .PHONY: test.integration
 test.integration: FOCUS?=

--- a/helm/cosmopilot/priority_classes_test.go
+++ b/helm/cosmopilot/priority_classes_test.go
@@ -1,21 +1,81 @@
 package cosmopilot
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"strings"
 	"testing"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestPriorityClassResourcesAreUnique(t *testing.T) {
-	template, err := os.ReadFile("templates/priority-classes.yaml")
+	templateSource, err := os.ReadFile("templates/priority-classes.yaml")
 	if err != nil {
 		t.Fatalf("read priority class template: %v", err)
 	}
 
-	for _, suffix := range []string{"default", "nodes", "validators"} {
-		name := "name: {{ .Release.Name }}-" + suffix
-		if count := strings.Count(string(template), name); count != 1 {
-			t.Errorf("priority class %q is declared %d times, want 1", suffix, count)
+	chartTemplate, err := template.New("priority-classes.yaml").Funcs(template.FuncMap{
+		"include": func(string, any) string {
+			return "\napp.kubernetes.io/name: cosmopilot\napp.kubernetes.io/instance: test"
+		},
+		"indent": func(spaces int, value string) string {
+			prefix := strings.Repeat(" ", spaces)
+			return prefix + strings.ReplaceAll(value, "\n", "\n"+prefix)
+		},
+		"lookup": func(string, string, string, string) map[string]any {
+			return map[string]any{"metadata": map[string]any{"name": "existing"}}
+		},
+	}).Parse(string(templateSource))
+	if err != nil {
+		t.Fatalf("parse priority class template: %v", err)
+	}
+
+	var rendered bytes.Buffer
+	err = chartTemplate.Execute(&rendered, map[string]any{
+		"Release": map[string]any{"Name": "test"},
+		"Values": map[string]any{
+			"defaultPriority":      0,
+			"nodesPodPriority":     950,
+			"validatorPodPriority": 1050,
+		},
+	})
+	if err != nil {
+		t.Fatalf("render priority class template: %v", err)
+	}
+
+	type manifest struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+	}
+
+	decoder := yaml.NewDecoder(&rendered)
+	seen := make(map[string]struct{})
+	for {
+		var resource manifest
+		err := decoder.Decode(&resource)
+		if err == io.EOF {
+			break
 		}
+		if err != nil {
+			t.Fatalf("decode rendered manifest: %v", err)
+		}
+		if resource.Kind != "PriorityClass" {
+			continue
+		}
+
+		identity := resource.Kind + "/" + resource.Metadata.Name
+		if _, exists := seen[identity]; exists {
+			t.Errorf("rendered duplicate resource %q", identity)
+		}
+		seen[identity] = struct{}{}
+	}
+
+	if len(seen) != 3 {
+		t.Errorf("rendered %d unique priority classes, want 3", len(seen))
 	}
 }

--- a/helm/cosmopilot/priority_classes_test.go
+++ b/helm/cosmopilot/priority_classes_test.go
@@ -1,0 +1,21 @@
+package cosmopilot
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPriorityClassResourcesAreUnique(t *testing.T) {
+	template, err := os.ReadFile("templates/priority-classes.yaml")
+	if err != nil {
+		t.Fatalf("read priority class template: %v", err)
+	}
+
+	for _, suffix := range []string{"default", "nodes", "validators"} {
+		name := "name: {{ .Release.Name }}-" + suffix
+		if count := strings.Count(string(template), name); count != 1 {
+			t.Errorf("priority class %q is declared %d times, want 1", suffix, count)
+		}
+	}
+}

--- a/helm/cosmopilot/templates/priority-classes.yaml
+++ b/helm/cosmopilot/templates/priority-classes.yaml
@@ -1,20 +1,3 @@
-{{- $existingDefaultClass := lookup "scheduling.k8s.io/v1" "PriorityClass" "" (printf "%s-default" .Release.Name) }}
-{{- if $existingDefaultClass }}
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: {{ .Release.Name }}-default
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-  labels:
-    {{- include "cosmopilot.labels" . | indent 4 }}
-value: {{ .Values.defaultPriority }}
-globalDefault: false
-description: "Delete default priority class before upgrading"
-{{- end }}
----
-# Always create the PriorityClass after checking/deleting existing ones
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -25,23 +8,6 @@ value: {{ .Values.defaultPriority }}
 globalDefault: false
 description: "CosmoPilot default priority class for background jobs and normal workloads"
 ---
-{{- $existingNodesClass := lookup "scheduling.k8s.io/v1" "PriorityClass" "" (printf "%s-nodes" .Release.Name) }}
-{{- if $existingNodesClass }}
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: {{ .Release.Name }}-nodes
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-  labels:
-    {{- include "cosmopilot.labels" . | indent 4 }}
-value: {{ .Values.nodesPodPriority }}
-globalDefault: false
-description: "Delete nodes priority class before upgrading"
-{{- end }}
----
-# Always create the PriorityClass after checking/deleting existing ones
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -52,23 +18,6 @@ value: {{ .Values.nodesPodPriority }}
 globalDefault: false
 description: "CosmoPilot priority class for nodes"
 ---
-{{- $existingValidatorsClass := lookup "scheduling.k8s.io/v1" "PriorityClass" "" (printf "%s-validators" .Release.Name) }}
-{{- if $existingValidatorsClass }}
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: {{ .Release.Name }}-validators
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-  labels:
-    {{- include "cosmopilot.labels" . | indent 4 }}
-value: {{ .Values.validatorPodPriority }}
-globalDefault: false
-description: "Delete validator priority class before upgrading"
-{{- end }}
----
-# Always create the PriorityClass after checking/deleting existing ones
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:


### PR DESCRIPTION
## Summary
- remove duplicate lookup-driven PriorityClass hook manifests from the Helm chart
- retain the three normal Helm-managed PriorityClasses
- add a regression test that requires each PriorityClass resource name to be unique
- include chart tests in `make test.unit`

## Root cause
During an upgrade, `lookup` found the existing PriorityClasses and rendered both hook and normal resources with identical IDs. Flux Helm post-rendering rejected the duplicates before the controller image could be upgraded.

## Validation
- regression test failed against the previous template and passes with this change
- `helm lint helm/cosmopilot`
- live-cluster `helm template --dry-run=server --is-upgrade` has unique resource IDs
- live-cluster `helm upgrade --dry-run=server` succeeds
- all Go package tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate Kubernetes PriorityClasses during Helm upgrades by removing `lookup`-based hooks and keeping only the three Helm-managed classes. Fixes Flux post-render failures and stabilizes upgrades.

- **Bug Fixes**
  - Removed all `lookup`-driven hook manifests from `priority-classes.yaml`; kept `default`, `nodes`, and `validators`.
  - Added a Helm chart unit test that renders the template and asserts exactly three unique PriorityClass identities (no duplicates).
  - Included Helm chart tests in `make test.unit` by adding `./helm/...` to `go test`.

<sup>Written for commit c1981373191f8a1514395b4d31e151a5acded428. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

