### PR TITLE
feat: configure data exporter image

### DIFF
--- a/cmd/manager/config.go
+++ b/cmd/manager/config.go
@@ -7,6 +7,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	"github.com/voluzi/cosmopilot/v2/internal/controllers"
 	"github.com/voluzi/cosmopilot/v2/pkg/environ"
 )
 
@@ -47,6 +48,11 @@ func init() {
 	flag.StringVar(&runOpts.CosmosignerImage, "cosmosigner-image",
 		environ.GetString("COSMOSIGNER_IMAGE", ""),
 		"default image to be used in cosmosigner deployments when enabled; overridden per-resource by .spec.cosmosigner.image.",
+	)
+
+	flag.StringVar(&runOpts.DataExporterImage, "dataexporter-image",
+		environ.GetString("DATA_EXPORTER_IMAGE", controllers.DefaultDataExporterImage),
+		"dataexporter image to be used by snapshot tarball upload and deletion jobs.",
 	)
 
 	flag.StringVar(&runOpts.WorkerName, "worker-name",

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -44,6 +44,10 @@ $ helm show values oci://ghcr.io/voluzi/helm/cosmopilot
 - **Description**: The default container image of [Cosmosigner](https://github.com/voluzi/cosmosigner) (with version tag included), used when deploying managed remote signers. Can be overridden per-signer with `.spec.cosmosigner.image`.
 - **Default**: `ghcr.io/voluzi/cosmosigner:0.2.1`
 
+### `dataExporterImage`
+- **Description**: The container image of Data Exporter (with version tag included) used by snapshot tarball upload and deletion Jobs.
+- **Default**: `ghcr.io/voluzi/dataexporter:2.0.0`
+
 ### `imagePullSecrets`
 - **Description**: Secrets for pulling images from private repositories.
 - **Default**: `[]`

--- a/helm/cosmopilot/deployment_test.go
+++ b/helm/cosmopilot/deployment_test.go
@@ -1,0 +1,120 @@
+package cosmopilot
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDataExporterImageDefault(t *testing.T) {
+	valuesSource, err := os.ReadFile("values.yaml")
+	if err != nil {
+		t.Fatalf("read values: %v", err)
+	}
+
+	var values struct {
+		DataExporterImage string `yaml:"dataExporterImage"`
+	}
+	if err := yaml.Unmarshal(valuesSource, &values); err != nil {
+		t.Fatalf("decode values: %v", err)
+	}
+	if values.DataExporterImage != "ghcr.io/voluzi/dataexporter:2.0.0" {
+		t.Errorf("dataExporterImage = %q, want %q", values.DataExporterImage, "ghcr.io/voluzi/dataexporter:2.0.0")
+	}
+}
+
+func TestDeploymentConfiguresDataExporterImage(t *testing.T) {
+	templateSource, err := os.ReadFile("templates/deployment.yaml")
+	if err != nil {
+		t.Fatalf("read deployment template: %v", err)
+	}
+
+	chartTemplate, err := template.New("deployment.yaml").Funcs(template.FuncMap{
+		"include": func(string, any) string {
+			return "\napp.kubernetes.io/name: cosmopilot\napp.kubernetes.io/instance: test"
+		},
+		"indent": func(spaces int, value string) string {
+			prefix := strings.Repeat(" ", spaces)
+			return prefix + strings.ReplaceAll(value, "\n", "\n"+prefix)
+		},
+		"randAlphaNum": func(int) string { return "abcde" },
+		"quote":        func(value string) string { return `"` + value + `"` },
+		"ternary": func(trueValue, falseValue string, condition bool) string {
+			if condition {
+				return trueValue
+			}
+			return falseValue
+		},
+		"toYaml": func(value any) string {
+			encoded, marshalErr := yaml.Marshal(value)
+			if marshalErr != nil {
+				t.Fatalf("encode template value: %v", marshalErr)
+			}
+			return string(encoded)
+		},
+	}).Parse(string(templateSource))
+	if err != nil {
+		t.Fatalf("parse deployment template: %v", err)
+	}
+
+	const image = "registry.example.com/dataexporter:custom"
+	data := map[string]any{
+		"Release": map[string]any{"Name": "test", "Namespace": "default"},
+		"Chart":   map[string]any{"AppVersion": "3.0.0-beta.7"},
+		"Values": map[string]any{
+			"replicas":                1,
+			"image":                   "ghcr.io/voluzi/cosmopilot",
+			"imageTag":                "3.0.0-beta.7",
+			"imagePullSecrets":        []string{},
+			"webHooksEnabled":         false,
+			"nodeSelector":            map[string]string{},
+			"nodeUtilsImage":          "node-utils",
+			"cosmoGuardImage":         "cosmoguard",
+			"cosmoseedImage":          "cosmoseed",
+			"cosmosignerImage":        "cosmosigner",
+			"dataExporterImage":       image,
+			"workerName":              "",
+			"workerCount":             10,
+			"debugMode":               false,
+			"disruptionChecksEnabled": true,
+			"probesEnabled":           false,
+		},
+	}
+
+	var rendered bytes.Buffer
+	if err := chartTemplate.Execute(&rendered, data); err != nil {
+		t.Fatalf("render deployment template: %v", err)
+	}
+
+	var deployment struct {
+		Spec struct {
+			Template struct {
+				Spec struct {
+					Containers []struct {
+						Env []struct {
+							Name  string `yaml:"name"`
+							Value string `yaml:"value"`
+						} `yaml:"env"`
+					} `yaml:"containers"`
+				} `yaml:"spec"`
+			} `yaml:"template"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(rendered.Bytes(), &deployment); err != nil {
+		t.Fatalf("decode rendered deployment: %v\n%s", err, rendered.String())
+	}
+
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "DATA_EXPORTER_IMAGE" {
+			if env.Value != image {
+				t.Errorf("DATA_EXPORTER_IMAGE = %q, want %q", env.Value, image)
+			}
+			return
+		}
+	}
+	t.Error("DATA_EXPORTER_IMAGE is not configured")
+}

--- a/helm/cosmopilot/deployment_test.go
+++ b/helm/cosmopilot/deployment_test.go
@@ -61,7 +61,7 @@ func TestDeploymentConfiguresDataExporterImage(t *testing.T) {
 		t.Fatalf("parse deployment template: %v", err)
 	}
 
-	const image = "registry.example.com/dataexporter:custom"
+	const image = "true"
 	data := map[string]any{
 		"Release": map[string]any{"Name": "test", "Namespace": "default"},
 		"Chart":   map[string]any{"AppVersion": "3.0.0-beta.7"},
@@ -96,8 +96,8 @@ func TestDeploymentConfiguresDataExporterImage(t *testing.T) {
 				Spec struct {
 					Containers []struct {
 						Env []struct {
-							Name  string `yaml:"name"`
-							Value string `yaml:"value"`
+							Name  string    `yaml:"name"`
+							Value yaml.Node `yaml:"value"`
 						} `yaml:"env"`
 					} `yaml:"containers"`
 				} `yaml:"spec"`
@@ -110,8 +110,8 @@ func TestDeploymentConfiguresDataExporterImage(t *testing.T) {
 
 	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
 		if env.Name == "DATA_EXPORTER_IMAGE" {
-			if env.Value != image {
-				t.Errorf("DATA_EXPORTER_IMAGE = %q, want %q", env.Value, image)
+			if env.Value.Tag != "!!str" || env.Value.Value != image {
+				t.Errorf("DATA_EXPORTER_IMAGE = %s %q, want !!str %q", env.Value.Tag, env.Value.Value, image)
 			}
 			return
 		}

--- a/helm/cosmopilot/templates/deployment.yaml
+++ b/helm/cosmopilot/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - name: COSMOSIGNER_IMAGE
               value: {{ .Values.cosmosignerImage }}
             - name: DATA_EXPORTER_IMAGE
-              value: {{ .Values.dataExporterImage }}
+              value: {{ .Values.dataExporterImage | quote }}
             - name: WORKER_NAME
               value: {{ .Values.workerName }}
             - name: WORKER_COUNT

--- a/helm/cosmopilot/templates/deployment.yaml
+++ b/helm/cosmopilot/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: {{ .Values.cosmoseedImage }}
             - name: COSMOSIGNER_IMAGE
               value: {{ .Values.cosmosignerImage }}
+            - name: DATA_EXPORTER_IMAGE
+              value: {{ .Values.dataExporterImage }}
             - name: WORKER_NAME
               value: {{ .Values.workerName }}
             - name: WORKER_COUNT

--- a/helm/cosmopilot/values.yaml
+++ b/helm/cosmopilot/values.yaml
@@ -3,6 +3,7 @@ nodeUtilsImage: ghcr.io/voluzi/node-utils:2.9.0
 cosmoGuardImage: ghcr.io/voluzi/cosmoguard:4.0.3
 cosmoseedImage: ghcr.io/voluzi/cosmoseed:0.11.0
 cosmosignerImage: ghcr.io/voluzi/cosmosigner:0.2.1
+dataExporterImage: ghcr.io/voluzi/dataexporter:2.0.0
 replicas: 1
 imagePullSecrets: []
 workerCount: 10

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -598,6 +598,7 @@ func (r *Reconciler) getTarballExportProvider(chainNode *appsv1.ChainNode) (data
 			r.Scheme,
 			chainNode,
 			r.opts.GetDefaultPriorityClassName(),
+			r.opts.GetDataExporterImage(),
 			chainNode.Spec.Persistence.Snapshots.ExportTarball,
 		), nil
 
@@ -607,6 +608,7 @@ func (r *Reconciler) getTarballExportProvider(chainNode *appsv1.ChainNode) (data
 			r.Scheme,
 			chainNode,
 			r.opts.GetDefaultPriorityClassName(),
+			r.opts.GetDataExporterImage(),
 			chainNode.Spec.Persistence.Snapshots.ExportTarball,
 		), nil
 

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -591,6 +591,10 @@ func (r *Reconciler) getTarballExportProvider(chainNode *appsv1.ChainNode) (data
 	if r.snapshotClientSet != nil {
 		clientSet = r.snapshotClientSet
 	}
+	var imagePullSecrets []corev1.LocalObjectReference
+	if chainNode.Spec.Config != nil {
+		imagePullSecrets = chainNode.Spec.Config.ImagePullSecrets
+	}
 	switch {
 	case chainNode.Spec.Persistence.Snapshots.ExportTarball.GCS != nil:
 		return datasnapshot.NewGcsSnapshotProvider(
@@ -599,6 +603,7 @@ func (r *Reconciler) getTarballExportProvider(chainNode *appsv1.ChainNode) (data
 			chainNode,
 			r.opts.GetDefaultPriorityClassName(),
 			r.opts.GetDataExporterImage(),
+			imagePullSecrets,
 			chainNode.Spec.Persistence.Snapshots.ExportTarball,
 		), nil
 
@@ -609,6 +614,7 @@ func (r *Reconciler) getTarballExportProvider(chainNode *appsv1.ChainNode) (data
 			chainNode,
 			r.opts.GetDefaultPriorityClassName(),
 			r.opts.GetDataExporterImage(),
+			imagePullSecrets,
 			chainNode.Spec.Persistence.Snapshots.ExportTarball,
 		), nil
 

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -13,6 +13,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -68,6 +69,71 @@ func TestGetTarballExportProvider(t *testing.T) {
 			provider, err := reconciler.getTarballExportProvider(node)
 			require.NoError(t, err)
 			tt.assertType(t, provider)
+		})
+	}
+}
+
+func TestGetTarballExportProviderUsesConfiguredDataExporterImage(t *testing.T) {
+	const image = "registry.example.com/dataexporter:custom"
+	tests := []struct {
+		name   string
+		export *appsv1.ExportTarballConfig
+	}{
+		{
+			name: "GCS",
+			export: &appsv1.ExportTarballConfig{
+				GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"},
+			},
+		},
+		{
+			name: "S3",
+			export: &appsv1.ExportTarballConfig{
+				S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+			clientSet := fake.NewSimpleClientset()
+			reconciler := &Reconciler{
+				Scheme:            scheme,
+				snapshotClientSet: clientSet,
+				opts:              &controllers.ControllerRunOptions{DataExporterImage: image},
+			}
+			node := &appsv1.ChainNode{
+				TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node",
+					Namespace: "default",
+					UID:       "node-uid",
+				},
+				Spec: appsv1.ChainNodeSpec{
+					Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+						Frequency:     "24h",
+						ExportTarball: tt.export,
+					}},
+				},
+			}
+			provider, err := reconciler.getTarballExportProvider(node)
+			require.NoError(t, err)
+
+			snapshot := &snapshotv1.VolumeSnapshot{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot"},
+				ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"},
+				Status: &snapshotv1.VolumeSnapshotStatus{
+					RestoreSize: resource.NewQuantity(1024, resource.BinarySI),
+				},
+			}
+			require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot", snapshot))
+
+			job, err := clientSet.BatchV1().Jobs("default").Get(context.Background(), "snapshot-upload", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, image, job.Spec.Template.Spec.Containers[0].Image)
 		})
 	}
 }

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -113,6 +113,9 @@ func TestGetTarballExportProviderUsesConfiguredDataExporterImage(t *testing.T) {
 					UID:       "node-uid",
 				},
 				Spec: appsv1.ChainNodeSpec{
+					Config: &appsv1.Config{
+						ImagePullSecrets: []corev1.LocalObjectReference{{Name: "registry-creds"}},
+					},
 					Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
 						Frequency:     "24h",
 						ExportTarball: tt.export,
@@ -134,6 +137,7 @@ func TestGetTarballExportProviderUsesConfiguredDataExporterImage(t *testing.T) {
 			job, err := clientSet.BatchV1().Jobs("default").Get(context.Background(), "snapshot-upload", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, image, job.Spec.Template.Spec.Containers[0].Image)
+			assert.Equal(t, node.Spec.Config.ImagePullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
 		})
 	}
 }

--- a/internal/controllers/options.go
+++ b/internal/controllers/options.go
@@ -3,7 +3,8 @@ package controllers
 import "fmt"
 
 const (
-	LabelWorkerName = "worker-name"
+	LabelWorkerName          = "worker-name"
+	DefaultDataExporterImage = "ghcr.io/voluzi/dataexporter:2.0.0"
 )
 
 type ControllerRunOptions struct {
@@ -14,9 +15,17 @@ type ControllerRunOptions struct {
 	CosmoGuardImage          string
 	CosmoseedImage           string
 	CosmosignerImage         string
+	DataExporterImage        string
 	ReleaseName              string
 	DisruptionCheckEnabled   bool
 	DisruptionMaxUnavailable int
+}
+
+func (opts *ControllerRunOptions) GetDataExporterImage() string {
+	if opts == nil || opts.DataExporterImage == "" {
+		return DefaultDataExporterImage
+	}
+	return opts.DataExporterImage
 }
 
 func (opts *ControllerRunOptions) GetDefaultPriorityClassName() string {

--- a/internal/controllers/options_test.go
+++ b/internal/controllers/options_test.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDataExporterImage(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		want  string
+	}{
+		{name: "default", want: DefaultDataExporterImage},
+		{name: "configured", image: "registry.example.com/dataexporter:custom", want: "registry.example.com/dataexporter:custom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &ControllerRunOptions{DataExporterImage: tt.image}
+			assert.Equal(t, tt.want, opts.GetDataExporterImage())
+		})
+	}
+}

--- a/internal/controllers/options_test.go
+++ b/internal/controllers/options_test.go
@@ -23,3 +23,8 @@ func TestGetDataExporterImage(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDataExporterImageWithNilOptions(t *testing.T) {
+	var opts *ControllerRunOptions
+	assert.Equal(t, DefaultDataExporterImage, opts.GetDataExporterImage())
+}

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -27,22 +27,24 @@ const (
 )
 
 type GCS struct {
-	Client        kubernetes.Interface
-	Scheme        *runtime.Scheme
-	Owner         metav1.Object
-	priorityClass string
-	Config        *appsv1.GcsExportConfig
-	ExportConfig  *appsv1.ExportTarballConfig
+	Client            kubernetes.Interface
+	Scheme            *runtime.Scheme
+	Owner             metav1.Object
+	priorityClass     string
+	dataExporterImage string
+	Config            *appsv1.GcsExportConfig
+	ExportConfig      *appsv1.ExportTarballConfig
 }
 
-func NewGcsSnapshotProvider(client kubernetes.Interface, scheme *runtime.Scheme, owner metav1.Object, priorityClass string, cfg *appsv1.ExportTarballConfig) SnapshotProvider {
+func NewGcsSnapshotProvider(client kubernetes.Interface, scheme *runtime.Scheme, owner metav1.Object, priorityClass, dataExporterImage string, cfg *appsv1.ExportTarballConfig) SnapshotProvider {
 	return &GCS{
-		Client:        client,
-		Config:        cfg.GCS,
-		ExportConfig:  cfg,
-		Owner:         owner,
-		Scheme:        scheme,
-		priorityClass: priorityClass,
+		Client:            client,
+		Config:            cfg.GCS,
+		ExportConfig:      cfg,
+		Owner:             owner,
+		Scheme:            scheme,
+		priorityClass:     priorityClass,
+		dataExporterImage: dataExporterImage,
 	}
 }
 
@@ -150,7 +152,7 @@ func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.
 					Containers: []corev1.Container{
 						{
 							Name:            "dataexporter",
-							Image:           "ghcr.io/voluzi/dataexporter:latest",
+							Image:           gcs.dataExporterImage,
 							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: k8s.RestrictedSecurityContext(),
 							Args:            []string{"gcs", "upload", "data", gcs.Config.Bucket, name},
@@ -279,7 +281,7 @@ func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus
 					Containers: []corev1.Container{
 						{
 							Name:            "dataexporter",
-							Image:           "ghcr.io/voluzi/dataexporter:latest",
+							Image:           gcs.dataExporterImage,
 							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: k8s.RestrictedSecurityContext(),
 							Args:            []string{"gcs", "delete", gcs.Config.Bucket, name},

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -32,11 +32,19 @@ type GCS struct {
 	Owner             metav1.Object
 	priorityClass     string
 	dataExporterImage string
+	imagePullSecrets  []corev1.LocalObjectReference
 	Config            *appsv1.GcsExportConfig
 	ExportConfig      *appsv1.ExportTarballConfig
 }
 
-func NewGcsSnapshotProvider(client kubernetes.Interface, scheme *runtime.Scheme, owner metav1.Object, priorityClass, dataExporterImage string, cfg *appsv1.ExportTarballConfig) SnapshotProvider {
+func NewGcsSnapshotProvider(
+	client kubernetes.Interface,
+	scheme *runtime.Scheme,
+	owner metav1.Object,
+	priorityClass, dataExporterImage string,
+	imagePullSecrets []corev1.LocalObjectReference,
+	cfg *appsv1.ExportTarballConfig,
+) SnapshotProvider {
 	return &GCS{
 		Client:            client,
 		Config:            cfg.GCS,
@@ -45,6 +53,7 @@ func NewGcsSnapshotProvider(client kubernetes.Interface, scheme *runtime.Scheme,
 		Scheme:            scheme,
 		priorityClass:     priorityClass,
 		dataExporterImage: dataExporterImage,
+		imagePullSecrets:  imagePullSecrets,
 	}
 }
 
@@ -139,6 +148,7 @@ func (gcs *GCS) CreateSnapshot(ctx context.Context, name string, vs *snapshotv1.
 					RestartPolicy:      corev1.RestartPolicyNever,
 					PriorityClassName:  gcs.priorityClass,
 					ServiceAccountName: gcs.serviceAccountName(),
+					ImagePullSecrets:   gcs.imagePullSecrets,
 					Volumes: append([]corev1.Volume{
 						{
 							Name: "data",
@@ -277,6 +287,7 @@ func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus
 					RestartPolicy:      corev1.RestartPolicyNever,
 					PriorityClassName:  gcs.priorityClass,
 					ServiceAccountName: gcs.serviceAccountName(),
+					ImagePullSecrets:   gcs.imagePullSecrets,
 					Volumes:            gcs.credentialsVolume(),
 					Containers: []corev1.Container{
 						{

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -84,6 +84,20 @@ func TestGCSCreateSnapshotAuthModes(t *testing.T) {
 	}
 }
 
+func TestGCSJobsUseConfiguredDataExporterImage(t *testing.T) {
+	const image = "registry.example.com/dataexporter:custom"
+	provider := newTestGCSProviderWithImage(t, &appsv1.ExportTarballConfig{
+		GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"},
+	}, image)
+
+	require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot", testVolumeSnapshot()))
+	assert.Equal(t, image, getJob(t, provider, "snapshot-upload").Spec.Template.Spec.Containers[0].Image)
+
+	_, err := provider.DeleteSnapshot(context.Background(), "snapshot")
+	require.NoError(t, err)
+	assert.Equal(t, image, getJob(t, provider, "snapshot-delete").Spec.Template.Spec.Containers[0].Image)
+}
+
 func TestGCSDeleteSnapshotAuthModes(t *testing.T) {
 	tests := []struct {
 		name                 string
@@ -346,6 +360,10 @@ func TestGCSCreateSnapshotCleansJobWhenPVCCreationFails(t *testing.T) {
 }
 
 func newTestGCSProvider(t *testing.T, cfg *appsv1.ExportTarballConfig) *GCS {
+	return newTestGCSProviderWithImage(t, cfg, "ghcr.io/voluzi/dataexporter:test")
+}
+
+func newTestGCSProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, image string) *GCS {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
@@ -357,7 +375,7 @@ func newTestGCSProvider(t *testing.T, cfg *appsv1.ExportTarballConfig) *GCS {
 		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"},
 	}
 
-	return NewGcsSnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", cfg).(*GCS)
+	return NewGcsSnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", image, cfg).(*GCS)
 }
 
 func getJob(t *testing.T, provider *GCS, name string) *batchv1.Job {

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -86,16 +86,21 @@ func TestGCSCreateSnapshotAuthModes(t *testing.T) {
 
 func TestGCSJobsUseConfiguredDataExporterImage(t *testing.T) {
 	const image = "registry.example.com/dataexporter:custom"
+	pullSecrets := []corev1.LocalObjectReference{{Name: "registry-creds"}}
 	provider := newTestGCSProviderWithImage(t, &appsv1.ExportTarballConfig{
 		GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"},
-	}, image)
+	}, image, pullSecrets)
 
 	require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot", testVolumeSnapshot()))
-	assert.Equal(t, image, getJob(t, provider, "snapshot-upload").Spec.Template.Spec.Containers[0].Image)
+	uploadPod := getJob(t, provider, "snapshot-upload").Spec.Template.Spec
+	assert.Equal(t, image, uploadPod.Containers[0].Image)
+	assert.Equal(t, pullSecrets, uploadPod.ImagePullSecrets)
 
 	_, err := provider.DeleteSnapshot(context.Background(), "snapshot")
 	require.NoError(t, err)
-	assert.Equal(t, image, getJob(t, provider, "snapshot-delete").Spec.Template.Spec.Containers[0].Image)
+	deletePod := getJob(t, provider, "snapshot-delete").Spec.Template.Spec
+	assert.Equal(t, image, deletePod.Containers[0].Image)
+	assert.Equal(t, pullSecrets, deletePod.ImagePullSecrets)
 }
 
 func TestGCSDeleteSnapshotAuthModes(t *testing.T) {
@@ -360,10 +365,10 @@ func TestGCSCreateSnapshotCleansJobWhenPVCCreationFails(t *testing.T) {
 }
 
 func newTestGCSProvider(t *testing.T, cfg *appsv1.ExportTarballConfig) *GCS {
-	return newTestGCSProviderWithImage(t, cfg, "ghcr.io/voluzi/dataexporter:test")
+	return newTestGCSProviderWithImage(t, cfg, "ghcr.io/voluzi/dataexporter:test", nil)
 }
 
-func newTestGCSProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, image string) *GCS {
+func newTestGCSProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, image string, pullSecrets []corev1.LocalObjectReference) *GCS {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
@@ -375,7 +380,7 @@ func newTestGCSProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, 
 		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"},
 	}
 
-	return NewGcsSnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", image, cfg).(*GCS)
+	return NewGcsSnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", image, pullSecrets, cfg).(*GCS)
 }
 
 func getJob(t *testing.T, provider *GCS, name string) *batchv1.Job {

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -31,6 +31,7 @@ type S3 struct {
 	Owner             metav1.Object
 	priorityClass     string
 	dataExporterImage string
+	imagePullSecrets  []corev1.LocalObjectReference
 	Config            *appsv1.S3ExportConfig
 	ExportConfig      *appsv1.ExportTarballConfig
 }
@@ -40,6 +41,7 @@ func NewS3SnapshotProvider(
 	scheme *runtime.Scheme,
 	owner metav1.Object,
 	priorityClass, dataExporterImage string,
+	imagePullSecrets []corev1.LocalObjectReference,
 	cfg *appsv1.ExportTarballConfig,
 ) SnapshotProvider {
 	return &S3{
@@ -48,6 +50,7 @@ func NewS3SnapshotProvider(
 		Owner:             owner,
 		priorityClass:     priorityClass,
 		dataExporterImage: dataExporterImage,
+		imagePullSecrets:  imagePullSecrets,
 		Config:            cfg.S3,
 		ExportConfig:      cfg,
 	}
@@ -116,6 +119,7 @@ func (provider *S3) CreateSnapshot(ctx context.Context, name string, snapshot *s
 					RestartPolicy:      corev1.RestartPolicyNever,
 					PriorityClassName:  provider.priorityClass,
 					ServiceAccountName: provider.serviceAccountName(),
+					ImagePullSecrets:   provider.imagePullSecrets,
 					Volumes: []corev1.Volume{{
 						Name: "data",
 						VolumeSource: corev1.VolumeSource{
@@ -191,6 +195,7 @@ func (provider *S3) DeleteSnapshot(ctx context.Context, name string) (SnapshotSt
 					RestartPolicy:      corev1.RestartPolicyNever,
 					PriorityClassName:  provider.priorityClass,
 					ServiceAccountName: provider.serviceAccountName(),
+					ImagePullSecrets:   provider.imagePullSecrets,
 					Containers: []corev1.Container{{
 						Name:            "dataexporter",
 						Image:           provider.dataExporterImage,

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -26,28 +26,30 @@ const s3Exporter = "s3-exporter"
 
 // S3 manages snapshot export Jobs targeting Amazon S3 or compatible object stores.
 type S3 struct {
-	Client        kubernetes.Interface
-	Scheme        *runtime.Scheme
-	Owner         metav1.Object
-	priorityClass string
-	Config        *appsv1.S3ExportConfig
-	ExportConfig  *appsv1.ExportTarballConfig
+	Client            kubernetes.Interface
+	Scheme            *runtime.Scheme
+	Owner             metav1.Object
+	priorityClass     string
+	dataExporterImage string
+	Config            *appsv1.S3ExportConfig
+	ExportConfig      *appsv1.ExportTarballConfig
 }
 
 func NewS3SnapshotProvider(
 	client kubernetes.Interface,
 	scheme *runtime.Scheme,
 	owner metav1.Object,
-	priorityClass string,
+	priorityClass, dataExporterImage string,
 	cfg *appsv1.ExportTarballConfig,
 ) SnapshotProvider {
 	return &S3{
-		Client:        client,
-		Scheme:        scheme,
-		Owner:         owner,
-		priorityClass: priorityClass,
-		Config:        cfg.S3,
-		ExportConfig:  cfg,
+		Client:            client,
+		Scheme:            scheme,
+		Owner:             owner,
+		priorityClass:     priorityClass,
+		dataExporterImage: dataExporterImage,
+		Config:            cfg.S3,
+		ExportConfig:      cfg,
 	}
 }
 
@@ -124,7 +126,7 @@ func (provider *S3) CreateSnapshot(ctx context.Context, name string, snapshot *s
 					}},
 					Containers: []corev1.Container{{
 						Name:            "dataexporter",
-						Image:           "ghcr.io/voluzi/dataexporter:latest",
+						Image:           provider.dataExporterImage,
 						ImagePullPolicy: corev1.PullAlways,
 						SecurityContext: k8s.RestrictedSecurityContext(),
 						Args:            []string{"s3", "upload", "data", provider.Config.Bucket, name},
@@ -191,7 +193,7 @@ func (provider *S3) DeleteSnapshot(ctx context.Context, name string) (SnapshotSt
 					ServiceAccountName: provider.serviceAccountName(),
 					Containers: []corev1.Container{{
 						Name:            "dataexporter",
-						Image:           "ghcr.io/voluzi/dataexporter:latest",
+						Image:           provider.dataExporterImage,
 						ImagePullPolicy: corev1.PullAlways,
 						SecurityContext: k8s.RestrictedSecurityContext(),
 						Args:            []string{"s3", "delete", provider.Config.Bucket, name},

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -82,16 +82,21 @@ func TestS3CreateSnapshotAuthAndStorageOptions(t *testing.T) {
 
 func TestS3JobsUseConfiguredDataExporterImage(t *testing.T) {
 	const image = "registry.example.com/dataexporter:custom"
+	pullSecrets := []corev1.LocalObjectReference{{Name: "registry-creds"}}
 	provider := newTestS3ProviderWithImage(t, &appsv1.ExportTarballConfig{
 		S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"},
-	}, image)
+	}, image, pullSecrets)
 
 	require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot", testVolumeSnapshot()))
-	assert.Equal(t, image, getS3Job(t, provider, "snapshot-upload").Spec.Template.Spec.Containers[0].Image)
+	uploadPod := getS3Job(t, provider, "snapshot-upload").Spec.Template.Spec
+	assert.Equal(t, image, uploadPod.Containers[0].Image)
+	assert.Equal(t, pullSecrets, uploadPod.ImagePullSecrets)
 
 	_, err := provider.DeleteSnapshot(context.Background(), "snapshot")
 	require.NoError(t, err)
-	assert.Equal(t, image, getS3Job(t, provider, "snapshot-delete").Spec.Template.Spec.Containers[0].Image)
+	deletePod := getS3Job(t, provider, "snapshot-delete").Spec.Template.Spec
+	assert.Equal(t, image, deletePod.Containers[0].Image)
+	assert.Equal(t, pullSecrets, deletePod.ImagePullSecrets)
 }
 
 func TestS3CreateSnapshotS3CompatibleOptions(t *testing.T) {
@@ -341,10 +346,10 @@ func TestS3CreateSnapshotCleansJobWhenPVCCreationFails(t *testing.T) {
 }
 
 func newTestS3Provider(t *testing.T, cfg *appsv1.ExportTarballConfig) *S3 {
-	return newTestS3ProviderWithImage(t, cfg, "ghcr.io/voluzi/dataexporter:test")
+	return newTestS3ProviderWithImage(t, cfg, "ghcr.io/voluzi/dataexporter:test", nil)
 }
 
-func newTestS3ProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, image string) *S3 {
+func newTestS3ProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, image string, pullSecrets []corev1.LocalObjectReference) *S3 {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
@@ -353,7 +358,7 @@ func newTestS3ProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, i
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"},
 	}
-	return NewS3SnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", image, cfg).(*S3)
+	return NewS3SnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", image, pullSecrets, cfg).(*S3)
 }
 
 func testVolumeSnapshot() *snapshotv1.VolumeSnapshot {

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -80,6 +80,20 @@ func TestS3CreateSnapshotAuthAndStorageOptions(t *testing.T) {
 	}
 }
 
+func TestS3JobsUseConfiguredDataExporterImage(t *testing.T) {
+	const image = "registry.example.com/dataexporter:custom"
+	provider := newTestS3ProviderWithImage(t, &appsv1.ExportTarballConfig{
+		S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"},
+	}, image)
+
+	require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot", testVolumeSnapshot()))
+	assert.Equal(t, image, getS3Job(t, provider, "snapshot-upload").Spec.Template.Spec.Containers[0].Image)
+
+	_, err := provider.DeleteSnapshot(context.Background(), "snapshot")
+	require.NoError(t, err)
+	assert.Equal(t, image, getS3Job(t, provider, "snapshot-delete").Spec.Template.Spec.Containers[0].Image)
+}
+
 func TestS3CreateSnapshotS3CompatibleOptions(t *testing.T) {
 	export := &appsv1.ExportTarballConfig{
 		S3: &appsv1.S3ExportConfig{
@@ -327,6 +341,10 @@ func TestS3CreateSnapshotCleansJobWhenPVCCreationFails(t *testing.T) {
 }
 
 func newTestS3Provider(t *testing.T, cfg *appsv1.ExportTarballConfig) *S3 {
+	return newTestS3ProviderWithImage(t, cfg, "ghcr.io/voluzi/dataexporter:test")
+}
+
+func newTestS3ProviderWithImage(t *testing.T, cfg *appsv1.ExportTarballConfig, image string) *S3 {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
@@ -335,7 +353,7 @@ func newTestS3Provider(t *testing.T, cfg *appsv1.ExportTarballConfig) *S3 {
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"},
 	}
-	return NewS3SnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", cfg).(*S3)
+	return NewS3SnapshotProvider(fake.NewSimpleClientset(), scheme, owner, "", image, cfg).(*S3)
 }
 
 func testVolumeSnapshot() *snapshotv1.VolumeSnapshot {


### PR DESCRIPTION
## Summary
- expose the Data Exporter image through manager flags and Helm values
- default snapshot Jobs to `ghcr.io/voluzi/dataexporter:2.0.0`
- use the configured image for GCS and S3 upload and deletion Jobs

## Test plan
- [x] `make test.unit`
- [x] `make test.integration` (89/89 specs)
- [x] manager binary build
- [x] `helm lint helm/cosmopilot`
- [x] Helm render with a custom Data Exporter image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Data Exporter image configurable across the operator and Helm chart. Snapshot upload and deletion jobs now use the configured image and inherit image pull secrets, defaulting to `ghcr.io/voluzi/dataexporter:2.0.0`.

- **New Features**
  - Helm: added `dataExporterImage`; wired to `DATA_EXPORTER_IMAGE` and quoted in the template.
  - Manager: added `--dataexporter-image` flag (env `DATA_EXPORTER_IMAGE`) with a default via a shared constant; nil-safe getter.
  - GCS/S3 snapshot jobs use the configured image and propagate `imagePullSecrets` from `ChainNode.spec.config`.
  - Updated docs and added tests for Helm rendering, options defaulting, and job image/pull-secret behavior.

<sup>Written for commit 4d6d52a1a87d9db77b722acd5fbf43bee15c6aa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

