### PR TITLE
fix: repair stale snapshot progress state

### DIFF
--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -1101,6 +1101,7 @@ func (r *Reconciler) setNodePhase(ctx context.Context, chainNode *appsv1.ChainNo
 		if chainNode.Status.Phase != appsv1.PhaseChainNodeSnapshotting {
 			return r.updatePhase(ctx, chainNode, appsv1.PhaseChainNodeSnapshotting)
 		}
+		return nil
 	}
 
 	c, err := r.getChainNodeClient(chainNode)

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -57,8 +57,13 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 		return snapshots[i].CreationTimestamp.Before(&snapshots[j].CreationTimestamp)
 	})
 
-	// Fix snapshotting status in case there are no snapshots for this node
-	if len(snapshots) == 0 && volumeSnapshotInProgress(chainNode) {
+	// Repair the snapshotting annotation from the actual snapshot state. Completed
+	// and deleting snapshots must not block future snapshots, while any live
+	// non-ready snapshot remains active. VolumeSnapshot status errors are not
+	// terminal: the CSI snapshot controller keeps retrying and clears the error on
+	// success, so they must not trigger a concurrent snapshot.
+	if volumeSnapshotInProgress(chainNode) && !hasActiveVolumeSnapshot(snapshots) {
+		logger.Info("clearing stale pvc snapshot in-progress annotation")
 		setSnapshotInProgress(chainNode, false)
 		if err = r.Update(ctx, chainNode); err != nil {
 			return err
@@ -489,6 +494,16 @@ func shouldSnapshot(chainNode *appsv1.ChainNode, nodePodReady bool) bool {
 
 func isSnapshotReady(snapshot *snapshotv1.VolumeSnapshot) bool {
 	return snapshot != nil && snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse
+}
+
+func hasActiveVolumeSnapshot(snapshots []snapshotv1.VolumeSnapshot) bool {
+	for i := range snapshots {
+		snapshot := &snapshots[i]
+		if snapshot.DeletionTimestamp.IsZero() && !isSnapshotReady(snapshot) {
+			return true
+		}
+	}
+	return false
 }
 
 func isSnapshotExpired(snapshot *snapshotv1.VolumeSnapshot) (bool, error) {

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -42,7 +42,19 @@ const (
 func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv1.ChainNode, nodePodReady bool) error {
 	logger := log.FromContext(ctx)
 
-	if !chainNode.SnapshotsEnabled() || chainNode.Status.PvcSize == "" || chainNode.Status.LatestHeight == 0 {
+	if !chainNode.SnapshotsEnabled() {
+		// Snapshot configuration can be removed while a snapshot annotation is
+		// still persisted. Do not let obsolete configuration pin setNodePhase in
+		// Snapshotting forever; with snapshots disabled there is no snapshot state
+		// for this controller to continue reconciling.
+		if volumeSnapshotInProgress(chainNode) {
+			logger.Info("clearing pvc snapshot in-progress annotation because snapshots are disabled")
+			setSnapshotInProgress(chainNode, false)
+			return r.Update(ctx, chainNode)
+		}
+		return nil
+	}
+	if chainNode.Status.PvcSize == "" || chainNode.Status.LatestHeight == 0 {
 		return nil
 	}
 
@@ -67,10 +79,13 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 	timestampNeedsRepair := latestCompletedSnapshot.After(getLastSnapshotTime(chainNode))
 	annotationNeedsRepair := volumeSnapshotInProgress(chainNode) != activeSnapshot
 	desiredPhase := chainNode.Status.Phase
-	// Only recover Snapshotting from a serving phase. Stopped and synchronization
-	// phases have higher priority, and clearing snapshot state must not advertise
-	// Running before normal pod reconciliation has proved the node is serving.
-	phaseNeedsRepair := activeSnapshot && desiredPhase == appsv1.PhaseChainNodeRunning
+	// Recover Snapshotting from a serving phase. Syncing normally remains higher
+	// priority for online snapshots, but a stop-node snapshot has deleted the pod
+	// and must be non-serving while active. Stopped and StateSyncing remain higher
+	// priority, and clearing snapshot state must not advertise Running before
+	// normal pod reconciliation has proved the node is serving.
+	phaseNeedsRepair := activeSnapshot && (desiredPhase == appsv1.PhaseChainNodeRunning ||
+		(desiredPhase == appsv1.PhaseChainNodeSyncing && chainNode.Spec.Persistence.Snapshots.ShouldStopNode()))
 	if phaseNeedsRepair {
 		desiredPhase = appsv1.PhaseChainNodeSnapshotting
 	}
@@ -541,8 +556,9 @@ func hasActiveVolumeSnapshot(snapshots []snapshotv1.VolumeSnapshot) bool {
 func latestReadySnapshotTime(snapshots []snapshotv1.VolumeSnapshot) time.Time {
 	var latest time.Time
 	for i := range snapshots {
-		if isSnapshotReady(&snapshots[i]) && snapshots[i].CreationTimestamp.Time.After(latest) {
-			latest = snapshots[i].CreationTimestamp.Time
+		completedAt := snapshots[i].CreationTimestamp.Time.UTC().Truncate(time.Second)
+		if isSnapshotReady(&snapshots[i]) && completedAt.After(latest) {
+			latest = completedAt
 		}
 	}
 	return latest

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -62,10 +62,29 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 	// non-ready snapshot remains active. VolumeSnapshot status errors are not
 	// terminal: the CSI snapshot controller keeps retrying and clears the error on
 	// success, so they must not trigger a concurrent snapshot.
-	if volumeSnapshotInProgress(chainNode) && !hasActiveVolumeSnapshot(snapshots) {
-		logger.Info("clearing stale pvc snapshot in-progress annotation")
-		setSnapshotInProgress(chainNode, false)
+	activeSnapshot := hasActiveVolumeSnapshot(snapshots)
+	annotationNeedsRepair := volumeSnapshotInProgress(chainNode) != activeSnapshot
+	desiredPhase := chainNode.Status.Phase
+	phaseNeedsRepair := false
+	if activeSnapshot && desiredPhase != appsv1.PhaseChainNodeSnapshotting {
+		desiredPhase = appsv1.PhaseChainNodeSnapshotting
+		phaseNeedsRepair = true
+	} else if !activeSnapshot && desiredPhase == appsv1.PhaseChainNodeSnapshotting {
+		desiredPhase = appsv1.PhaseChainNodeRunning
+		phaseNeedsRepair = true
+	}
+	if annotationNeedsRepair {
+		logger.Info("repairing pvc snapshot in-progress annotation", "active", activeSnapshot)
+		setSnapshotInProgress(chainNode, activeSnapshot)
 		if err = r.Update(ctx, chainNode); err != nil {
+			return err
+		}
+	}
+	if phaseNeedsRepair {
+		// Update may refresh status from the status subresource, so restore the
+		// derived phase before persisting it through the status client.
+		chainNode.Status.Phase = desiredPhase
+		if err = r.Status().Update(ctx, chainNode); err != nil {
 			return err
 		}
 	}

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -67,13 +67,12 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 	timestampNeedsRepair := latestCompletedSnapshot.After(getLastSnapshotTime(chainNode))
 	annotationNeedsRepair := volumeSnapshotInProgress(chainNode) != activeSnapshot
 	desiredPhase := chainNode.Status.Phase
-	phaseNeedsRepair := false
-	if activeSnapshot && desiredPhase != appsv1.PhaseChainNodeSnapshotting {
+	// Only recover Snapshotting from a serving phase. Stopped and synchronization
+	// phases have higher priority, and clearing snapshot state must not advertise
+	// Running before normal pod reconciliation has proved the node is serving.
+	phaseNeedsRepair := activeSnapshot && desiredPhase == appsv1.PhaseChainNodeRunning
+	if phaseNeedsRepair {
 		desiredPhase = appsv1.PhaseChainNodeSnapshotting
-		phaseNeedsRepair = true
-	} else if !activeSnapshot && desiredPhase == appsv1.PhaseChainNodeSnapshotting {
-		desiredPhase = appsv1.PhaseChainNodeRunning
-		phaseNeedsRepair = true
 	}
 	if annotationNeedsRepair {
 		logger.Info("repairing pvc snapshot in-progress annotation", "active", activeSnapshot)
@@ -129,7 +128,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 			// recovery from a partially persisted reconcile, so preserve the
 			// aggregate active state rather than clearing it unconditionally.
 			setSnapshotInProgress(chainNode, activeSnapshot)
-			setSnapshotTime(chainNode, snapshot.CreationTimestamp.Time)
+			// The loop is oldest-first; never let an older newly-processed snapshot
+			// move cadence behind a newer ReadyToUse snapshot found above.
+			setSnapshotTime(chainNode, latestCompletedSnapshot)
 			if err = r.Update(ctx, chainNode); err != nil {
 				return err
 			}
@@ -605,11 +606,6 @@ func setSnapshotInProgress(chainNode *appsv1.ChainNode, snapshotting bool) {
 		chainNode.ObjectMeta.Annotations = make(map[string]string)
 	}
 	chainNode.ObjectMeta.Annotations[controllers.AnnotationPvcSnapshotInProgress] = strconv.FormatBool(snapshotting)
-	if snapshotting {
-		chainNode.Status.Phase = appsv1.PhaseChainNodeSnapshotting
-	} else {
-		chainNode.Status.Phase = appsv1.PhaseChainNodeRunning
-	}
 }
 
 func setSnapshotTime(chainNode *appsv1.ChainNode, ts time.Time) {

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -63,6 +63,8 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 	// terminal: the CSI snapshot controller keeps retrying and clears the error on
 	// success, so they must not trigger a concurrent snapshot.
 	activeSnapshot := hasActiveVolumeSnapshot(snapshots)
+	latestCompletedSnapshot := latestReadySnapshotTime(snapshots)
+	timestampNeedsRepair := latestCompletedSnapshot.After(getLastSnapshotTime(chainNode))
 	annotationNeedsRepair := volumeSnapshotInProgress(chainNode) != activeSnapshot
 	desiredPhase := chainNode.Status.Phase
 	phaseNeedsRepair := false
@@ -76,6 +78,12 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 	if annotationNeedsRepair {
 		logger.Info("repairing pvc snapshot in-progress annotation", "active", activeSnapshot)
 		setSnapshotInProgress(chainNode, activeSnapshot)
+	}
+	if timestampNeedsRepair {
+		logger.Info("repairing last pvc snapshot timestamp", "timestamp", latestCompletedSnapshot)
+		setSnapshotTime(chainNode, latestCompletedSnapshot)
+	}
+	if annotationNeedsRepair || timestampNeedsRepair {
 		if err = r.Update(ctx, chainNode); err != nil {
 			return err
 		}
@@ -117,8 +125,10 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 				return err
 			}
 
-			// Update ChainNode status
-			setSnapshotInProgress(chainNode, false)
+			// Update ChainNode state. A second pending snapshot can exist after
+			// recovery from a partially persisted reconcile, so preserve the
+			// aggregate active state rather than clearing it unconditionally.
+			setSnapshotInProgress(chainNode, activeSnapshot)
 			setSnapshotTime(chainNode, snapshot.CreationTimestamp.Time)
 			if err = r.Update(ctx, chainNode); err != nil {
 				return err
@@ -428,9 +438,11 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 }
 
 func (r *Reconciler) listNodeSnapshots(ctx context.Context, chainNode *appsv1.ChainNode) ([]snapshotv1.VolumeSnapshot, error) {
-	listOption := client.MatchingLabels{controllers.LabelChainNode: chainNode.GetName()}
 	list := &snapshotv1.VolumeSnapshotList{}
-	if err := r.List(ctx, list, listOption); err != nil {
+	if err := r.List(ctx, list,
+		client.InNamespace(chainNode.GetNamespace()),
+		client.MatchingLabels{controllers.LabelChainNode: chainNode.GetName()},
+	); err != nil {
 		return nil, err
 	}
 	return list.Items, nil
@@ -523,6 +535,16 @@ func hasActiveVolumeSnapshot(snapshots []snapshotv1.VolumeSnapshot) bool {
 		}
 	}
 	return false
+}
+
+func latestReadySnapshotTime(snapshots []snapshotv1.VolumeSnapshot) time.Time {
+	var latest time.Time
+	for i := range snapshots {
+		if isSnapshotReady(&snapshots[i]) && snapshots[i].CreationTimestamp.Time.After(latest) {
+			latest = snapshots[i].CreationTimestamp.Time
+		}
+	}
+	return latest
 }
 
 func isSnapshotExpired(snapshot *snapshotv1.VolumeSnapshot) (bool, error) {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -481,7 +481,11 @@ func TestFinishTarballExportRetriesCleanupAfterUpload(t *testing.T) {
 			controllers.AnnotationExportingTarball: "true",
 		},
 	}}
-	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(snapshot).Build()
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, snapshot).
+		Build()
 	clientSet := fake.NewSimpleClientset(
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "chain-00010101000000-upload", Namespace: "default"}},
 		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "chain-00010101000000-upload", Namespace: "default"}},
@@ -814,6 +818,7 @@ func TestEnsureVolumeSnapshotsRepairsSnapshotInProgressAnnotation(t *testing.T) 
 
 			controllerClient := fakeclient.NewClientBuilder().
 				WithScheme(scheme).
+				WithStatusSubresource(&appsv1.ChainNode{}).
 				WithObjects(objects...).
 				Build()
 			reconciler := &Reconciler{
@@ -828,6 +833,100 @@ func TestEnsureVolumeSnapshotsRepairsSnapshotInProgressAnnotation(t *testing.T) 
 			assert.Equal(t, tt.wantSnapshotting, stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
 		})
 	}
+}
+
+func TestEnsureVolumeSnapshotsRepairsFalseAnnotationFromActiveSnapshot(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	now := metav1.Now()
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "false",
+				controllers.AnnotationLastPvcSnapshot:       now.Add(-25 * time.Hour).UTC().Format(timeLayout),
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{
+			Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{Frequency: "24h"}},
+		},
+		Status: appsv1.ChainNodeStatus{
+			Phase:        appsv1.PhaseChainNodeRunning,
+			PvcSize:      "1Gi",
+			LatestHeight: 1,
+		},
+	}
+	pendingSnapshot := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-pending",
+			Namespace:         "default",
+			CreationTimestamp: now,
+			Labels:            map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotReady: "false",
+			},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(false)},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, pendingSnapshot).
+		Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, "true", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+	assert.Equal(t, appsv1.PhaseChainNodeSnapshotting, stored.Status.Phase)
+
+	snapshots := &snapshotv1.VolumeSnapshotList{}
+	require.NoError(t, controllerClient.List(context.Background(), snapshots, client.MatchingLabels{controllers.LabelChainNode: chainNode.Name}))
+	assert.Len(t, snapshots.Items, 1, "an active snapshot must prevent scheduling another snapshot")
+}
+
+func TestEnsureVolumeSnapshotsClearingStaleAnnotationPersistsRunningPhase(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	now := metav1.Now()
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "true",
+				controllers.AnnotationLastPvcSnapshot:       now.UTC().Format(timeLayout),
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{
+			Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{Frequency: "24h"}},
+		},
+		Status: appsv1.ChainNodeStatus{
+			Phase:        appsv1.PhaseChainNodeSnapshotting,
+			PvcSize:      "1Gi",
+			LatestHeight: 1,
+		},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode).
+		Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, "false", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+	assert.Equal(t, appsv1.PhaseChainNodeRunning, stored.Status.Phase)
 }
 
 func TestVolumeSnapshotInProgress(t *testing.T) {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -929,6 +929,130 @@ func TestEnsureVolumeSnapshotsClearingStaleAnnotationPersistsRunningPhase(t *tes
 	assert.Equal(t, appsv1.PhaseChainNodeRunning, stored.Status.Phase)
 }
 
+func TestListNodeSnapshotsScopesResultsToNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	labels := map[string]string{controllers.LabelChainNode: "node"}
+	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{Name: "local", Namespace: "local", Labels: labels}},
+		&snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: "foreign", Labels: labels}},
+	).Build()
+	reconciler := &Reconciler{Client: controllerClient}
+	chainNode := &appsv1.ChainNode{ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "local"}}
+
+	snapshots, err := reconciler.listNodeSnapshots(context.Background(), chainNode)
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, "local", snapshots[0].Name)
+}
+
+func TestEnsureVolumeSnapshotsPreservesActiveStateWhenAnotherSnapshotCompletes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	now := metav1.Now()
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "true",
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{Frequency: "24h"}}},
+		Status: appsv1.ChainNodeStatus{
+			Phase:        appsv1.PhaseChainNodeSnapshotting,
+			PvcSize:      "1Gi",
+			LatestHeight: 1,
+		},
+	}
+	ready := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-ready",
+			Namespace:         "default",
+			CreationTimestamp: now,
+			Labels:            map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations:       map[string]string{controllers.AnnotationPvcSnapshotReady: "false"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+	}
+	pending := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-pending",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(time.Minute)),
+			Labels:            map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations:       map[string]string{controllers.AnnotationPvcSnapshotReady: "false"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(false)},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, ready, pending).
+		Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, "true", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+	assert.Equal(t, appsv1.PhaseChainNodeSnapshotting, stored.Status.Phase)
+}
+
+func TestEnsureVolumeSnapshotsRepairsTimestampFromAlreadyAnnotatedReadySnapshot(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	completedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "true",
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{Frequency: "24h"}}},
+		Status: appsv1.ChainNodeStatus{
+			Phase:        appsv1.PhaseChainNodeSnapshotting,
+			PvcSize:      "1Gi",
+			LatestHeight: 1,
+		},
+	}
+	ready := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-ready",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(completedAt),
+			Labels:            map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations:       map[string]string{controllers.AnnotationPvcSnapshotReady: "true"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, ready).
+		Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, completedAt.Format(timeLayout), stored.Annotations[controllers.AnnotationLastPvcSnapshot])
+	assert.Equal(t, "false", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+
+	snapshots := &snapshotv1.VolumeSnapshotList{}
+	require.NoError(t, controllerClient.List(context.Background(), snapshots, client.InNamespace(chainNode.Namespace)))
+	assert.Len(t, snapshots.Items, 1, "repairing the completion timestamp must prevent an immediate replacement snapshot")
+}
+
 func TestVolumeSnapshotInProgress(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -890,7 +890,7 @@ func TestEnsureVolumeSnapshotsRepairsFalseAnnotationFromActiveSnapshot(t *testin
 	assert.Len(t, snapshots.Items, 1, "an active snapshot must prevent scheduling another snapshot")
 }
 
-func TestEnsureVolumeSnapshotsClearingStaleAnnotationPersistsRunningPhase(t *testing.T) {
+func TestEnsureVolumeSnapshotsClearingStaleAnnotationKeepsSnapshottingUntilPodReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, appsv1.AddToScheme(scheme))
 	require.NoError(t, snapshotv1.AddToScheme(scheme))
@@ -926,7 +926,52 @@ func TestEnsureVolumeSnapshotsClearingStaleAnnotationPersistsRunningPhase(t *tes
 	stored := &appsv1.ChainNode{}
 	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
 	assert.Equal(t, "false", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
-	assert.Equal(t, appsv1.PhaseChainNodeRunning, stored.Status.Phase)
+	assert.Equal(t, appsv1.PhaseChainNodeSnapshotting, stored.Status.Phase)
+}
+
+func TestEnsureVolumeSnapshotsClearingStaleAnnotationPreservesSyncingPhase(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	now := metav1.Now()
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "true",
+				controllers.AnnotationLastPvcSnapshot:       now.Add(-25 * time.Hour).UTC().Format(timeLayout),
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency:           "24h",
+			DisableWhileSyncing: ptr.To(true),
+		}}},
+		Status: appsv1.ChainNodeStatus{
+			Phase:        appsv1.PhaseChainNodeSyncing,
+			PvcSize:      "1Gi",
+			LatestHeight: 1,
+		},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode).
+		Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, "false", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+	assert.Equal(t, appsv1.PhaseChainNodeSyncing, stored.Status.Phase)
+	assert.Equal(t, appsv1.PhaseChainNodeSyncing, chainNode.Status.Phase)
+
+	snapshots := &snapshotv1.VolumeSnapshotList{}
+	require.NoError(t, controllerClient.List(context.Background(), snapshots, client.InNamespace(chainNode.Namespace)))
+	assert.Empty(t, snapshots.Items, "clearing stale state must not bypass disableWhileSyncing")
 }
 
 func TestListNodeSnapshotsScopesResultsToNamespace(t *testing.T) {
@@ -1053,6 +1098,48 @@ func TestEnsureVolumeSnapshotsRepairsTimestampFromAlreadyAnnotatedReadySnapshot(
 	assert.Len(t, snapshots.Items, 1, "repairing the completion timestamp must prevent an immediate replacement snapshot")
 }
 
+func TestEnsureVolumeSnapshotsKeepsNewestReadySnapshotTimestamp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	olderAt := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	newerAt := olderAt.Add(time.Hour)
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default"},
+		Spec:       appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{Frequency: "24h"}}},
+		Status:     appsv1.ChainNodeStatus{Phase: appsv1.PhaseChainNodeRunning, PvcSize: "1Gi", LatestHeight: 1},
+	}
+	olderReady := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-older", Namespace: "default", CreationTimestamp: metav1.NewTime(olderAt),
+			Labels:      map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations: map[string]string{controllers.AnnotationPvcSnapshotReady: "false"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+	}
+	newerReady := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-newer", Namespace: "default", CreationTimestamp: metav1.NewTime(newerAt),
+			Labels:      map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations: map[string]string{controllers.AnnotationPvcSnapshotReady: "true"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, olderReady, newerReady).
+		Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, newerAt.Format(timeLayout), stored.Annotations[controllers.AnnotationLastPvcSnapshot])
+}
+
 func TestVolumeSnapshotInProgress(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1131,34 +1218,31 @@ func TestSetSnapshotInProgress(t *testing.T) {
 		{
 			name: "start snapshotting",
 			chainNode: &appsv1.ChainNode{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				Status:     appsv1.ChainNodeStatus{Phase: appsv1.PhaseChainNodeSyncing},
 			},
 			snapshotting: true,
-			wantPhase:    appsv1.PhaseChainNodeSnapshotting,
+			wantPhase:    appsv1.PhaseChainNodeSyncing,
 			wantValue:    "true",
 		},
 		{
 			name: "stop snapshotting",
 			chainNode: &appsv1.ChainNode{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				Status:     appsv1.ChainNodeStatus{Phase: appsv1.PhaseChainNodeSnapshotting},
 			},
 			snapshotting: false,
-			wantPhase:    appsv1.PhaseChainNodeRunning,
+			wantPhase:    appsv1.PhaseChainNodeSnapshotting,
 			wantValue:    "false",
 		},
 		{
 			name: "start with nil annotations",
 			chainNode: &appsv1.ChainNode{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: nil,
-				},
+				ObjectMeta: metav1.ObjectMeta{Annotations: nil},
+				Status:     appsv1.ChainNodeStatus{Phase: appsv1.PhaseChainNodeStopped},
 			},
 			snapshotting: true,
-			wantPhase:    appsv1.PhaseChainNodeSnapshotting,
+			wantPhase:    appsv1.PhaseChainNodeStopped,
 			wantValue:    "true",
 		},
 	}

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -667,6 +667,169 @@ func TestIsSnapshotExpired(t *testing.T) {
 	}
 }
 
+func TestEnsureVolumeSnapshotsRepairsSnapshotInProgressAnnotation(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name             string
+		snapshots        []snapshotv1.VolumeSnapshot
+		wantSnapshotting string
+	}{
+		{
+			name: "retained ready snapshot does not keep stale annotation",
+			snapshots: []snapshotv1.VolumeSnapshot{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node-ready",
+					Namespace:         "default",
+					CreationTimestamp: now,
+					Annotations: map[string]string{
+						controllers.AnnotationPvcSnapshotReady: "true",
+					},
+				},
+				Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+			}},
+			wantSnapshotting: "false",
+		},
+		{
+			name: "pending snapshot alongside retained ready snapshot keeps annotation",
+			snapshots: []snapshotv1.VolumeSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node-ready",
+						Namespace:         "default",
+						CreationTimestamp: now,
+						Annotations: map[string]string{
+							controllers.AnnotationPvcSnapshotReady: "true",
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node-pending",
+						Namespace:         "default",
+						CreationTimestamp: now,
+						Annotations: map[string]string{
+							controllers.AnnotationPvcSnapshotReady: "false",
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(false)},
+				},
+			},
+			wantSnapshotting: "true",
+		},
+		{
+			name: "snapshot error alongside retained ready snapshot keeps annotation while CSI retries",
+			snapshots: []snapshotv1.VolumeSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node-ready",
+						Namespace:         "default",
+						CreationTimestamp: now,
+						Annotations: map[string]string{
+							controllers.AnnotationPvcSnapshotReady: "true",
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node-failed",
+						Namespace:         "default",
+						CreationTimestamp: now,
+						Annotations: map[string]string{
+							controllers.AnnotationPvcSnapshotReady: "false",
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{
+						ReadyToUse: ptr.To(false),
+						Error:      &snapshotv1.VolumeSnapshotError{Message: ptr.To("snapshot failed")},
+					},
+				},
+			},
+			wantSnapshotting: "true",
+		},
+		{
+			name: "deleting snapshot alongside retained ready snapshot does not keep stale annotation",
+			snapshots: []snapshotv1.VolumeSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node-ready",
+						Namespace:         "default",
+						CreationTimestamp: now,
+						Annotations: map[string]string{
+							controllers.AnnotationPvcSnapshotReady: "true",
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node-deleting",
+						Namespace:         "default",
+						CreationTimestamp: now,
+						DeletionTimestamp: &now,
+						Finalizers:        []string{"snapshot.storage.kubernetes.io/volumesnapshot-bound-protection"},
+						Annotations: map[string]string{
+							controllers.AnnotationPvcSnapshotReady: "false",
+						},
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(false)},
+				},
+			},
+			wantSnapshotting: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+			chainNode := &appsv1.ChainNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node",
+					Namespace:         "default",
+					CreationTimestamp: now,
+					Annotations: map[string]string{
+						controllers.AnnotationPvcSnapshotInProgress: "true",
+						controllers.AnnotationLastPvcSnapshot:       now.UTC().Format(timeLayout),
+					},
+				},
+				Spec: appsv1.ChainNodeSpec{
+					Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{Frequency: "24h"}},
+				},
+				Status: appsv1.ChainNodeStatus{
+					Phase:        appsv1.PhaseChainNodeSnapshotting,
+					PvcSize:      "1Gi",
+					LatestHeight: 1,
+				},
+			}
+			objects := make([]client.Object, 0, len(tt.snapshots)+1)
+			objects = append(objects, chainNode)
+			for i := range tt.snapshots {
+				tt.snapshots[i].Labels = map[string]string{controllers.LabelChainNode: chainNode.Name}
+				objects = append(objects, &tt.snapshots[i])
+			}
+
+			controllerClient := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+			reconciler := &Reconciler{
+				Client:   controllerClient,
+				recorder: record.NewFakeRecorder(10),
+			}
+
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			stored := &appsv1.ChainNode{}
+			require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+			assert.Equal(t, tt.wantSnapshotting, stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+		})
+	}
+}
+
 func TestVolumeSnapshotInProgress(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -1140,6 +1140,120 @@ func TestEnsureVolumeSnapshotsKeepsNewestReadySnapshotTimestamp(t *testing.T) {
 	assert.Equal(t, newerAt.Format(timeLayout), stored.Annotations[controllers.AnnotationLastPvcSnapshot])
 }
 
+func TestEnsureVolumeSnapshotsDoesNotRewriteSecondPrecisionTimestamp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	completedAt := time.Date(2026, time.August, 1, 19, 14, 25, 987654321, time.UTC)
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "false",
+				controllers.AnnotationLastPvcSnapshot:       completedAt.Format(timeLayout),
+			},
+		},
+		Spec:   appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{Frequency: "24h"}}},
+		Status: appsv1.ChainNodeStatus{Phase: appsv1.PhaseChainNodeRunning, PvcSize: "1Gi", LatestHeight: 1},
+	}
+	ready := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-ready", Namespace: "default", CreationTimestamp: metav1.NewTime(completedAt),
+			Labels:      map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations: map[string]string{controllers.AnnotationPvcSnapshotReady: "true"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+	}
+	baseClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, ready).
+		Build()
+	countingClient := &countingUpdateClient{Client: baseClient}
+	reconciler := &Reconciler{Client: countingClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+	assert.Zero(t, countingClient.updates, "matching second-resolution timestamps must not trigger a metadata write")
+}
+
+func TestEnsureVolumeSnapshotsRepairsSyncingPhaseForStopNodeSnapshot(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "false",
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency: "24h",
+			StopNode:  ptr.To(true),
+		}}},
+		Status: appsv1.ChainNodeStatus{Phase: appsv1.PhaseChainNodeSyncing, PvcSize: "1Gi", LatestHeight: 1},
+	}
+	pending := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-pending", Namespace: "default",
+			Labels:      map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations: map[string]string{controllers.AnnotationPvcSnapshotReady: "false"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(false)},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, pending).
+		Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, "true", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+	assert.Equal(t, appsv1.PhaseChainNodeSnapshotting, stored.Status.Phase)
+}
+
+func TestEnsureVolumeSnapshotsClearsProgressWhenSnapshotsDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotInProgress: "true",
+			},
+		},
+		Status: appsv1.ChainNodeStatus{Phase: appsv1.PhaseChainNodeSnapshotting},
+	}
+	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(chainNode).Build()
+	reconciler := &Reconciler{Client: controllerClient, recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &appsv1.ChainNode{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(chainNode), stored))
+	assert.Equal(t, "false", stored.Annotations[controllers.AnnotationPvcSnapshotInProgress])
+}
+
+type countingUpdateClient struct {
+	client.Client
+	updates int
+}
+
+func (c *countingUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updates++
+	return c.Client.Update(ctx, obj, opts...)
+}
+
 func TestVolumeSnapshotInProgress(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- repair the ChainNode snapshot-in-progress annotation from live VolumeSnapshot state
- ignore retained Ready and deleting snapshots when deciding whether an operation remains active
- conservatively keep non-ready snapshots active during transient CSI errors to prevent concurrent snapshots
- add regression coverage for retained, pending, retrying, and deleting snapshot combinations

## Test plan
- `make test.unit`
- `make test.integration` (89/89 specs passed)
- focused race test for snapshot state repair helpers

Closes #81