### PR TITLE
fix: surface the cosmosigner genesis collapse and name the multi-validator alternative

### DIFF
--- a/api/v1/chainnodeset_webhook.go
+++ b/api/v1/chainnodeset_webhook.go
@@ -87,6 +87,30 @@ func (nodeSet *ChainNodeSet) validatorGroupMisplacedFieldWarnings() admission.Wa
 	return warnings
 }
 
+// genesisSignerCollapseWarnings surfaces multi-instance genesis-initializing validator groups that a
+// cosmosigner collapses to a single validator. A signer holds one consensus identity, so only
+// instance 0 runs the key flow and the genesis gets one gentx instead of one per instance — the same
+// manifest means N validators without a signer and one with it, and nothing else says which was
+// applied. This is a warning rather than an error because the shape is legitimate (it is the
+// documented HA layout), but it is only reported for .validator.init groups: there the collapse is
+// baked into the immutable genesis validator set, so admission is the last point at which it can be
+// corrected. Non-init groups are silent — an HA signer over a running validator is reversible.
+func (nodeSet *ChainNodeSet) genesisSignerCollapseWarnings() admission.Warnings {
+	warnings := admission.Warnings{}
+	for i, group := range nodeSet.Spec.Nodes {
+		if group.Validator == nil || group.Validator.Init == nil || group.GetInstances() <= 1 {
+			continue
+		}
+		if nodeSet.groupCosmosigner(group.Name) == nil {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			".spec.nodes[%d] initializes genesis with %d instances and a cosmosigner, so it adds ONE validator to the immutable genesis set, not %d; remove the cosmosigner if each instance should be its own genesis validator",
+			i, group.GetInstances(), group.GetInstances()))
+	}
+	return warnings
+}
+
 func (nodeSet *ChainNodeSet) Validate(old *ChainNodeSet) (admission.Warnings, error) {
 	// Count validators and how many of them initialize a new genesis.
 	initValidators := 0
@@ -138,7 +162,7 @@ func (nodeSet *ChainNodeSet) Validate(old *ChainNodeSet) (admission.Warnings, er
 		case initValidators == 0:
 			return nil, fmt.Errorf(".spec.genesis is required except when initializing new genesis with .spec.validator.init")
 		case nonInitValidators > 0:
-			return nil, fmt.Errorf(".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init")
+			return nil, fmt.Errorf(".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init; to run multiple validators in a generated genesis, set instances on the single genesis-initializing validator group instead of adding another validator group")
 		}
 	}
 
@@ -354,7 +378,7 @@ func (nodeSet *ChainNodeSet) Validate(old *ChainNodeSet) (admission.Warnings, er
 	}
 
 	if initValidators > 1 {
-		return nil, fmt.Errorf("only one ChainNodeSet validator can initialize genesis")
+		return nil, fmt.Errorf("only one ChainNodeSet validator can initialize genesis; to run multiple genesis validators, set instances on that single validator group")
 	}
 
 	// Validate the managed cosmosigner deployment and its target resolution.
@@ -562,7 +586,8 @@ func (nodeSet *ChainNodeSet) Validate(old *ChainNodeSet) (admission.Warnings, er
 		}
 	}
 
-	return append(nodeSet.tmKMSDeprecationWarnings(), nodeSet.validatorGroupMisplacedFieldWarnings()...), nil
+	warnings := append(nodeSet.tmKMSDeprecationWarnings(), nodeSet.validatorGroupMisplacedFieldWarnings()...)
+	return append(warnings, nodeSet.genesisSignerCollapseWarnings()...), nil
 }
 
 // validateCosmosigner validates every managed cosmosigner a ChainNodeSet runs: the top-level

--- a/api/v1/chainnodeset_webhook.go
+++ b/api/v1/chainnodeset_webhook.go
@@ -95,8 +95,15 @@ func (nodeSet *ChainNodeSet) validatorGroupMisplacedFieldWarnings() admission.Wa
 // documented HA layout), but it is only reported for .validator.init groups: there the collapse is
 // baked into the immutable genesis validator set, so admission is the last point at which it can be
 // corrected. Non-init groups are silent — an HA signer over a running validator is reversible.
-func (nodeSet *ChainNodeSet) genesisSignerCollapseWarnings() admission.Warnings {
+//
+// Once the genesis exists the remedy is gone: dropping the signer from such a group is rejected
+// below, because it would change which instances are genesis validators. The warning is therefore
+// only emitted while the genesis can still be shaped.
+func (nodeSet *ChainNodeSet) genesisSignerCollapseWarnings(genesisAlreadyCreated bool) admission.Warnings {
 	warnings := admission.Warnings{}
+	if genesisAlreadyCreated {
+		return warnings
+	}
 	for i, group := range nodeSet.Spec.Nodes {
 		if group.Validator == nil || group.Validator.Init == nil || group.GetInstances() <= 1 {
 			continue
@@ -162,7 +169,14 @@ func (nodeSet *ChainNodeSet) Validate(old *ChainNodeSet) (admission.Warnings, er
 		case initValidators == 0:
 			return nil, fmt.Errorf(".spec.genesis is required except when initializing new genesis with .spec.validator.init")
 		case nonInitValidators > 0:
-			return nil, fmt.Errorf(".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init; to run multiple validators in a generated genesis, set instances on the single genesis-initializing validator group instead of adding another validator group")
+			// Point at the alternative that actually applies: multiple validators in a generated genesis
+			// are expressed as instances on one init group. The legacy singleton .spec.validator has no
+			// instances field, so that shape must move into a node group before it can be scaled.
+			remedy := "to run multiple validators in a generated genesis, set instances on the single genesis-initializing validator group instead of adding another validator group"
+			if nodeSet.Spec.Validator != nil && nodeSet.Spec.Validator.Init != nil {
+				remedy = "to run multiple validators in a generated genesis, move .spec.validator into a .spec.nodes[] validator group and set instances on it, instead of adding another validator group"
+			}
+			return nil, fmt.Errorf(".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init; %s", remedy)
 		}
 	}
 
@@ -378,7 +392,12 @@ func (nodeSet *ChainNodeSet) Validate(old *ChainNodeSet) (admission.Warnings, er
 	}
 
 	if initValidators > 1 {
-		return nil, fmt.Errorf("only one ChainNodeSet validator can initialize genesis; to run multiple genesis validators, set instances on that single validator group")
+		// Same remedy split as the .spec.genesis rejection above: only a node group can be scaled.
+		remedy := "to run multiple genesis validators, set instances on that single validator group"
+		if nodeSet.Spec.Validator != nil && nodeSet.Spec.Validator.Init != nil {
+			remedy = "to run multiple genesis validators, keep a single .spec.nodes[] validator group and set instances on it"
+		}
+		return nil, fmt.Errorf("only one ChainNodeSet validator can initialize genesis; %s", remedy)
 	}
 
 	// Validate the managed cosmosigner deployment and its target resolution.
@@ -587,7 +606,7 @@ func (nodeSet *ChainNodeSet) Validate(old *ChainNodeSet) (admission.Warnings, er
 	}
 
 	warnings := append(nodeSet.tmKMSDeprecationWarnings(), nodeSet.validatorGroupMisplacedFieldWarnings()...)
-	return append(warnings, nodeSet.genesisSignerCollapseWarnings()...), nil
+	return append(warnings, nodeSet.genesisSignerCollapseWarnings(genesisAlreadyCreated)...), nil
 }
 
 // validateCosmosigner validates every managed cosmosigner a ChainNodeSet runs: the top-level

--- a/api/v1/chainnodeset_webhook_test.go
+++ b/api/v1/chainnodeset_webhook_test.go
@@ -153,7 +153,7 @@ func TestChainNodeSetValidateGenesis(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: ".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init; to run multiple validators in a generated genesis, set instances on the single genesis-initializing validator group instead of adding another validator group",
+			errContains: ".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init; to run multiple validators in a generated genesis, move .spec.validator into a .spec.nodes[] validator group and set instances on it, instead of adding another validator group",
 		},
 		{
 			name: "genesis present with non-init validators is allowed",
@@ -171,6 +171,30 @@ func TestChainNodeSetValidateGenesis(t *testing.T) {
 				Validator: &NodeSetValidatorConfig{Init: initConfig},
 				Nodes: []NodeGroupSpec{
 					{Name: "validators", Instances: ptr.To(1), Validator: &NodeSetValidatorConfig{Init: initConfig}},
+				},
+			},
+			wantErr:     true,
+			errContains: "only one ChainNodeSet validator can initialize genesis; to run multiple genesis validators, keep a single .spec.nodes[] validator group and set instances on it",
+		},
+		{
+			// The singleton .spec.validator has no instances field, so the remedy above only applies
+			// when the initializer is already a node group.
+			name: "genesis missing with a group initializer points at that group's instances",
+			spec: ChainNodeSetSpec{
+				Nodes: []NodeGroupSpec{
+					{Name: "genesis-validators", Instances: ptr.To(1), Validator: &NodeSetValidatorConfig{Init: initConfig}},
+					{Name: "joiners", Instances: ptr.To(1), Validator: &NodeSetValidatorConfig{}},
+				},
+			},
+			wantErr:     true,
+			errContains: ".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init; to run multiple validators in a generated genesis, set instances on the single genesis-initializing validator group instead of adding another validator group",
+		},
+		{
+			name: "more than one init group is rejected without mentioning .spec.validator",
+			spec: ChainNodeSetSpec{
+				Nodes: []NodeGroupSpec{
+					{Name: "validators-a", Instances: ptr.To(1), Validator: &NodeSetValidatorConfig{Init: initConfig}},
+					{Name: "validators-b", Instances: ptr.To(1), Validator: &NodeSetValidatorConfig{Init: initConfig}},
 				},
 			},
 			wantErr:     true,
@@ -2033,6 +2057,24 @@ func TestChainNodeSetValidateWarnsOnGenesisSignerCollapse(t *testing.T) {
 			Validator: &NodeSetValidatorConfig{Init: initConfig},
 		}}}}
 		warnings, err := nodeSet.Validate(nil)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
+
+	// Once the genesis exists the validator set is fixed and dropping the signer is rejected outright,
+	// so repeating the warning would only offer a remedy the webhook forbids.
+	t.Run("an established genesis is not reported", func(t *testing.T) {
+		group := NodeGroupSpec{
+			Name:        "validators",
+			Instances:   ptr.To(3),
+			Validator:   &NodeSetValidatorConfig{Init: initConfig},
+			Cosmosigner: signer(),
+		}
+		established := &ChainNodeSet{
+			Spec:   ChainNodeSetSpec{Nodes: []NodeGroupSpec{group}},
+			Status: ChainNodeSetStatus{ChainID: initConfig.ChainID},
+		}
+		warnings, err := established.Validate(established.DeepCopy())
 		require.NoError(t, err)
 		assert.Empty(t, warnings)
 	})

--- a/api/v1/chainnodeset_webhook_test.go
+++ b/api/v1/chainnodeset_webhook_test.go
@@ -153,7 +153,7 @@ func TestChainNodeSetValidateGenesis(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: ".spec.genesis is required when a validator does not initialize a new genesis",
+			errContains: ".spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init; to run multiple validators in a generated genesis, set instances on the single genesis-initializing validator group instead of adding another validator group",
 		},
 		{
 			name: "genesis present with non-init validators is allowed",
@@ -174,7 +174,7 @@ func TestChainNodeSetValidateGenesis(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: "only one ChainNodeSet validator can initialize genesis",
+			errContains: "only one ChainNodeSet validator can initialize genesis; to run multiple genesis validators, set instances on that single validator group",
 		},
 	}
 
@@ -1951,5 +1951,89 @@ func TestChainNodeSetValidateWarnsOnMisplacedValidatorGroupFields(t *testing.T) 
 		require.Equal(t, []string{
 			".spec.nodes[1].nodeSelector is ignored because this group has a validator block; set .spec.nodes[1].validator.nodeSelector instead",
 		}, []string(warnings))
+	})
+}
+
+// TestChainNodeSetValidateWarnsOnGenesisSignerCollapse covers the sharp edge where the same manifest
+// means two different things: a multi-instance validator group is N genesis validators on its own,
+// but ONE validator once a cosmosigner targets it. Only .validator.init groups are reported — there
+// the collapse lands in the immutable genesis validator set — while the documented HA layout (a
+// signer over a multi-instance group without init) stays silent.
+func TestChainNodeSetValidateWarnsOnGenesisSignerCollapse(t *testing.T) {
+	initConfig := &GenesisInitConfig{ChainID: "test-localnet", Assets: []string{"1unibi"}, StakeAmount: "1unibi"}
+	signer := func() *Cosmosigner {
+		return &Cosmosigner{Backend: CosmosignerBackend{Vault: &CosmosignerVaultBackend{
+			Address: "https://vault:8200", KeyName: "validator",
+			TokenSecret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "vault-token"}, Key: "token",
+			},
+		}}}
+	}
+	collapseWarning := ".spec.nodes[0] initializes genesis with 3 instances and a cosmosigner, so it adds ONE validator to the immutable genesis set, not 3; remove the cosmosigner if each instance should be its own genesis validator"
+
+	t.Run("a group-level signer on a multi-instance init group is reported", func(t *testing.T) {
+		nodeSet := &ChainNodeSet{Spec: ChainNodeSetSpec{Nodes: []NodeGroupSpec{{
+			Name:        "validators",
+			Instances:   ptr.To(3),
+			Validator:   &NodeSetValidatorConfig{Init: initConfig},
+			Cosmosigner: signer(),
+		}}}}
+		warnings, err := nodeSet.Validate(nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{collapseWarning}, []string(warnings))
+	})
+
+	t.Run("a top-level signer targeting the group is reported", func(t *testing.T) {
+		topLevel := signer()
+		topLevel.NodeGroups = []string{"validators"}
+		nodeSet := &ChainNodeSet{Spec: ChainNodeSetSpec{
+			Cosmosigner: topLevel,
+			Nodes: []NodeGroupSpec{{
+				Name:      "validators",
+				Instances: ptr.To(3),
+				Validator: &NodeSetValidatorConfig{Init: initConfig},
+			}},
+		}}
+		warnings, err := nodeSet.Validate(nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{collapseWarning}, []string(warnings))
+	})
+
+	t.Run("the documented HA layout without init is not reported", func(t *testing.T) {
+		nodeSet := &ChainNodeSet{Spec: ChainNodeSetSpec{
+			Genesis: &GenesisConfig{Url: ptr.To("https://example.com/genesis.json")},
+			Nodes: []NodeGroupSpec{{
+				Name:        "validators",
+				Instances:   ptr.To(3),
+				Validator:   &NodeSetValidatorConfig{},
+				Cosmosigner: signer(),
+			}},
+		}}
+		warnings, err := nodeSet.Validate(nil)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("a single-instance init group with a signer is not reported", func(t *testing.T) {
+		nodeSet := &ChainNodeSet{Spec: ChainNodeSetSpec{Nodes: []NodeGroupSpec{{
+			Name:        "validators",
+			Instances:   ptr.To(1),
+			Validator:   &NodeSetValidatorConfig{Init: initConfig},
+			Cosmosigner: signer(),
+		}}}}
+		warnings, err := nodeSet.Validate(nil)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("a multi-instance init group without a signer is not reported", func(t *testing.T) {
+		nodeSet := &ChainNodeSet{Spec: ChainNodeSetSpec{Nodes: []NodeGroupSpec{{
+			Name:      "validators",
+			Instances: ptr.To(3),
+			Validator: &NodeSetValidatorConfig{Init: initConfig},
+		}}}}
+		warnings, err := nodeSet.Validate(nil)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
 	})
 }

--- a/api/v1/cosmosigner_helper_test.go
+++ b/api/v1/cosmosigner_helper_test.go
@@ -27,6 +27,37 @@ func TestCosmosignerGetImagePrecedence(t *testing.T) {
 	}
 }
 
+// TestVaultUploadsGeneratedAutoDefaultsForInitTargets pins the auto-default: a genesis-initializing
+// validator always generates its consensus key locally, so the Vault backend must import it even
+// when uploadGenerated is left unset. Without an init target the field is the only thing that
+// enables the import, and a non-Vault backend never imports at all.
+func TestVaultUploadsGeneratedAutoDefaultsForInitTargets(t *testing.T) {
+	vault := func(uploadGenerated bool) *Cosmosigner {
+		return &Cosmosigner{Backend: CosmosignerBackend{Vault: &CosmosignerVaultBackend{
+			Address: "https://vault:8200", KeyName: "validator",
+			TokenSecret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "vault-token"}, Key: "token",
+			},
+			UploadGenerated: uploadGenerated,
+		}}}
+	}
+
+	if !vault(false).VaultUploadsGenerated(true) {
+		t.Fatal("a genesis-initializing target must import its generated key even with uploadGenerated unset")
+	}
+	if vault(false).VaultUploadsGenerated(false) {
+		t.Fatal("without an init target, uploadGenerated=false must not import a generated key")
+	}
+	if !vault(true).VaultUploadsGenerated(false) {
+		t.Fatal("an explicit uploadGenerated=true must import a generated key")
+	}
+
+	software := &Cosmosigner{Backend: CosmosignerBackend{Software: &CosmosignerSoftwareBackend{}}}
+	if software.VaultUploadsGenerated(true) {
+		t.Fatal("a non-Vault backend must never report a Vault import")
+	}
+}
+
 func TestVaultVersionOneMatchesTmKMSIdentity(t *testing.T) {
 	token := &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "vault-token"}, Key: "token"}
 	tmkms := &ChainNode{

--- a/docs/docs/usage/cosmosigner.md
+++ b/docs/docs/usage/cosmosigner.md
@@ -206,7 +206,8 @@ cosmosigner:
       certificateSecret: { name: vault-ca, key: ca.crt }   # optional CA
       # uploadGenerated: true    # testnets only: import the validator's generated key into Vault.
       #                          # Requires targeting a validator (init/create-validator) so the
-      #                          # imported key matches the one registered on-chain. Defaults to false.
+      #                          # imported key matches the one registered on-chain. Defaults to
+      #                          # false, but is implied when the target initializes a new genesis.
 ```
 
 Cosmosigner renews renewable and periodic Vault tokens itself at half their current TTL. No
@@ -223,6 +224,14 @@ startup; use a new Secret name when those values rotate so Cosmopilot performs b
 `keyVersion` is pinned into every public-key lookup and signing request. Rotating the Vault Transit
 key therefore does not silently change the validator identity on restart. Deliberately moving to a
 new version is a managed signer migration and must match the key the chain expects.
+
+:::note[Genesis init implies `uploadGenerated`]
+When the signer targets a validator that initializes a new genesis (`validator.init`),
+`uploadGenerated` is treated as `true` even if you leave it unset. A fresh genesis always generates
+its consensus key locally, so a pre-provisioned Vault key can never be used there — the generated key
+must be imported for the signer to hold it. The `keyVersion: 1` requirement below therefore applies
+to every genesis-initializing validator, not only to the explicit opt-in.
+:::
 
 `uploadGenerated` creates version 1 of a previously unused Transit `keyName`; set `keyVersion: 1`.
 After a completed import, the source Secret is immutable for that target. To import different key

--- a/docs/docs/usage/initializing-new-network.md
+++ b/docs/docs/usage/initializing-new-network.md
@@ -47,7 +47,7 @@ See the [Nibiru Testnet Multi Validator](../examples/nibiru/testnet-multi-valida
 :::info
 Because each instance must sign with its own key, a multi-instance validator group cannot set a shared `privateKeySecret`, `tmKMS`, or `init.accountMnemonicSecret`. The group name `validator` is reserved for the legacy `.spec.validator`; use any other name.
 
-All of the genesis validators must live in this one group: only one validator may initialize the genesis, and adding a second validator group without `init` is rejected because it would have no genesis to consume. Raise `instances` rather than declaring more groups.
+Every validator that Cosmopilot *runs* for this chain must live in this one group: only one validator may initialize the genesis, and adding a second validator group without `init` is rejected because it would have no genesis to consume. Raise `instances` rather than declaring more groups. (Validators whose keys are provisioned outside the group can still be written into the genesis with `validator.init.genesisValidators` — Cosmopilot adds each entry's account and gentx to the initial validator set without running a node for it.)
 :::
 
 :::warning[A `cosmosigner` makes this one validator]

--- a/docs/docs/usage/initializing-new-network.md
+++ b/docs/docs/usage/initializing-new-network.md
@@ -46,6 +46,12 @@ See the [Nibiru Testnet Multi Validator](../examples/nibiru/testnet-multi-valida
 
 :::info
 Because each instance must sign with its own key, a multi-instance validator group cannot set a shared `privateKeySecret`, `tmKMS`, or `init.accountMnemonicSecret`. The group name `validator` is reserved for the legacy `.spec.validator`; use any other name.
+
+All of the genesis validators must live in this one group: only one validator may initialize the genesis, and adding a second validator group without `init` is rejected because it would have no genesis to consume. Raise `instances` rather than declaring more groups.
+:::
+
+:::warning[A `cosmosigner` makes this one validator]
+Attaching a [cosmosigner](../usage/cosmosigner) to a multi-instance validator group makes it **one** validator with redundant signing endpoints — the genesis then contains a single `gen_tx`, not one per instance. Cosmopilot emits an admission warning for this combination, because the genesis validator set is fixed once created. Leave the signer off if every instance should be its own genesis validator.
 :::
 
 :::warning[Immutable after creation]

--- a/docs/docs/usage/validator.md
+++ b/docs/docs/usage/validator.md
@@ -93,8 +93,9 @@ On a chain you are initializing yourself, **all genesis validators must live in 
 validator may carry `validator.init`, and a validator group without `init` requires an external
 `.spec.genesis` — so the intuitive "one group initializes the genesis, other validator groups join
 it" layout is rejected by both rules at once. Scale the single init group with `instances` instead.
-Separate validator groups are for chains whose genesis already exists, where each group joins with
-`createValidator` (below).
+Separate validator groups are for chains whose genesis already exists — there each group either
+carries a consensus key the genesis already lists ([Existing Consensus Key](#existing-consensus-key))
+or joins with `createValidator` (below).
 :::
 
 ### Validators on a running chain

--- a/docs/docs/usage/validator.md
+++ b/docs/docs/usage/validator.md
@@ -88,6 +88,15 @@ nodes:
 
 See [Initializing a New Network → Multiple Genesis Validators](../usage/initializing-new-network#multiple-genesis-validators) and the [Nibiru Testnet Multi Validator](../examples/nibiru/testnet-multi-validator) example.
 
+:::warning[Use `instances`, not several groups]
+On a chain you are initializing yourself, **all genesis validators must live in one group**. Only one
+validator may carry `validator.init`, and a validator group without `init` requires an external
+`.spec.genesis` — so the intuitive "one group initializes the genesis, other validator groups join
+it" layout is rejected by both rules at once. Scale the single init group with `instances` instead.
+Separate validator groups are for chains whose genesis already exists, where each group joins with
+`createValidator` (below).
+:::
+
 ### Validators on a running chain
 
 Use a group with `validator.createValidator` (together with an external `.spec.genesis`) to add validators to a chain that is already running. Each instance submits its own `create-validator` transaction once it is synced:
@@ -114,6 +123,7 @@ nodes:
 - **Per-instance keys are mandatory.** A multi-instance validator group cannot set a shared `privateKeySecret`, `tmKMS`, or account secret — that would make every instance sign with the same key (double-signing). Single-instance validator groups may use them, just like `.spec.validator`.
 - **`validator` is a reserved group name** (it backs the legacy `.spec.validator`). Use any other name for your groups.
 - **Genesis (`init`) validator groups are immutable after the genesis is created** — you cannot add, remove, scale, or change their keys. Use a `createValidator` group to grow a running validator set.
+- **A `cosmosigner` collapses the group to one validator.** A signer holds a single consensus identity, so a group it targets is ONE validator whose instances are redundant signing endpoints — `instances: 3` means three validators without a signer and one with it. Cosmopilot warns at admission when a genesis-initializing group is affected, since the resulting genesis validator set cannot be changed afterwards. See [High-availability validators](../usage/cosmosigner#high-availability-validators-multiple-instances-one-identity).
 - **Backward compatible.** The singleton `.spec.validator` continues to work unchanged and is equivalent to a one-instance validator group that keeps the legacy ChainNode name `<nodeset>-validator`.
 
 ### Where to put each setting

--- a/docs/docs/usage/validator.md
+++ b/docs/docs/usage/validator.md
@@ -89,10 +89,12 @@ nodes:
 See [Initializing a New Network → Multiple Genesis Validators](../usage/initializing-new-network#multiple-genesis-validators) and the [Nibiru Testnet Multi Validator](../examples/nibiru/testnet-multi-validator) example.
 
 :::warning[Use `instances`, not several groups]
-On a chain you are initializing yourself, **all genesis validators must live in one group**. Only one
+On a chain you are initializing yourself, **every validator Cosmopilot runs lives in one group**. Only one
 validator may carry `validator.init`, and a validator group without `init` requires an external
 `.spec.genesis` — so the intuitive "one group initializes the genesis, other validator groups join
 it" layout is rejected by both rules at once. Scale the single init group with `instances` instead.
+Genesis validators that Cosmopilot does not run — keys provisioned elsewhere, or ones needing their
+own stake, assets or moniker — go in that group's `validator.init.genesisValidators` list.
 Separate validator groups are for chains whose genesis already exists — there each group either
 carries a consensus key the genesis already lists ([Existing Consensus Key](#existing-consensus-key))
 or joins with `createValidator` (below).


### PR DESCRIPTION
Addresses all three parts of #68. In each case the product behaves correctly, so this is docs plus admission signal — **no runtime behaviour changes**.

## 1. `uploadGenerated` auto-defaults for genesis-init targets

A genesis-initializing validator always generates its consensus key locally, so a pre-provisioned Vault key can never be used there — `VaultUploadsGenerated` returns true regardless of the field. `cosmosigner.md` documented it as pure opt-in ("Defaults to false"); the only description of the real behaviour was on the legacy `tmkms.md` page.

Adds the auto-default to the Vault section, noting that `keyVersion: 1` therefore applies to *every* genesis-initializing validator, not just the explicit opt-in. Adds the direct unit test the issue asked for.

**Skipped:** the field-comment half of the action item. `cosmosigner_types.go:165-166` already says "It is set to `true` automatically when this validator initializes a new genesis." Touching it would force CRD/`crds.md` regeneration for no gain — this PR has **zero generated-file diffs**.

## 2. Multi-validator genesis shape

Both rejections now name the working alternative:

```
.spec.genesis is required when a validator does not initialize a new genesis with .spec.validator.init;
  to run multiple validators in a generated genesis, set instances on the single genesis-initializing
  validator group instead of adding another validator group

only one ChainNodeSet validator can initialize genesis; to run multiple genesis validators, set
  instances on that single validator group
```

No new logic — reaching the first arm already guarantees `initValidators >= 1`. Both are suffix additions, so existing substring assertions still hold; the two `errContains` in `TestChainNodeSetValidateGenesis` are tightened to the full strings to pin the guidance.

The issue only asked about the first message. I extended the second too: it's the other half of the same trap, and fixing one while leaving the other still dead-ends anyone who tries two init groups first.

Docs contrast the two layouts in `validator.md` §Multiple Validators (which already splits "Genesis validators" vs "Validators on a running chain") rather than adding a new page.

## 3. Cosmosigner collapsing a multi-instance validator group

New admission warning:

```
.spec.nodes[0] initializes genesis with 3 instances and a cosmosigner, so it adds ONE validator to the
  immutable genesis set, not 3; remove the cosmosigner if each instance should be its own genesis validator
```

**Narrower trigger than the issue proposed**, and this is the one judgement call worth review. The issue suggests warning on `instances > 1` + validator + cosmosigner — but that is also the signature of the *documented, recommended* HA layout (`cosmosigner.md:163-178`, "3 redundant nodes, ONE validator"). Warning there would fire on every correct HA deployment and train people to ignore warnings.

So it is gated on `validator.init`:

| | `validator: {}` + signer (HA) | `validator.init` + signer |
|---|---|---|
| Meaning | 1 validator, N redundant nodes | 1 genesis validator, not N |
| Intended? | yes — documented HA shape | almost certainly not |
| Fixable later? | yes | **no** — genesis set is immutable |

That's the issue's own reproduction (3 instances → 1 `gen_tx`) and the only case where the collapse is irreversible. The webhook already freezes this combination on the *update* path (`chainnodeset_webhook.go:470-474`) precisely because it "changes which instances are genesis validators" — the gap was that create time, when it is still fixable, said nothing. If you'd rather have the broader trigger, it's a one-line change.

Preferred the warning over the `.status.validators[]` marker the issue also floated, per the issue's own steer. Detection reuses the existing `groupCosmosigner`, so a top-level `.spec.cosmosigner.nodeGroups` signer is caught the same as a group-level one.

`validator.md` and `initializing-new-network.md` both read as if instances map 1:1 to validators with no cosmosigner cross-reference; both now carry the caveat.

## Testing

`TestChainNodeSetValidateWarnsOnGenesisSignerCollapse` covers group-level and top-level signers firing, and three negatives — `instances: 1`, no signer, and the documented HA shape staying silent. `TestVaultUploadsGeneratedAutoDefaultsForInitTargets` was mutation-checked: it fails against a helper with the `initTarget` clause removed.

`make test.unit` clean; `make generate manifests` produces no diff; docs build clean (Docusaurus fails on broken links, so the new anchors resolve).

Fixes #68

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admission warning for multi‑instance genesis validator groups with a `cosmosigner`, and makes validation errors suggest fixes that match the submitted shape. Clarifies that `uploadGenerated` is implied for genesis targets and documents how to include validators not run by Cosmopilot; no runtime behavior changes. Fixes #68.

- **New Features**
  - Admission: warn when a multi‑instance `.spec.nodes[*].validator.init` group has a `cosmosigner`; emitted only before genesis; HA groups without `init` are not warned.
  - Validation: errors now suggest the correct remedy for the submitted shape — move `.spec.validator` into a `.spec.nodes[]` group and set `instances`, or set `instances` on the existing init group — and reiterate that only one group may initialize genesis.
  - Docs: state `uploadGenerated` is implied for genesis‑initializing targets; call out signer collapse and “use `instances`, not several groups”; and point to `validator.init.genesisValidators` for validators Cosmopilot does not run.

<sup>Written for commit 4d792aa448d99289b8a83bc72447cc0dec98b71b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

