### PR TITLE
fix: stop recoverable snapshot errors from aborting ChainNode reconcile

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -49,6 +49,7 @@ const (
 	ReasonTarballDeleted             = "TarballDeleted"
 	ReasonTarballExportError         = "TarballExportError"
 	ReasonTarballDeleteError         = "TarballDeleteError"
+	ReasonSnapshotJobReplaced        = "SnapshotJobReplaced"
 	ReasonSnapshotIntegrityStart     = "IntegrityCheckStart"
 	ReasonUpgradeCompleted           = "UpgradeCompleted"
 	ReasonUpgradeFailed              = "UpgradeFailed"

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -2,6 +2,7 @@ package chainnode
 
 import (
 	"context"
+	stderrors "errors"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -22,6 +23,7 @@ import (
 	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
 	"github.com/voluzi/cosmopilot/v2/internal/chainutils/sdkcmd"
 	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	"github.com/voluzi/cosmopilot/v2/internal/datasnapshot"
 	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
 )
 
@@ -290,7 +292,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Ensure snapshots are taken if enabled and check if they are ready
 	logger.V(1).Info("ensure volume snapshots if applicable")
 	if err = r.ensureVolumeSnapshots(ctx, chainNode, nodePodReady); err != nil {
-		return ctrl.Result{}, err
+		// A stale export/delete Job was dropped and will be recreated on the next pass. Keep it out of the
+		// reconcile error path so an unrelated subsystem cannot freeze the whole ChainNode.
+		if !stderrors.Is(err, datasnapshot.ErrStaleJobReplaced) {
+			return ctrl.Result{}, err
+		}
+		logger.Info("replaced stale snapshot job", "reason", err.Error())
+		r.recorder.Eventf(chainNode,
+			corev1.EventTypeWarning,
+			appsv1.ReasonSnapshotJobReplaced,
+			"Replaced stale snapshot job: %v", err,
+		)
 	}
 
 	// If the node will be down during snapshot, most methods below will fail.

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -303,6 +303,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			appsv1.ReasonSnapshotJobReplaced,
 			"Replaced stale snapshot job: %v", err,
 		)
+		// Requeue now rather than waiting a full reconcile period: Jobs are not watched, so nothing else
+		// would wake the controller, and the snapshot stays stuck in its exporting state until it does.
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// If the node will be down during snapshot, most methods below will fail.

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -291,6 +291,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// Ensure snapshots are taken if enabled and check if they are ready
 	logger.V(1).Info("ensure volume snapshots if applicable")
+	staleSnapshotJobReplaced := false
 	if err = r.ensureVolumeSnapshots(ctx, chainNode, nodePodReady); err != nil {
 		// A stale export/delete Job was dropped and will be recreated on the next pass. Keep it out of the
 		// reconcile error path so an unrelated subsystem cannot freeze the whole ChainNode.
@@ -303,9 +304,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			appsv1.ReasonSnapshotJobReplaced,
 			"Replaced stale snapshot job: %v", err,
 		)
-		// Requeue now rather than waiting a full reconcile period: Jobs are not watched, so nothing else
-		// would wake the controller, and the snapshot stays stuck in its exporting state until it does.
-		return ctrl.Result{Requeue: true}, nil
+		// Note it and carry on. Returning here would freeze genesis, services, config and the pod behind
+		// snapshot cleanup — the very failure mode this path exists to prevent — and foreground deletion
+		// can stay pending for a while behind the upload pod, its PVC or a finalizer.
+		staleSnapshotJobReplaced = true
 	}
 
 	// If the node will be down during snapshot, most methods below will fail.
@@ -434,6 +436,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	logger.Info("finishing reconcile")
+	if staleSnapshotJobReplaced {
+		// Come back promptly to recreate the replaced Job: Jobs are not watched, so nothing else would
+		// wake the controller before the full reconcile period elapses.
+		return ctrl.Result{Requeue: true}, nil
+	}
 	if dashboardRoutesPending {
 		return ctrl.Result{RequeueAfter: dashboardRouteCheckPeriod}, nil
 	}

--- a/internal/controllers/chainnode/pvc.go
+++ b/internal/controllers/chainnode/pvc.go
@@ -381,6 +381,14 @@ func (r *Reconciler) updatePvcDataHeight(ctx context.Context, chainNode *appsv1.
 		if err := r.reservationReader().Get(ctx, client.ObjectKeyFromObject(pvc), fresh); err != nil {
 			return err
 		}
+		// Same name does not mean same volume: the PVC may have been deleted and recreated since the
+		// cached lookup earlier in this reconcile. Stamping the old volume's height onto the replacement
+		// would make a freshly initialized volume claim the previous chain height, which is later adopted
+		// as PVC state. Bail out and let the next reconcile start from the real object.
+		if pvc.UID != "" && fresh.UID != pvc.UID {
+			return fmt.Errorf("PVC %s was replaced (uid %s != %s); skipping data height annotation",
+				pvc.GetName(), fresh.UID, pvc.UID)
+		}
 		if fresh.Annotations == nil {
 			fresh.Annotations = make(map[string]string)
 		}

--- a/internal/controllers/chainnode/pvc.go
+++ b/internal/controllers/chainnode/pvc.go
@@ -322,12 +322,16 @@ func (r *Reconciler) ensurePvcUpdates(ctx context.Context, chainNode *appsv1.Cha
 	}
 
 	if err = r.updatePvcDataHeight(ctx, chainNode, pvc); err != nil {
-		// data-height is advisory metadata. The snapshot flow annotates this same PVC, so write conflicts
-		// are expected; returning the error would abort the reconcile over cosmetic metadata.
+		// Only exhausted optimistic-concurrency conflicts are tolerated here. data-height is advisory
+		// metadata and the snapshot flow annotates this same PVC, so conflicts are expected and must not
+		// abort the reconcile over cosmetic metadata.
 		//
 		// Stop before the resize rather than falling through: the local pvc still holds the resource
 		// version that just lost, so resizing it would conflict again and abort anyway. Both writes are
 		// retried on the next reconcile against a fresh copy.
+		if !errors.IsConflict(err) {
+			return fmt.Errorf("failed to update PVC %s data height annotation: %w", pvc.GetName(), err)
+		}
 		logger.Error(err, "failed to update PVC data height annotation; deferring PVC writes to next reconcile", "pvc", pvc.GetName())
 		return nil
 	}

--- a/internal/controllers/chainnode/pvc.go
+++ b/internal/controllers/chainnode/pvc.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -320,12 +321,11 @@ func (r *Reconciler) ensurePvcUpdates(ctx context.Context, chainNode *appsv1.Cha
 		return fmt.Errorf("failed to update latest height for %s: %w", chainNode.GetName(), err)
 	}
 
-	dataHeight := strconv.FormatInt(chainNode.Status.LatestHeight, 10)
-	if pvc.Annotations[controllers.AnnotationDataHeight] != dataHeight {
-		pvc.Annotations[controllers.AnnotationDataHeight] = dataHeight
-		if err = r.Update(ctx, pvc); err != nil {
-			return fmt.Errorf("failed to update PVC %s data height annotation: %w", pvc.GetName(), err)
-		}
+	if err = r.updatePvcDataHeight(ctx, chainNode, pvc); err != nil {
+		// data-height is advisory metadata. The snapshot flow annotates this same PVC, so write conflicts
+		// are expected; failing here would skip everything after PVC reconciliation, including the
+		// snapshot state machine. Log it and let the next reconcile retry.
+		logger.Error(err, "failed to update PVC data height annotation", "pvc", pvc.GetName())
 	}
 
 	switch pvc.Spec.Resources.Requests.Storage().Cmp(expectedStorageSize) {
@@ -356,6 +356,31 @@ func (r *Reconciler) ensurePvcUpdates(ctx context.Context, chainNode *appsv1.Cha
 		}
 		return nil
 	}
+}
+
+// updatePvcDataHeight records the current data height on the PVC, retrying on optimistic-concurrency
+// conflicts against a freshly read copy. On success, pvc is refreshed so later writes in this reconcile
+// carry an up-to-date resource version.
+func (r *Reconciler) updatePvcDataHeight(ctx context.Context, chainNode *appsv1.ChainNode, pvc *corev1.PersistentVolumeClaim) error {
+	dataHeight := strconv.FormatInt(chainNode.Status.LatestHeight, 10)
+	if pvc.Annotations[controllers.AnnotationDataHeight] == dataHeight {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(pvc), fresh); err != nil {
+			return err
+		}
+		if fresh.Annotations == nil {
+			fresh.Annotations = make(map[string]string)
+		}
+		fresh.Annotations[controllers.AnnotationDataHeight] = dataHeight
+		if err := r.Update(ctx, fresh); err != nil {
+			return err
+		}
+		fresh.DeepCopyInto(pvc)
+		return nil
+	})
 }
 
 func (r *Reconciler) getStorageSize(ctx context.Context, chainNode *appsv1.ChainNode) (resource.Quantity, error) {

--- a/internal/controllers/chainnode/pvc.go
+++ b/internal/controllers/chainnode/pvc.go
@@ -323,9 +323,13 @@ func (r *Reconciler) ensurePvcUpdates(ctx context.Context, chainNode *appsv1.Cha
 
 	if err = r.updatePvcDataHeight(ctx, chainNode, pvc); err != nil {
 		// data-height is advisory metadata. The snapshot flow annotates this same PVC, so write conflicts
-		// are expected; failing here would skip everything after PVC reconciliation, including the
-		// snapshot state machine. Log it and let the next reconcile retry.
-		logger.Error(err, "failed to update PVC data height annotation", "pvc", pvc.GetName())
+		// are expected; returning the error would abort the reconcile over cosmetic metadata.
+		//
+		// Stop before the resize rather than falling through: the local pvc still holds the resource
+		// version that just lost, so resizing it would conflict again and abort anyway. Both writes are
+		// retried on the next reconcile against a fresh copy.
+		logger.Error(err, "failed to update PVC data height annotation; deferring PVC writes to next reconcile", "pvc", pvc.GetName())
+		return nil
 	}
 
 	switch pvc.Spec.Resources.Requests.Storage().Cmp(expectedStorageSize) {
@@ -368,7 +372,9 @@ func (r *Reconciler) updatePvcDataHeight(ctx context.Context, chainNode *appsv1.
 	}
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		fresh := &corev1.PersistentVolumeClaim{}
-		if err := r.Get(ctx, client.ObjectKeyFromObject(pvc), fresh); err != nil {
+		// Read uncached: the cache may still serve the pre-conflict resource version, in which case every
+		// retry would resend the same stale version and exhaust without ever converging.
+		if err := r.reservationReader().Get(ctx, client.ObjectKeyFromObject(pvc), fresh); err != nil {
 			return err
 		}
 		if fresh.Annotations == nil {

--- a/internal/controllers/chainnode/pvc_test.go
+++ b/internal/controllers/chainnode/pvc_test.go
@@ -100,6 +100,62 @@ func TestUpdatePvcDataHeightLeavesCallerCopyStaleOnFailure(t *testing.T) {
 		"a failed write must not refresh the caller's copy, so callers must not keep writing to it")
 }
 
+// TestUpdatePvcDataHeightReadsUncachedOnRetry models the production failure: a concurrent writer bumps
+// the PVC at the API server, but the controller cache has not caught up. If the retry re-read went
+// through the cached client it would keep seeing the pre-conflict resource version, resend the same
+// losing version, and exhaust every attempt without converging. Reading through APIReader observes the
+// current version and the second attempt succeeds.
+func TestUpdatePvcDataHeightReadsUncachedOnRetry(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Namespace:   "default",
+		Annotations: map[string]string{controllers.AnnotationDataHeight: "100"},
+	}}
+	apiServer := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+
+	// Simulate a concurrent writer: the stored PVC moves to a new resource version that the cache has
+	// not observed yet.
+	concurrent := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, apiServer.Get(context.Background(), types.NamespacedName{Name: "node", Namespace: "default"}, concurrent))
+	concurrent.Labels = map[string]string{"touched-by": "snapshot-flow"}
+	require.NoError(t, apiServer.Update(context.Background(), concurrent))
+
+	staleCache := &staleReadClient{Client: apiServer, stale: pvc.DeepCopy()}
+	reconciler := &Reconciler{Client: staleCache, APIReader: apiServer, Scheme: scheme}
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
+		Status:     appsv1.ChainNodeStatus{LatestHeight: 200},
+	}
+
+	// The caller starts from the stale copy, as it would after a cached Get earlier in the reconcile.
+	caller := pvc.DeepCopy()
+	require.NoError(t, reconciler.updatePvcDataHeight(context.Background(), chainNode, caller))
+
+	stored := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, apiServer.Get(context.Background(), types.NamespacedName{Name: "node", Namespace: "default"}, stored))
+	assert.Equal(t, "200", stored.Annotations[controllers.AnnotationDataHeight])
+	assert.Equal(t, "snapshot-flow", stored.Labels["touched-by"], "the concurrent writer's change must survive")
+}
+
+// staleReadClient serves a frozen copy of the PVC from Get, standing in for a controller cache that has
+// not yet observed a concurrent update. Writes go through to the real store, so an Update built from a
+// stale read is rejected as a conflict exactly as the API server would.
+type staleReadClient struct {
+	client.Client
+	stale *corev1.PersistentVolumeClaim
+}
+
+func (c *staleReadClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok && key.Name == c.stale.Name {
+		c.stale.DeepCopyInto(pvc)
+		return nil
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
 // conflictOnceClient rejects the first Update with a conflict, mimicking a concurrent write to the PVC.
 type conflictOnceClient struct {
 	client.Client

--- a/internal/controllers/chainnode/pvc_test.go
+++ b/internal/controllers/chainnode/pvc_test.go
@@ -30,7 +30,8 @@ func TestUpdatePvcDataHeightRetriesOnConflict(t *testing.T) {
 	}}
 	baseClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
 	conflicting := &conflictOnceClient{Client: baseClient}
-	reconciler := &Reconciler{Client: conflicting, Scheme: scheme}
+	// APIReader mirrors production: retry reads bypass the cache so each attempt sees the current version.
+	reconciler := &Reconciler{Client: conflicting, APIReader: baseClient, Scheme: scheme}
 
 	chainNode := &appsv1.ChainNode{
 		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
@@ -67,6 +68,36 @@ func TestUpdatePvcDataHeightSurfacesExhaustedConflicts(t *testing.T) {
 	err := reconciler.updatePvcDataHeight(context.Background(), chainNode, pvc)
 	require.Error(t, err)
 	assert.True(t, apierrors.IsConflict(err))
+}
+
+// TestUpdatePvcDataHeightLeavesCallerCopyStaleOnFailure documents why ensurePvcUpdates returns early
+// when this fails: the caller's PVC still holds the resource version that just lost, so any further
+// write in the same pass (notably the resize) would conflict again and abort the reconcile — the very
+// failure this path exists to prevent.
+func TestUpdatePvcDataHeightLeavesCallerCopyStaleOnFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Namespace:   "default",
+		Annotations: map[string]string{controllers.AnnotationDataHeight: "100"},
+	}}
+	baseClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+	reconciler := &Reconciler{
+		Client:    &pvcUpdateFailingClient{Client: baseClient},
+		APIReader: baseClient,
+		Scheme:    scheme,
+	}
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
+		Status:     appsv1.ChainNodeStatus{LatestHeight: 200},
+	}
+
+	before := pvc.DeepCopy()
+	require.Error(t, reconciler.updatePvcDataHeight(context.Background(), chainNode, pvc))
+	assert.Equal(t, before.ResourceVersion, pvc.ResourceVersion,
+		"a failed write must not refresh the caller's copy, so callers must not keep writing to it")
 }
 
 // conflictOnceClient rejects the first Update with a conflict, mimicking a concurrent write to the PVC.

--- a/internal/controllers/chainnode/pvc_test.go
+++ b/internal/controllers/chainnode/pvc_test.go
@@ -156,6 +156,46 @@ func (c *staleReadClient) Get(ctx context.Context, key client.ObjectKey, obj cli
 	return c.Client.Get(ctx, key, obj, opts...)
 }
 
+// TestUpdatePvcDataHeightRejectsReplacedPvc guards against writing the old volume's height onto a
+// different volume: a PVC deleted and recreated under the same name between the cached lookup and this
+// step would otherwise be stamped with the previous chain height, which is later adopted as PVC state
+// and would make a freshly initialized volume look like it already held the old chain data.
+func TestUpdatePvcDataHeightRejectsReplacedPvc(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	// What the API server holds now: a different volume that happens to reuse the name.
+	replacement := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Namespace:   "default",
+		UID:         "new-pvc-uid",
+		Annotations: map[string]string{controllers.AnnotationDataHeight: "0"},
+	}}
+	baseClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(replacement).Build()
+	reconciler := &Reconciler{Client: baseClient, APIReader: baseClient, Scheme: scheme}
+
+	// What the caller is still holding from earlier in the reconcile: the deleted volume.
+	stale := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Namespace:   "default",
+		UID:         "old-pvc-uid",
+		Annotations: map[string]string{controllers.AnnotationDataHeight: "100"},
+	}}
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
+		Status:     appsv1.ChainNodeStatus{LatestHeight: 200},
+	}
+
+	err := reconciler.updatePvcDataHeight(context.Background(), chainNode, stale)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "was replaced")
+
+	stored := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, baseClient.Get(context.Background(), types.NamespacedName{Name: "node", Namespace: "default"}, stored))
+	assert.Equal(t, "0", stored.Annotations[controllers.AnnotationDataHeight],
+		"the replacement volume must not inherit the old volume's height")
+}
+
 // TestUpdatePvcDataHeightPropagatesNonConflictErrors pins the distinction ensurePvcUpdates relies on:
 // only exhausted optimistic-concurrency conflicts are tolerable there. A timeout or an authorization
 // failure must stay a real error so controller-runtime applies its own retry/backoff, rather than being

--- a/internal/controllers/chainnode/pvc_test.go
+++ b/internal/controllers/chainnode/pvc_test.go
@@ -1,0 +1,104 @@
+package chainnode
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+)
+
+func TestUpdatePvcDataHeightRetriesOnConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Namespace:   "default",
+		Annotations: map[string]string{controllers.AnnotationDataHeight: "100"},
+	}}
+	baseClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+	conflicting := &conflictOnceClient{Client: baseClient}
+	reconciler := &Reconciler{Client: conflicting, Scheme: scheme}
+
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
+		Status:     appsv1.ChainNodeStatus{LatestHeight: 200},
+	}
+
+	require.NoError(t, reconciler.updatePvcDataHeight(context.Background(), chainNode, pvc))
+	assert.Equal(t, 1, conflicting.conflicts)
+
+	stored := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, baseClient.Get(context.Background(), types.NamespacedName{Name: "node", Namespace: "default"}, stored))
+	assert.Equal(t, "200", stored.Annotations[controllers.AnnotationDataHeight])
+	// The caller's copy is refreshed so later writes in the same reconcile do not conflict on a stale version.
+	assert.Equal(t, stored.ResourceVersion, pvc.ResourceVersion)
+}
+
+func TestUpdatePvcDataHeightSurfacesExhaustedConflicts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Namespace:   "default",
+		Annotations: map[string]string{controllers.AnnotationDataHeight: "100"},
+	}}
+	baseClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+	reconciler := &Reconciler{Client: &pvcUpdateFailingClient{Client: baseClient}, Scheme: scheme}
+
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
+		Status:     appsv1.ChainNodeStatus{LatestHeight: 200},
+	}
+
+	err := reconciler.updatePvcDataHeight(context.Background(), chainNode, pvc)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
+}
+
+// conflictOnceClient rejects the first Update with a conflict, mimicking a concurrent write to the PVC.
+type conflictOnceClient struct {
+	client.Client
+	conflicts int
+}
+
+func (c *conflictOnceClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if c.conflicts == 0 {
+		c.conflicts++
+		return apierrors.NewConflict(
+			schema.GroupResource{Resource: "persistentvolumeclaims"},
+			obj.GetName(),
+			assert.AnError,
+		)
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+// pvcUpdateFailingClient rejects every PVC Update with a conflict, so retries are exhausted.
+type pvcUpdateFailingClient struct {
+	client.Client
+}
+
+func (c *pvcUpdateFailingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+		return apierrors.NewConflict(
+			schema.GroupResource{Resource: "persistentvolumeclaims"},
+			obj.GetName(),
+			assert.AnError,
+		)
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}

--- a/internal/controllers/chainnode/pvc_test.go
+++ b/internal/controllers/chainnode/pvc_test.go
@@ -156,6 +156,52 @@ func (c *staleReadClient) Get(ctx context.Context, key client.ObjectKey, obj cli
 	return c.Client.Get(ctx, key, obj, opts...)
 }
 
+// TestUpdatePvcDataHeightPropagatesNonConflictErrors pins the distinction ensurePvcUpdates relies on:
+// only exhausted optimistic-concurrency conflicts are tolerable there. A timeout or an authorization
+// failure must stay a real error so controller-runtime applies its own retry/backoff, rather than being
+// silently converted to success.
+func TestUpdatePvcDataHeightPropagatesNonConflictErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node",
+		Namespace:   "default",
+		Annotations: map[string]string{controllers.AnnotationDataHeight: "100"},
+	}}
+	baseClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+	reconciler := &Reconciler{
+		Client:    &pvcForbiddenClient{Client: baseClient},
+		APIReader: baseClient,
+		Scheme:    scheme,
+	}
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
+		Status:     appsv1.ChainNodeStatus{LatestHeight: 200},
+	}
+
+	err := reconciler.updatePvcDataHeight(context.Background(), chainNode, pvc)
+	require.Error(t, err)
+	assert.False(t, apierrors.IsConflict(err), "a non-conflict failure must not masquerade as a conflict")
+	assert.True(t, apierrors.IsForbidden(err))
+}
+
+// pvcForbiddenClient rejects PVC writes with a non-conflict error.
+type pvcForbiddenClient struct {
+	client.Client
+}
+
+func (c *pvcForbiddenClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+		return apierrors.NewForbidden(
+			schema.GroupResource{Resource: "persistentvolumeclaims"},
+			obj.GetName(),
+			assert.AnError,
+		)
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
 // conflictOnceClient rejects the first Update with a conflict, mimicking a concurrent write to the PVC.
 type conflictOnceClient struct {
 	client.Client

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -2,6 +2,7 @@ package chainnode
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -630,6 +631,15 @@ func (r *Reconciler) isTarballReady(ctx context.Context, chainNode *appsv1.Chain
 
 	status, err := exporter.GetSnapshotStatus(ctx, getTarballName(chainNode, snapshot))
 	if err != nil {
+		// The upload Job belonged to a previous exporter and was deleted. Clear the export state instead
+		// of letting the next poll see the intentionally removed Job as SnapshotNotFound and charge it as
+		// another failed attempt — that could exhaust the retry limit and permanently mark the export
+		// failed without ever starting one for the newly configured provider.
+		if stderrors.Is(err, datasnapshot.ErrStaleJobReplaced) {
+			if resetErr := r.resetTarballExport(ctx, snapshot); resetErr != nil {
+				return false, resetErr
+			}
+		}
 		return false, err
 	}
 
@@ -694,6 +704,22 @@ func (r *Reconciler) recordTarballExportFailure(ctx context.Context, snapshot *s
 		snapshot.Annotations[controllers.AnnotationExportingTarball] = tarballFailed
 	}
 	return retry, r.Update(ctx, snapshot)
+}
+
+// resetTarballExport clears the export markers so the next reconcile starts a fresh upload against the
+// currently configured provider, without the attempt counter carried over from the replaced Job.
+func (r *Reconciler) resetTarballExport(ctx context.Context, snapshot *snapshotv1.VolumeSnapshot) error {
+	if snapshot.Annotations == nil {
+		return nil
+	}
+	_, exporting := snapshot.Annotations[controllers.AnnotationExportingTarball]
+	_, attempts := snapshot.Annotations[controllers.AnnotationTarballExportAttempts]
+	if !exporting && !attempts {
+		return nil
+	}
+	delete(snapshot.Annotations, controllers.AnnotationExportingTarball)
+	delete(snapshot.Annotations, controllers.AnnotationTarballExportAttempts)
+	return r.Update(ctx, snapshot)
 }
 
 func tarballFailureAction(retry bool) string {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -133,6 +133,13 @@ func TestTarballExportFailureWaitsForCleanupBeforeRetry(t *testing.T) {
 				Name:      "-00010101000000-upload",
 				Namespace: "default",
 				Labels:    map[string]string{"exporter": "gcs-exporter"},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: appsv1.GroupVersion.String(),
+					Kind:       "ChainNode",
+					Name:       "node",
+					UID:        "node-uid",
+					Controller: ptr.To(true),
+				}},
 			},
 			Status: batchv1.JobStatus{Failed: 1, Conditions: []batchv1.JobCondition{{
 				Type: batchv1.JobFailed, Status: corev1.ConditionTrue,

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -107,6 +107,70 @@ func TestRecordTarballExportFailureStopsAtRetryLimit(t *testing.T) {
 	}
 }
 
+// TestStaleUploadJobReplacementDoesNotChargeFailedAttempt covers a provider switch on a snapshot that
+// has already burned attempts. Deleting the mismatched Job must clear the export markers: otherwise the
+// next poll sees the intentionally removed Job as SnapshotNotFound, charges another failure, hits the
+// retry limit, and permanently marks the export failed without ever starting one for the new provider.
+func TestStaleUploadJobReplacementDoesNotChargeFailedAttempt(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	chainNode := &appsv1.ChainNode{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default", UID: "node-uid"},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency: "24h",
+			// Now exporting to GCS...
+			ExportTarball: &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		}}},
+	}
+	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{
+		Name: "snapshot", Namespace: "default",
+		Annotations: map[string]string{
+			controllers.AnnotationExportingTarball:      "true",
+			controllers.AnnotationTarballExportAttempts: strconv.Itoa(tarballExportMaxAttempts - 1),
+		},
+	}}
+	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(snapshot).Build()
+	// ...but the in-flight upload Job belongs to the previous S3 exporter.
+	clientSet := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "-00010101000000-upload",
+			Namespace: "default",
+			UID:       "stale-uid",
+			Labels:    map[string]string{"exporter": "s3-exporter"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: appsv1.GroupVersion.String(),
+				Kind:       "ChainNode",
+				Name:       "node",
+				UID:        "node-uid",
+				Controller: ptr.To(true),
+			}},
+		},
+	})
+	reconciler := &Reconciler{
+		Client:            controllerClient,
+		snapshotClientSet: clientSet,
+		Scheme:            scheme,
+		opts:              &controllers.ControllerRunOptions{},
+		recorder:          record.NewFakeRecorder(10),
+	}
+
+	ready, err := reconciler.isTarballReady(context.Background(), chainNode, snapshot)
+	assert.False(t, ready)
+	require.ErrorIs(t, err, datasnapshot.ErrStaleJobReplaced)
+
+	stored := &snapshotv1.VolumeSnapshot{}
+	require.NoError(t, controllerClient.Get(context.Background(), types.NamespacedName{Name: "snapshot", Namespace: "default"}, stored))
+	_, exporting := stored.Annotations[controllers.AnnotationExportingTarball]
+	assert.False(t, exporting, "export state must be cleared so a fresh upload starts")
+	_, attempts := stored.Annotations[controllers.AnnotationTarballExportAttempts]
+	assert.False(t, attempts, "the intentional deletion must not count as a failed attempt")
+}
+
 func TestTarballExportFailureWaitsForCleanupBeforeRetry(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, snapshotv1.AddToScheme(scheme))

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -129,7 +129,11 @@ func TestTarballExportFailureWaitsForCleanupBeforeRetry(t *testing.T) {
 	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(snapshot).Build()
 	clientSet := fake.NewSimpleClientset(
 		&batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: "-00010101000000-upload", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "-00010101000000-upload",
+				Namespace: "default",
+				Labels:    map[string]string{"exporter": "gcs-exporter"},
+			},
 			Status: batchv1.JobStatus{Failed: 1, Conditions: []batchv1.JobCondition{{
 				Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
 			}}},

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -226,7 +226,7 @@ func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.
 }
 
 func (gcs *GCS) GetSnapshotStatus(ctx context.Context, name string) (SnapshotStatus, error) {
-	return uploadJobStatus(ctx, gcs.Client, gcs.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), gcsExporter)
+	return uploadJobStatus(ctx, gcs.Client, gcs.Owner, gcs.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), gcsExporter)
 }
 
 func (gcs *GCS) CleanupSnapshot(ctx context.Context, name string) error {

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -226,15 +226,7 @@ func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.
 }
 
 func (gcs *GCS) GetSnapshotStatus(ctx context.Context, name string) (SnapshotStatus, error) {
-	job, err := gcs.Client.BatchV1().Jobs(gcs.Owner.GetNamespace()).Get(ctx, fmt.Sprintf("%s-upload", name), metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return SnapshotNotFound, nil
-		}
-		return "", err
-	}
-
-	return snapshotJobStatus(job), nil
+	return uploadJobStatus(ctx, gcs.Client, gcs.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), gcsExporter)
 }
 
 func (gcs *GCS) CleanupSnapshot(ctx context.Context, name string) error {

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -233,8 +233,12 @@ func TestGCSGetSnapshotStatusPreservesUploadResources(t *testing.T) {
 			}})
 			if tt.createJob {
 				_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{Name: "snapshot-upload", Namespace: "default"},
-					Status:     tt.jobStatus,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "snapshot-upload",
+						Namespace: "default",
+						Labels:    map[string]string{labelExporter: gcsExporter},
+					},
+					Status: tt.jobStatus,
 				}, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -234,9 +234,10 @@ func TestGCSGetSnapshotStatusPreservesUploadResources(t *testing.T) {
 			if tt.createJob {
 				_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "snapshot-upload",
-						Namespace: "default",
-						Labels:    map[string]string{labelExporter: gcsExporter},
+						Name:            "snapshot-upload",
+						Namespace:       "default",
+						Labels:          map[string]string{labelExporter: gcsExporter},
+						OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(provider.Owner)},
 					},
 					Status: tt.jobStatus,
 				}, metav1.CreateOptions{})

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -164,7 +164,7 @@ func (provider *S3) CreateSnapshot(ctx context.Context, name string, snapshot *s
 }
 
 func (provider *S3) GetSnapshotStatus(ctx context.Context, name string) (SnapshotStatus, error) {
-	return uploadJobStatus(ctx, provider.Client, provider.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), s3Exporter)
+	return uploadJobStatus(ctx, provider.Client, provider.Owner, provider.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), s3Exporter)
 }
 
 func (provider *S3) CleanupSnapshot(ctx context.Context, name string) error {

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -164,14 +164,7 @@ func (provider *S3) CreateSnapshot(ctx context.Context, name string, snapshot *s
 }
 
 func (provider *S3) GetSnapshotStatus(ctx context.Context, name string) (SnapshotStatus, error) {
-	job, err := provider.Client.BatchV1().Jobs(provider.Owner.GetNamespace()).Get(ctx, fmt.Sprintf("%s-upload", name), metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return SnapshotNotFound, nil
-		}
-		return "", err
-	}
-	return snapshotJobStatus(job), nil
+	return uploadJobStatus(ctx, provider.Client, provider.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), s3Exporter)
 }
 
 func (provider *S3) CleanupSnapshot(ctx context.Context, name string) error {

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -215,9 +215,10 @@ func TestS3GetSnapshotStatusPreservesUploadResources(t *testing.T) {
 			if tt.createJob {
 				_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "snapshot-upload",
-						Namespace: "default",
-						Labels:    map[string]string{labelExporter: s3Exporter},
+						Name:            "snapshot-upload",
+						Namespace:       "default",
+						Labels:          map[string]string{labelExporter: s3Exporter},
+						OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(provider.Owner)},
 					},
 					Status: tt.jobStatus,
 				}, metav1.CreateOptions{})

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -214,8 +214,12 @@ func TestS3GetSnapshotStatusPreservesUploadResources(t *testing.T) {
 			}})
 			if tt.createJob {
 				_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{Name: "snapshot-upload", Namespace: "default"},
-					Status:     tt.jobStatus,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "snapshot-upload",
+						Namespace: "default",
+						Labels:    map[string]string{labelExporter: s3Exporter},
+					},
+					Status: tt.jobStatus,
 				}, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -107,6 +107,35 @@ func ensureSnapshotJob(
 	return job, false, nil
 }
 
+// uploadJobStatus reports the status of an existing upload Job, rejecting one that belongs to a
+// different exporter. Polling looks the Job up by name, and the name does not encode the provider, so
+// without this check an in-flight upload started by the previous provider would be read as progress
+// towards the newly configured one — and its success would mark the export finished even though
+// nothing was written to the new destination.
+//
+// The stale Job is removed so the next reconcile starts a real upload against the current provider.
+func uploadJobStatus(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace, name, exporter string,
+) (SnapshotStatus, error) {
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return SnapshotNotFound, nil
+		}
+		return "", err
+	}
+	if job.Labels[labelExporter] != exporter {
+		if err = deleteSnapshotJob(ctx, client, job); err != nil {
+			return "", fmt.Errorf("delete stale upload job %s/%s: %w", job.Namespace, job.Name, err)
+		}
+		return "", fmt.Errorf("upload job %s/%s belongs to exporter %q, not %q: %w",
+			job.Namespace, job.Name, job.Labels[labelExporter], exporter, ErrStaleJobReplaced)
+	}
+	return snapshotJobStatus(job), nil
+}
+
 func deleteSnapshotJob(ctx context.Context, client kubernetes.Interface, job *batchv1.Job) error {
 	propagation := metav1.DeletePropagationForeground
 	err := client.BatchV1().Jobs(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -117,6 +117,7 @@ func ensureSnapshotJob(
 func uploadJobStatus(
 	ctx context.Context,
 	client kubernetes.Interface,
+	owner metav1.Object,
 	namespace, name, exporter string,
 ) (SnapshotStatus, error) {
 	job, err := client.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -125,6 +126,13 @@ func uploadJobStatus(
 			return SnapshotNotFound, nil
 		}
 		return "", err
+	}
+	// Tarball names derive from chain ID and a second-resolution timestamp, so two ChainNodes in one
+	// namespace can collide on this Job name. Never delete a Job this node does not own — that would
+	// terminate another node's active export. Mirrors the ownership guard in ensureSnapshotJob.
+	if !metav1.IsControlledBy(job, owner) {
+		return "", fmt.Errorf("upload job %s/%s is not controlled by snapshot owner %s",
+			job.Namespace, job.Name, owner.GetName())
 	}
 	if job.Labels[labelExporter] != exporter {
 		if err = deleteSnapshotJob(ctx, client, job); err != nil {

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -2,6 +2,7 @@ package datasnapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -31,6 +32,12 @@ const (
 	typeUpload = "upload"
 	typeDelete = "delete"
 )
+
+// ErrStaleJobReplaced reports that an existing snapshot Job was deleted because its labels could not
+// converge to the desired ones — the exporter label encodes the export provider, so a Job left behind
+// by a previous provider never matches again. Callers should requeue instead of failing the reconcile:
+// the replacement Job is created once the stale one is gone.
+var ErrStaleJobReplaced = errors.New("stale snapshot job deleted; it will be recreated")
 
 type SnapshotProvider interface {
 	CreateSnapshot(context.Context, string, *snapshotv1.VolumeSnapshot) error
@@ -88,10 +95,28 @@ func ensureSnapshotJob(
 	}
 	for key, value := range desired.Labels {
 		if job.Labels[key] != value {
-			return nil, false, fmt.Errorf("%s job %s/%s has conflicting label %s", purpose, job.Namespace, job.Name, key)
+			// Labels are set at creation and never updated, so a mismatch can never converge — it means
+			// the Job was created for a different desired state (e.g. another export provider). Exports
+			// and deletions are idempotent, so drop the stale Job and let the next reconcile recreate it.
+			if err = deleteSnapshotJob(ctx, client, job); err != nil {
+				return nil, false, fmt.Errorf("delete stale %s job %s/%s: %w", purpose, job.Namespace, job.Name, err)
+			}
+			return nil, false, fmt.Errorf("%s job %s/%s had conflicting label %s: %w", purpose, job.Namespace, job.Name, key, ErrStaleJobReplaced)
 		}
 	}
 	return job, false, nil
+}
+
+func deleteSnapshotJob(ctx context.Context, client kubernetes.Interface, job *batchv1.Job) error {
+	propagation := metav1.DeletePropagationForeground
+	err := client.BatchV1().Jobs(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+		Preconditions:     &metav1.Preconditions{UID: &job.UID},
+	})
+	if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+		return err
+	}
+	return nil
 }
 
 func snapshotJobStatus(job *batchv1.Job) SnapshotStatus {

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -1,11 +1,20 @@
 package datasnapshot
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 )
 
 func TestSnapshotJobStatusUsesTerminalConditions(t *testing.T) {
@@ -46,5 +55,93 @@ func TestSnapshotJobStatusUsesTerminalConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, snapshotJobStatus(&batchv1.Job{Status: tt.status}))
 		})
+	}
+}
+
+func TestEnsureSnapshotJobReplacesJobWithUnconvergeableLabels(t *testing.T) {
+	owner := testJobOwner()
+	client := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-delete",
+			Namespace:       "default",
+			UID:             "stale-uid",
+			Labels:          map[string]string{labelExporter: "s3-exporter", labelOwner: "owner", labelType: typeDelete},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		},
+	})
+
+	desired := desiredDeleteJob(owner, "gcs-exporter")
+	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desired, "delete")
+	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	assert.ErrorContains(t, err, labelExporter)
+
+	// The stale Job is gone, so the next reconcile creates the desired one instead of erroring forever.
+	_, err = client.BatchV1().Jobs("default").Get(context.Background(), "snapshot-delete", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+
+	job, created, err := ensureSnapshotJob(context.Background(), client, owner, desired, "delete")
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, "gcs-exporter", job.Labels[labelExporter])
+}
+
+func TestEnsureSnapshotJobKeepsJobWithMatchingLabels(t *testing.T) {
+	owner := testJobOwner()
+	existing := desiredDeleteJob(owner, "s3-exporter")
+	existing.UID = "existing-uid"
+	existing.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(owner)}
+	client := fake.NewSimpleClientset(existing)
+
+	job, created, err := ensureSnapshotJob(context.Background(), client, owner, desiredDeleteJob(owner, "s3-exporter"), "delete")
+	require.NoError(t, err)
+	assert.False(t, created)
+	assert.Equal(t, "existing-uid", string(job.UID))
+}
+
+func TestEnsureSnapshotJobReportsDeleteFailureOfStaleJob(t *testing.T) {
+	owner := testJobOwner()
+	client := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-delete",
+			Namespace:       "default",
+			UID:             "stale-uid",
+			Labels:          map[string]string{labelExporter: "s3-exporter", labelOwner: "owner", labelType: typeDelete},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		},
+	})
+	client.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("delete refused")
+	})
+
+	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desiredDeleteJob(owner, "gcs-exporter"), "delete")
+	require.ErrorContains(t, err, "delete refused")
+	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
+}
+
+func testJobOwner() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"},
+	}
+}
+
+func ownerReferenceTo(owner *corev1.ConfigMap) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       owner.Name,
+		UID:        owner.UID,
+		Controller: ptr.To(true),
+	}
+}
+
+func desiredDeleteJob(owner *corev1.ConfigMap, exporter string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-delete",
+			Namespace:       "default",
+			Labels:          map[string]string{labelExporter: exporter, labelOwner: owner.Name, labelType: typeDelete},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		},
 	}
 }

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -85,6 +85,58 @@ func TestEnsureSnapshotJobReplacesJobWithUnconvergeableLabels(t *testing.T) {
 	assert.Equal(t, "gcs-exporter", job.Labels[labelExporter])
 }
 
+// TestUploadJobStatusRejectsOtherExportersJob covers the polling path. Upload Jobs are looked up by
+// name, and the name does not encode the provider, so a Job left in flight by the previous exporter
+// would otherwise be read as progress towards the newly configured one — and its success would mark the
+// export finished with nothing written to the new destination.
+func TestUploadJobStatusRejectsOtherExportersJob(t *testing.T) {
+	client := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-upload",
+			Namespace: "default",
+			UID:       "stale-uid",
+			Labels:    map[string]string{labelExporter: "s3-exporter", labelType: typeUpload},
+		},
+		// The old provider's Job completed successfully — the case that would be misreported.
+		Status: batchv1.JobStatus{
+			Succeeded:  1,
+			Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
+		},
+	})
+
+	_, err := uploadJobStatus(context.Background(), client, "default", "snapshot-upload", "gcs-exporter")
+	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	assert.ErrorContains(t, err, "s3-exporter")
+
+	// Removed, so the next reconcile starts a real upload against the configured provider.
+	_, err = client.BatchV1().Jobs("default").Get(context.Background(), "snapshot-upload", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestUploadJobStatusReportsMatchingExportersJob(t *testing.T) {
+	client := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-upload",
+			Namespace: "default",
+			Labels:    map[string]string{labelExporter: "gcs-exporter", labelType: typeUpload},
+		},
+		Status: batchv1.JobStatus{
+			Succeeded:  1,
+			Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
+		},
+	})
+
+	status, err := uploadJobStatus(context.Background(), client, "default", "snapshot-upload", "gcs-exporter")
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotSucceeded, status)
+}
+
+func TestUploadJobStatusReportsMissingJob(t *testing.T) {
+	status, err := uploadJobStatus(context.Background(), fake.NewSimpleClientset(), "default", "snapshot-upload", "gcs-exporter")
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotNotFound, status)
+}
+
 func TestEnsureSnapshotJobKeepsJobWithMatchingLabels(t *testing.T) {
 	owner := testJobOwner()
 	existing := desiredDeleteJob(owner, "s3-exporter")

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -90,12 +90,14 @@ func TestEnsureSnapshotJobReplacesJobWithUnconvergeableLabels(t *testing.T) {
 // would otherwise be read as progress towards the newly configured one — and its success would mark the
 // export finished with nothing written to the new destination.
 func TestUploadJobStatusRejectsOtherExportersJob(t *testing.T) {
+	owner := testJobOwner()
 	client := fake.NewSimpleClientset(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "snapshot-upload",
-			Namespace: "default",
-			UID:       "stale-uid",
-			Labels:    map[string]string{labelExporter: "s3-exporter", labelType: typeUpload},
+			Name:            "snapshot-upload",
+			Namespace:       "default",
+			UID:             "stale-uid",
+			Labels:          map[string]string{labelExporter: "s3-exporter", labelType: typeUpload},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
 		},
 		// The old provider's Job completed successfully — the case that would be misreported.
 		Status: batchv1.JobStatus{
@@ -104,7 +106,7 @@ func TestUploadJobStatusRejectsOtherExportersJob(t *testing.T) {
 		},
 	})
 
-	_, err := uploadJobStatus(context.Background(), client, "default", "snapshot-upload", "gcs-exporter")
+	_, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-upload", "gcs-exporter")
 	require.ErrorIs(t, err, ErrStaleJobReplaced)
 	assert.ErrorContains(t, err, "s3-exporter")
 
@@ -113,12 +115,64 @@ func TestUploadJobStatusRejectsOtherExportersJob(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err))
 }
 
-func TestUploadJobStatusReportsMatchingExportersJob(t *testing.T) {
+// TestUploadJobStatusNeverDeletesAnotherOwnersJob guards a cross-node hazard: tarball names derive from
+// chain ID plus a second-resolution timestamp, so two ChainNodes in one namespace can collide on the
+// Job name. Deleting on an exporter mismatch alone would let one node terminate another's live export.
+func TestUploadJobStatusNeverDeletesAnotherOwnersJob(t *testing.T) {
+	owner := testJobOwner()
+	stranger := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "other-node", Namespace: "default", UID: "other-uid"},
+	}
 	client := fake.NewSimpleClientset(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "snapshot-upload",
 			Namespace: "default",
-			Labels:    map[string]string{labelExporter: "gcs-exporter", labelType: typeUpload},
+			UID:       "other-job-uid",
+			// A different exporter AND a different owner: the mismatch must not authorise a delete.
+			Labels:          map[string]string{labelExporter: "s3-exporter", labelType: typeUpload},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(stranger)},
+		},
+	})
+
+	_, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-upload", "gcs-exporter")
+	require.ErrorContains(t, err, "not controlled by snapshot owner")
+	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
+
+	_, err = client.BatchV1().Jobs("default").Get(context.Background(), "snapshot-upload", metav1.GetOptions{})
+	require.NoError(t, err, "another owner's export job must survive")
+}
+
+func TestUploadJobStatusReportsDeleteFailureOfStaleJob(t *testing.T) {
+	owner := testJobOwner()
+	client := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-upload",
+			Namespace:       "default",
+			UID:             "stale-uid",
+			Labels:          map[string]string{labelExporter: "s3-exporter", labelType: typeUpload},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		},
+	})
+	client.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("delete refused")
+	})
+
+	// A failed delete must surface, not be masked as the sentinel: the caller would otherwise treat the
+	// stale Job as replaced when it is still there.
+	_, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-upload", "gcs-exporter")
+	require.ErrorContains(t, err, "delete refused")
+	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
+}
+
+func TestUploadJobStatusReportsMatchingExportersJob(t *testing.T) {
+	owner := testJobOwner()
+	client := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-upload",
+			Namespace:       "default",
+			Labels:          map[string]string{labelExporter: "gcs-exporter", labelType: typeUpload},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
 		},
 		Status: batchv1.JobStatus{
 			Succeeded:  1,
@@ -126,13 +180,13 @@ func TestUploadJobStatusReportsMatchingExportersJob(t *testing.T) {
 		},
 	})
 
-	status, err := uploadJobStatus(context.Background(), client, "default", "snapshot-upload", "gcs-exporter")
+	status, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-upload", "gcs-exporter")
 	require.NoError(t, err)
 	assert.Equal(t, SnapshotSucceeded, status)
 }
 
 func TestUploadJobStatusReportsMissingJob(t *testing.T) {
-	status, err := uploadJobStatus(context.Background(), fake.NewSimpleClientset(), "default", "snapshot-upload", "gcs-exporter")
+	status, err := uploadJobStatus(context.Background(), fake.NewSimpleClientset(), testJobOwner(), "default", "snapshot-upload", "gcs-exporter")
 	require.NoError(t, err)
 	assert.Equal(t, SnapshotNotFound, status)
 }
@@ -178,11 +232,17 @@ func testJobOwner() *corev1.ConfigMap {
 }
 
 func ownerReferenceTo(owner *corev1.ConfigMap) metav1.OwnerReference {
+	return ownerReferenceToObject(owner)
+}
+
+// ownerReferenceToObject builds the controller reference the providers set on the Jobs they create, so
+// fixtures pass the ownership guard that protects another node's Jobs from deletion.
+func ownerReferenceToObject(owner metav1.Object) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: "v1",
 		Kind:       "ConfigMap",
-		Name:       owner.Name,
-		UID:        owner.UID,
+		Name:       owner.GetName(),
+		UID:        owner.GetUID(),
 		Controller: ptr.To(true),
 	}
 }


### PR DESCRIPTION
Closes #64.

Two defects where a recoverable, expected condition was returned as a fatal reconcile error, halting **all** ChainNode reconciliation — not just the subsystem that failed.

## 1. Stale snapshot Job wedges reconciliation

`internal/datasnapshot/snapshot.go` compared every desired label against an existing Job and made any mismatch a hard error. Labels are set at creation and never updated, so after an `exportTarball` provider change the leftover Job carries `exporter: s3-exporter` while the controller wants `gcs-exporter` — **these can never converge**, and the error repeats forever, freezing the whole ChainNode.

A label mismatch now means the Job was created for a different desired state, so it is treated as stale: the Job is deleted (UID-precondition guarded, so a concurrent recreate is not clobbered) and `ErrStaleJobReplaced` is returned. Exports and deletions are idempotent, so the replacement Job is created on the next pass.

`Reconcile` unwraps that sentinel, logs it, emits a `SnapshotJobReplaced` event on the ChainNode, and continues — a failure in the snapshot subsystem can no longer block unrelated reconcile work. Previously recovery required manually deleting the orphaned Job, which was undocumented and not discoverable from the CR.

## 2. PVC write conflict stalls snapshots and exports

`ensurePvcUpdates` returned an ordinary optimistic-concurrency conflict (HTTP 409) on the `data-height` annotation as fatal. That conflict is expected — the snapshot flow annotates the same PVC — and returning it skipped everything after PVC reconciliation, including the snapshot state machine that flips `snapshot-ready` and starts the export. The busier the snapshot activity, the likelier the conflict, so the feature undermined itself.

The write moves to `updatePvcDataHeight`, which retries on conflict against a freshly read PVC and refreshes the caller's copy so later writes in the same reconcile carry an up-to-date resource version. If retries are exhausted, the caller logs instead of returning: `data-height` is advisory metadata and should not gate the rest of the reconcile.

## Testing

Five new unit tests, each verified to fail against the pre-fix code:

- stale Job is deleted and the next call creates the desired one
- a Job whose labels already match is kept, not replaced
- a failure to delete the stale Job is surfaced rather than masked as the sentinel
- the data-height write survives a conflict and refreshes the caller's PVC
- exhausted retries surface the conflict to the caller

Full suite passes; `go vet` clean.

## Note

Issue #63 (MinIO `DeleteObjects` failing with `MissingContentMD5`) is what produced the stuck Job in the original report and is still open. This PR makes the resulting wedge self-healing, but delete Jobs will keep failing on MinIO until #63 is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents recoverable snapshot and PVC annotation conflicts from aborting ChainNode reconcile. Stale snapshot Jobs are cleaned up with an event and quick requeue; PVC data-height writes retry on conflict and don’t block other work.

- **Bug Fixes**
  - Snapshots: label-mismatched upload/delete Jobs are treated as stale and deleted with UID preconditions; providers return ErrStaleJobReplaced. The controller logs, emits ReasonSnapshotJobReplaced, keeps reconciling, and requeues promptly to recreate the Job. Upload polling now verifies the Job is controlled by this owner and matches the configured exporter; mismatched-but-owned Jobs are deleted, non-owned Jobs are left and return an error. When a stale upload Job is replaced, export annotations (exporting/attempts) are cleared so the next pass starts fresh and doesn’t charge a failed attempt.
  - PVCs: updatePvcDataHeight retries on 409 using uncached reads and refreshes the caller’s PVC on success; if retries exhaust, it logs and skips further PVC writes this pass. A UID check prevents annotating a replaced PVC. Non-conflict errors are propagated.

<sup>Written for commit 71c3e459033c8f391608120e7b5f05d90285a775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

