### PR TITLE
chore(cosmoguard): bump default image to 4.0.1

### DIFF
--- a/cmd/manager/config.go
+++ b/cmd/manager/config.go
@@ -35,7 +35,7 @@ func init() {
 	)
 
 	flag.StringVar(&runOpts.CosmoGuardImage, "cosmoguard-image",
-		environ.GetString("COSMOGUARD_IMAGE", "ghcr.io/voluzi/cosmoguard:4.0.0"),
+		environ.GetString("COSMOGUARD_IMAGE", "ghcr.io/voluzi/cosmoguard:4.0.1"),
 		"cosmoguard image for the standalone deployments created when CosmoGuard is enabled.",
 	)
 

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -34,7 +34,7 @@ $ helm show values oci://ghcr.io/voluzi/helm/cosmopilot
 
 ### `cosmoGuardImage`
 - **Description**: The container image of [CosmoGuard](https://github.com/voluzi/cosmoguard) (with version tag included) used for the standalone CosmoGuard deployments.
-- **Default**: `ghcr.io/voluzi/cosmoguard:4.0.0`
+- **Default**: `ghcr.io/voluzi/cosmoguard:4.0.1`
 
 ### `cosmoseedImage`
 - **Description**: The container image of [Cosmoseed](https://github.com/voluzi/cosmoseed) (with version tag included). Used when deploying seed nodes.

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -23,7 +23,7 @@ admission webhook server.
 | `-health-probe-bind-address` | `HEALTH_PROBE_BIND_ADDRESS` | `:8081` | Address the health/readiness probe endpoint binds to. |
 | `-enable-leader-election` | `ENABLE_LEADER_ELECTION` | `false` | Enable leader election so only one manager is active at a time. |
 | `-nodeutils-image` | `NODE_UTILS_IMAGE` | `ghcr.io/voluzi/node-utils` | `node-utils` image deployed as a sidecar with each node. |
-| `-cosmoguard-image` | `COSMOGUARD_IMAGE` | `ghcr.io/voluzi/cosmoguard:4.0.0` | CosmoGuard image for the standalone deployments created when CosmoGuard is enabled. |
+| `-cosmoguard-image` | `COSMOGUARD_IMAGE` | `ghcr.io/voluzi/cosmoguard:4.0.1` | CosmoGuard image for the standalone deployments created when CosmoGuard is enabled. |
 | `-cosmoseed-image` | `COSMOSEED_IMAGE` | `ghcr.io/voluzi/cosmoseed` | Image used for Cosmoseed deployments when enabled. |
 | `-worker-name` | `WORKER_NAME` | `""` | Name of this worker (set as the `worker-name` label). Used to shard which resources this instance reconciles. |
 | `-worker-count` | `WORKER_COUNT` | `1` | Maximum number of concurrent reconciles. |

--- a/docs/docs/usage/cosmoguard.md
+++ b/docs/docs/usage/cosmoguard.md
@@ -82,7 +82,7 @@ config:
       name: cosmoguard-config  # Name of the ConfigMap created in Step 2.
       key: cosmoguard.yaml     # Key within the ConfigMap containing the rules.
     replicas: 2                # Optional: number of CosmoGuard replicas (default 1). Ignored when autoscaling is enabled.
-    image: ghcr.io/voluzi/cosmoguard:4.0.0  # Optional: override the operator-wide default image.
+    image: ghcr.io/voluzi/cosmoguard:4.0.1  # Optional: override the operator-wide default image.
     resources:                 # Optional: per-pod resources (defaults shown).
       requests:
         cpu: 200m

--- a/helm/cosmopilot/values.yaml
+++ b/helm/cosmopilot/values.yaml
@@ -1,6 +1,6 @@
 image: ghcr.io/voluzi/cosmopilot
 nodeUtilsImage: ghcr.io/voluzi/node-utils:2.9.0
-cosmoGuardImage: ghcr.io/voluzi/cosmoguard:4.0.0
+cosmoGuardImage: ghcr.io/voluzi/cosmoguard:4.0.1
 cosmoseedImage: ghcr.io/voluzi/cosmoseed:0.11.0
 cosmosignerImage: ghcr.io/voluzi/cosmosigner:0.2.0
 replicas: 1

--- a/internal/controllers/chainnode/cosmoguard_test.go
+++ b/internal/controllers/chainnode/cosmoguard_test.go
@@ -35,7 +35,7 @@ func cosmoGuardTestReconciler(t *testing.T, objs ...client.Object) *Reconciler {
 	return &Reconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
 		Scheme: scheme,
-		opts:   &controllers.ControllerRunOptions{CosmoGuardImage: "ghcr.io/voluzi/cosmoguard:4.0.0"},
+		opts:   &controllers.ControllerRunOptions{CosmoGuardImage: "ghcr.io/voluzi/cosmoguard:4.0.1"},
 	}
 }
 

--- a/internal/cosmoguard/cosmoguard_test.go
+++ b/internal/cosmoguard/cosmoguard_test.go
@@ -18,7 +18,7 @@ func baseParams() Params {
 	return Params{
 		Name:      "chain-group-cg",
 		Namespace: "ns",
-		Image:     "ghcr.io/voluzi/cosmoguard:4.0.0",
+		Image:     "ghcr.io/voluzi/cosmoguard:4.0.1",
 		Replicas:  2,
 		ConfigMap: &corev1.ConfigMapKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{Name: "rules"},


### PR DESCRIPTION
## Summary
- bump the operator-wide CosmoGuard default image to v4.0.1
- update Helm values, CLI defaults, tests, and current documentation

## Validation
- `helm lint helm/cosmopilot`
- `helm template cosmopilot helm/cosmopilot`
- `make test.unit`
- `make test.integration` (88/88)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the operator-wide CosmoGuard default image to 4.0.1 to use the latest patch release. Updates Helm values, CLI defaults/docs, tests, and docs so defaults deploy `ghcr.io/voluzi/cosmoguard:4.0.1`.

<sup>Written for commit 4d13461206f5abbbd5673eee8ee7f097ade527ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

