### PR TITLE
fix: delete S3 objects individually so S3-compatible stores accept it

### DIFF
--- a/pkg/dataexporter/s3.go
+++ b/pkg/dataexporter/s3.go
@@ -45,12 +45,19 @@ type s3API interface {
 	CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput, ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput, ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
 	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 	DeleteObjects(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
 }
 
 // S3Exporter implements Exporter for Amazon S3 and compatible object stores.
 type S3Exporter struct {
 	client s3API
+	// perObjectDelete forces one DeleteObject per key instead of batched DeleteObjects. DeleteObjects is
+	// modelled with RequireChecksum, so the SDK always sends x-amz-checksum-crc32 and ignores
+	// RequestChecksumCalculation; Amazon S3 accepts that but S3-compatible stores such as MinIO require
+	// the legacy Content-MD5 and reject the request with 400 MissingContentMD5. Batching stays on for
+	// Amazon S3, where an archive split into many parts would otherwise cost one request per part.
+	perObjectDelete bool
 }
 
 // NewS3Exporter creates an exporter using the AWS SDK default credential chain.
@@ -83,7 +90,10 @@ func NewS3Exporter(ctx context.Context, cfg S3Config) (*S3Exporter, error) {
 			options.BaseEndpoint = aws.String(cfg.Endpoint)
 		}
 	})
-	return newS3Exporter(client), nil
+	exporter := newS3Exporter(client)
+	// A custom endpoint means an S3-compatible store, which may reject checksummed batch deletes.
+	exporter.perObjectDelete = cfg.Endpoint != ""
+	return exporter, nil
 }
 
 func newS3Exporter(client s3API) *S3Exporter {
@@ -446,7 +456,7 @@ func (exporter *S3Exporter) Delete(bucket, name string, opts ...DeleteOption) er
 	}
 	ctx := context.Background()
 	var continuationToken *string
-	objectIDs := make([]types.ObjectIdentifier, 0)
+	keys := make([]string, 0)
 	for {
 		output, err := exporter.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 			Bucket:            aws.String(bucket),
@@ -458,7 +468,7 @@ func (exporter *S3Exporter) Delete(bucket, name string, opts ...DeleteOption) er
 		}
 		for _, object := range output.Contents {
 			if isArchiveObjectName(name, aws.ToString(object.Key)) {
-				objectIDs = append(objectIDs, types.ObjectIdentifier{Key: object.Key})
+				keys = append(keys, aws.ToString(object.Key))
 			}
 		}
 		if !aws.ToBool(output.IsTruncated) {
@@ -466,17 +476,29 @@ func (exporter *S3Exporter) Delete(bucket, name string, opts ...DeleteOption) er
 		}
 		continuationToken = output.NextContinuationToken
 	}
-	if len(objectIDs) == 0 {
+	if len(keys) == 0 {
 		log.Warnf("no objects found with prefix: %s", name)
 		return nil
 	}
 
-	semaphore := make(chan struct{}, options.ConcurrentJobs)
-	errCh := make(chan error, (len(objectIDs)+s3DeleteBatchSize-1)/s3DeleteBatchSize)
+	// A small partSize splits a large snapshot into very many objects, so batch wherever the store
+	// accepts it: one request per 1000 keys instead of one per key.
+	if !exporter.perObjectDelete {
+		return exporter.deleteBatched(ctx, bucket, name, keys, options.ConcurrentJobs)
+	}
+	return exporter.deletePerObject(ctx, bucket, keys, options.ConcurrentJobs)
+}
+
+func (exporter *S3Exporter) deleteBatched(ctx context.Context, bucket, name string, keys []string, concurrency int) error {
+	semaphore := make(chan struct{}, concurrency)
+	errCh := make(chan error, (len(keys)+s3DeleteBatchSize-1)/s3DeleteBatchSize)
 	var wg sync.WaitGroup
-	for start := 0; start < len(objectIDs); start += s3DeleteBatchSize {
-		end := min(start+s3DeleteBatchSize, len(objectIDs))
-		batch := append([]types.ObjectIdentifier(nil), objectIDs[start:end]...)
+	for start := 0; start < len(keys); start += s3DeleteBatchSize {
+		end := min(start+s3DeleteBatchSize, len(keys))
+		batch := make([]types.ObjectIdentifier, 0, end-start)
+		for _, key := range keys[start:end] {
+			batch = append(batch, types.ObjectIdentifier{Key: aws.String(key)})
+		}
 		semaphore <- struct{}{}
 		wg.Add(1)
 		go func() {
@@ -492,6 +514,35 @@ func (exporter *S3Exporter) Delete(bucket, name string, opts ...DeleteOption) er
 			}
 			if len(output.Errors) > 0 {
 				errCh <- fmt.Errorf("delete S3 objects with prefix %q: %s", name, formatS3DeleteErrors(output.Errors))
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	var deleteErrors []error
+	for err := range errCh {
+		deleteErrors = append(deleteErrors, err)
+	}
+	return errors.Join(deleteErrors...)
+}
+
+// deletePerObject issues one DeleteObject per key. DeleteObject sends no body and therefore no
+// integrity header, so it is accepted by stores that reject the checksummed batch API.
+func (exporter *S3Exporter) deletePerObject(ctx context.Context, bucket string, keys []string, concurrency int) error {
+	semaphore := make(chan struct{}, concurrency)
+	errCh := make(chan error, len(keys))
+	var wg sync.WaitGroup
+	for _, key := range keys {
+		semaphore <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			if _, err := exporter.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+			}); err != nil {
+				errCh <- fmt.Errorf("delete S3 object %q: %w", key, err)
 			}
 		}()
 	}

--- a/pkg/dataexporter/s3.go
+++ b/pkg/dataexporter/s3.go
@@ -92,7 +92,12 @@ func NewS3Exporter(ctx context.Context, cfg S3Config) (*S3Exporter, error) {
 	})
 	exporter := newS3Exporter(client)
 	// A custom endpoint means an S3-compatible store, which may reject checksummed batch deletes.
-	exporter.perObjectDelete = cfg.Endpoint != ""
+	//
+	// Read the endpoint back off the constructed client rather than off cfg: the SDK also resolves
+	// AWS_ENDPOINT_URL_S3, AWS_ENDPOINT_URL and shared-config endpoint_url, and it does so onto the
+	// service client's options, not onto aws.Config. Checking our own field alone would leave batch
+	// deletes enabled against a store configured entirely through the SDK's own mechanisms.
+	exporter.perObjectDelete = aws.ToString(client.Options().BaseEndpoint) != ""
 	return exporter, nil
 }
 

--- a/pkg/dataexporter/s3_test.go
+++ b/pkg/dataexporter/s3_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -197,9 +198,141 @@ func TestS3DeleteRemovesAllObjectsWithPrefix(t *testing.T) {
 	if err := exporter.Delete("snapshots", "snapshot"); err != nil {
 		t.Fatalf("Delete() error = %v", err)
 	}
-	want := []string{"snapshot.tar.zst", "snapshot-part-00000000.tar.lz4", "snapshot-part-00000001.tar.lz4"}
-	if fmt.Sprint(client.deletedKeys) != fmt.Sprint(want) {
-		t.Fatalf("deleted keys = %v, want %v", client.deletedKeys, want)
+	// Deletions run concurrently, so compare as a set.
+	want := []string{"snapshot-part-00000000.tar.lz4", "snapshot-part-00000001.tar.lz4", "snapshot.tar.zst"}
+	got := append([]string(nil), client.deletedKeys...)
+	sort.Strings(got)
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("deleted keys = %v, want %v", got, want)
+	}
+}
+
+// TestS3DeleteBatchesAgainstAmazonS3 keeps request volume bounded where batching is accepted: a small
+// partSize splits a large snapshot into very many objects, and one DeleteObject per key would cost
+// three orders of magnitude more requests than batches of 1000 — long enough to be throttled and to
+// block snapshot expiration.
+func TestS3DeleteBatchesAgainstAmazonS3(t *testing.T) {
+	client := newFakeS3Client()
+	for i := range 2500 {
+		client.listedObjects = append(client.listedObjects,
+			types.Object{Key: aws.String(fmt.Sprintf("snapshot-part-%08d.tar.lz4", i))})
+	}
+	exporter := newS3Exporter(client) // no custom endpoint: Amazon S3
+
+	if err := exporter.Delete("snapshots", "snapshot"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if len(client.deletedKeys) != 2500 {
+		t.Fatalf("deleted keys = %d, want 2500", len(client.deletedKeys))
+	}
+	if client.singleCalls != 0 {
+		t.Fatalf("per-object calls = %d, want 0 against Amazon S3", client.singleCalls)
+	}
+	if client.batchCalls != 3 {
+		t.Fatalf("batch calls = %d, want 3 (2500 keys in batches of 1000)", client.batchCalls)
+	}
+}
+
+func TestS3DeleteUsesPerObjectAgainstCustomEndpoint(t *testing.T) {
+	client := newFakeS3Client()
+	client.listedObjects = []types.Object{
+		{Key: aws.String("snapshot.tar.zst")},
+		{Key: aws.String("snapshot-part-00000000.tar.lz4")},
+	}
+	exporter := newS3Exporter(client)
+	exporter.perObjectDelete = true
+
+	if err := exporter.Delete("snapshots", "snapshot"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if client.batchCalls != 0 {
+		t.Fatalf("batch calls = %d, want 0 against an S3-compatible endpoint", client.batchCalls)
+	}
+	if client.singleCalls != 2 {
+		t.Fatalf("per-object calls = %d, want 2", client.singleCalls)
+	}
+}
+
+// TestS3DeleteSendsNoChecksumHeaderAgainstCustomEndpoint exercises a real SDK client against an
+// httptest server and asserts on the bytes actually put on the wire.
+//
+// The multi-object DeleteObjects API is modelled with RequireChecksum, so the SDK sends
+// x-amz-checksum-crc32 and ignores RequestChecksumCalculation entirely. Amazon S3 accepts that, but
+// MinIO and other S3-compatible stores require the legacy Content-MD5 and reject it with 400
+// MissingContentMD5. Deleting per object sends no body, hence no integrity header at all.
+//
+// A fake s3API cannot catch this: the header is added by SDK middleware, below the interface.
+func TestS3DeleteSendsNoChecksumHeaderAgainstCustomEndpoint(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	var mu sync.Mutex
+	var deleteRequests []*http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		if r.Method == http.MethodDelete {
+			mu.Lock()
+			deleteRequests = append(deleteRequests, r.Clone(context.Background()))
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		// MinIO rejects a POST ?delete carrying a CRC32 checksum instead of Content-MD5.
+		if r.URL.Query().Has("delete") {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`<Error><Code>MissingContentMD5</Code>` +
+				`<Message>Missing required header for this request: Content-Md5.</Message></Error>`))
+			return
+		}
+		_, _ = w.Write([]byte("<ListBucketResult><IsTruncated>false</IsTruncated>" +
+			"<Contents><Key>cosmoshub-1.tar.gz</Key></Contents></ListBucketResult>"))
+	}))
+	defer server.Close()
+
+	exporter, err := NewS3Exporter(context.Background(), S3Config{
+		Region:         "us-east-1",
+		Endpoint:       server.URL,
+		ForcePathStyle: true,
+	})
+	if err != nil {
+		t.Fatalf("NewS3Exporter() error = %v", err)
+	}
+	if err := exporter.Delete("snapshots", "cosmoshub-1"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleteRequests) != 1 {
+		t.Fatalf("per-object DELETE requests = %d, want 1", len(deleteRequests))
+	}
+	request := deleteRequests[0]
+	if got := request.URL.Path; got != "/snapshots/cosmoshub-1.tar.gz" {
+		t.Fatalf("delete path = %q, want /snapshots/cosmoshub-1.tar.gz", got)
+	}
+	for _, header := range []string{"X-Amz-Checksum-Crc32", "X-Amz-Sdk-Checksum-Algorithm"} {
+		if value := request.Header.Get(header); value != "" {
+			t.Fatalf("delete request carried %s=%q; S3-compatible stores reject checksummed deletes", header, value)
+		}
+	}
+}
+
+func TestS3DeleteReportsPerObjectFailures(t *testing.T) {
+	client := newFakeS3Client()
+	client.listedObjects = []types.Object{
+		{Key: aws.String("snapshot.tar.zst")},
+		{Key: aws.String("snapshot-part-00000000.tar.lz4")},
+	}
+	client.deleteErr = errors.New("access denied")
+	exporter := newS3Exporter(client)
+
+	err := exporter.Delete("snapshots", "snapshot")
+	if err == nil {
+		t.Fatal("Delete() expected an error")
+	}
+	if !strings.Contains(err.Error(), "access denied") {
+		t.Fatalf("Delete() error = %v, want it to mention the underlying failure", err)
 	}
 }
 
@@ -210,7 +343,10 @@ type fakeS3Client struct {
 	completed     map[string][]byte
 	listedObjects []types.Object
 	deletedKeys   []string
+	batchCalls    int
+	singleCalls   int
 	uploadErr     error
+	deleteErr     error
 	abortCount    int
 	nextUploadID  int
 	diskBacked    bool
@@ -283,10 +419,27 @@ func (f *fakeS3Client) ListObjectsV2(_ context.Context, _ *s3.ListObjectsV2Input
 }
 
 func (f *fakeS3Client) DeleteObjects(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	f.batchCalls++
 	for _, object := range input.Delete.Objects {
 		f.deletedKeys = append(f.deletedKeys, aws.ToString(object.Key))
 	}
 	return &s3.DeleteObjectsOutput{}, nil
+}
+
+func (f *fakeS3Client) DeleteObject(_ context.Context, input *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	f.singleCalls++
+	f.deletedKeys = append(f.deletedKeys, aws.ToString(input.Key))
+	return &s3.DeleteObjectOutput{}, nil
 }
 
 func (f *fakeS3Client) completedObject(name string) ([]byte, bool) {

--- a/pkg/dataexporter/s3_test.go
+++ b/pkg/dataexporter/s3_test.go
@@ -326,6 +326,8 @@ func TestS3DeleteReportsPerObjectFailures(t *testing.T) {
 	}
 	client.deleteErr = errors.New("access denied")
 	exporter := newS3Exporter(client)
+	// Exercise the per-object path this test is named for; the default is batched.
+	exporter.perObjectDelete = true
 
 	err := exporter.Delete("snapshots", "snapshot")
 	if err == nil {
@@ -333,6 +335,11 @@ func TestS3DeleteReportsPerObjectFailures(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "access denied") {
 		t.Fatalf("Delete() error = %v, want it to mention the underlying failure", err)
+	}
+	// Pin the per-object wrapper: the batched path reports "objects with prefix" instead, so this also
+	// catches the exporter silently falling back to batching.
+	if !strings.Contains(err.Error(), `delete S3 object "snapshot.tar.zst"`) {
+		t.Fatalf("Delete() error = %v, want the per-object wrapper naming the key", err)
 	}
 }
 
@@ -479,4 +486,38 @@ func (f *fakeS3Client) multipartBodiesAreFiles() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.diskBacked
+}
+
+// TestNewS3ExporterDetectsEndpointFromAWSConfigChain: a compatible store can be pointed at via the
+// SDK's own AWS_ENDPOINT_URL_S3 / AWS_ENDPOINT_URL / shared-config endpoint_url rather than our
+// Endpoint field. Deciding on our field alone would leave batch deletes on, reproducing the
+// MissingContentMD5 failure this change exists to fix.
+func TestNewS3ExporterDetectsEndpointFromAWSConfigChain(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ENDPOINT_URL_S3", "http://minio.storage.svc:9000")
+
+	// Note: no Endpoint set on our own config.
+	exporter, err := NewS3Exporter(context.Background(), S3Config{Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("NewS3Exporter() error = %v", err)
+	}
+	if !exporter.perObjectDelete {
+		t.Fatal("an endpoint resolved through the AWS config chain must still select per-object deletes")
+	}
+}
+
+func TestNewS3ExporterUsesBatchedDeletesAgainstAmazonS3(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	exporter, err := NewS3Exporter(context.Background(), S3Config{Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("NewS3Exporter() error = %v", err)
+	}
+	if exporter.perObjectDelete {
+		t.Fatal("Amazon S3 accepts batched deletes; per-object would cost one request per object")
+	}
 }


### PR DESCRIPTION
Fixes the `MissingContentMD5` half of #63.

## The bug

With `retain` + `deleteOnExpire` against MinIO, every delete Job failed:

```
delete S3 objects: operation error S3: DeleteObjects, https response error StatusCode: 400,
api error MissingContentMD5: Missing required header for this request: Content-Md5.
```

## Root cause — not the one the issue proposed

`RequestChecksumCalculation: WhenRequired` was **already set** for custom endpoints (added in #59) and the bug still reproduced. `DeleteObjects` is modelled with `RequireChecksum: true` (`api_op_DeleteObjects.go:406`), and the middleware honours that over user config, forcing CRC32 (`middleware_setup_context.go:58`). So the existing setting was dead code for this call.

Verified against the SDK with a local server:

| call | `Content-Md5` | `x-amz-checksum-crc32` |
| --- | --- | --- |
| `DeleteObjects` (multi) | *(absent)* | `5S94mQ==` |
| `DeleteObject` (single) | *(absent)* | *(absent)* |

Amazon S3 accepts the CRC32; MinIO and other S3-compatible stores require the legacy `Content-MD5` and reject with 400.

## The fix

Per-object `DeleteObject` when a custom `endpoint` is configured — no request body, so no integrity header at all. Amazon S3 keeps batched `DeleteObjects` (1000 keys per request), since a small `partSize` can split a large snapshot into very many objects and one request per object would be three orders of magnitude more traffic.

`RequestChecksumCalculation` stays: `UploadPart` is `RequireChecksum: false`, so it genuinely governs the upload path.

## Testing

The issue noted that a permissive fake cannot catch this — correct, the header is added by SDK middleware below the `s3API` interface. So the regression test drives a **real SDK client** against an `httptest` server and asserts on the bytes on the wire. Against the pre-fix code it fails with the issue's verbatim error.

Also covers: batching preserved for Amazon S3 (2500 keys → 3 calls, 0 per-object), per-object used for custom endpoints, and per-object failure reporting.

## Scope

Deliberately only part 1. Part 2 of #63 — deletion targeting the *current* provider after a config change — is **not** addressed here and the issue should stay open for it. Tracking where every tarball was written turned out to need a records state machine (live/superseded/orphaned/mid-deletion, keyed by snapshot and destination identity) that was not worth the complexity: after a config change, an operator can remove the old objects manually. Revisit only if that proves to be a real operational burden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete S3 objects one-by-one when a custom endpoint is used (including endpoints set via the AWS config chain) so S3‑compatible stores like MinIO accept deletions. Batched deletes remain for Amazon S3 to keep request volume low.

- **Bug Fixes**
  - Detect custom endpoints from the SDK client so cases set via `AWS_ENDPOINT_URL_S3`/`AWS_ENDPOINT_URL`/shared-config are covered.
  - Use per-object deletes for S3‑compatible endpoints to avoid checksum headers that trigger `MissingContentMD5`.
  - Keep 1000-key batching on Amazon S3; add tests with a real SDK client to assert no checksum headers, batching on S3, and per-object error reporting.

<sup>Written for commit 3e6f1bdcd2f2ac1be551171cf623111b06540e30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

