### PR TITLE
fix: emit stale snapshot job replacement events

### DIFF
--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -298,12 +298,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if !stderrors.Is(err, datasnapshot.ErrStaleJobReplaced) {
 			return ctrl.Result{}, err
 		}
+		// The snapshot path records the success event where the stale Job deletion is confirmed.
 		logger.Info("replaced stale snapshot job", "reason", err.Error())
-		r.recorder.Eventf(chainNode,
-			corev1.EventTypeWarning,
-			appsv1.ReasonSnapshotJobReplaced,
-			"Replaced stale snapshot job: %v", err,
-		)
 		// Note it and carry on. Returning here would freeze genesis, services, config and the pod behind
 		// snapshot cleanup — the very failure mode this path exists to prevent — and foreground deletion
 		// can stay pending for a while behind the upload pod, its PVC or a finalizer.

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -292,18 +292,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Ensure snapshots are taken if enabled and check if they are ready
 	logger.V(1).Info("ensure volume snapshots if applicable")
 	staleSnapshotJobReplaced := false
+	staleSnapshotJobTerminating := false
 	if err = r.ensureVolumeSnapshots(ctx, chainNode, nodePodReady); err != nil {
 		// A stale export/delete Job was dropped and will be recreated on the next pass. Keep it out of the
 		// reconcile error path so an unrelated subsystem cannot freeze the whole ChainNode.
-		if !stderrors.Is(err, datasnapshot.ErrStaleJobReplaced) {
+		switch {
+		case stderrors.Is(err, datasnapshot.ErrStaleJobReplaced):
+			// The snapshot path records the success event where the stale Job deletion is confirmed.
+			logger.Info("replaced stale snapshot job", "reason", err.Error())
+			staleSnapshotJobReplaced = true
+		case stderrors.Is(err, datasnapshot.ErrStaleJobTerminating):
+			logger.Info("waiting for stale snapshot job deletion", "reason", err.Error())
+			staleSnapshotJobTerminating = true
+		default:
 			return ctrl.Result{}, err
 		}
-		// The snapshot path records the success event where the stale Job deletion is confirmed.
-		logger.Info("replaced stale snapshot job", "reason", err.Error())
-		// Note it and carry on. Returning here would freeze genesis, services, config and the pod behind
-		// snapshot cleanup — the very failure mode this path exists to prevent — and foreground deletion
-		// can stay pending for a while behind the upload pod, its PVC or a finalizer.
-		staleSnapshotJobReplaced = true
+		// Carry on so snapshot cleanup cannot freeze genesis, services, config or the node pod.
 	}
 
 	// If the node will be down during snapshot, most methods below will fail.
@@ -436,6 +440,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Come back promptly to recreate the replaced Job: Jobs are not watched, so nothing else would
 		// wake the controller before the full reconcile period elapses.
 		return ctrl.Result{Requeue: true}, nil
+	}
+	if staleSnapshotJobTerminating {
+		// Foreground deletion may wait on pods, PVCs or finalizers. Poll at the normal snapshot cadence
+		// instead of immediately hot-looping full ChainNode reconciliation.
+		return ctrl.Result{RequeueAfter: snapshotCheckPeriod}, nil
 	}
 	if dashboardRoutesPending {
 		return ctrl.Result{RequeueAfter: dashboardRouteCheckPeriod}, nil

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -847,7 +847,7 @@ func (r *Reconciler) deleteTarballWithProvider(
 }
 
 func (r *Reconciler) recordTarballExportError(chainNode *appsv1.ChainNode, err error) {
-	if stderrors.Is(err, datasnapshot.ErrStaleJobReplaced) {
+	if stderrors.Is(err, datasnapshot.ErrStaleJobReplaced) || stderrors.Is(err, datasnapshot.ErrStaleJobTerminating) {
 		return
 	}
 	r.recorder.Eventf(chainNode,

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -286,11 +286,7 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 			snapshot.Annotations[controllers.AnnotationExportingTarball] == strconv.FormatBool(true):
 			ready, err := r.isTarballReady(ctx, chainNode, &snapshot)
 			if err != nil {
-				r.recorder.Eventf(chainNode,
-					corev1.EventTypeWarning,
-					appsv1.ReasonTarballExportError,
-					"Error on tarball export %v", err,
-				)
+				r.recordTarballExportError(chainNode, err)
 				return err
 			}
 			if ready {
@@ -850,30 +846,41 @@ func (r *Reconciler) deleteTarballWithProvider(
 	return status, err
 }
 
+func (r *Reconciler) recordTarballExportError(chainNode *appsv1.ChainNode, err error) {
+	if stderrors.Is(err, datasnapshot.ErrStaleJobReplaced) {
+		return
+	}
+	r.recorder.Eventf(chainNode,
+		corev1.EventTypeWarning,
+		appsv1.ReasonTarballExportError,
+		"Error on tarball export %v", err,
+	)
+}
+
 func (r *Reconciler) recordSnapshotJobReplacement(chainNode *appsv1.ChainNode, err error) {
 	var replacement *datasnapshot.StaleJobReplacedError
 	if !stderrors.As(err, &replacement) {
 		return
 	}
 	message := controllers.FormatEventMessage(
-		"Replaced stale %s Job %s/%s with conflicting label %q; previous value %q; desired value %q; UID %s",
+		"Replaced stale %s Job %s/%s UID %s with conflicting label %q; previous value %q; desired value %q",
 		replacement.Purpose,
 		replacement.Namespace,
 		replacement.Name,
+		replacement.UID,
 		replacement.ConflictingLabel,
 		replacement.PreviousValue,
 		replacement.DesiredValue,
-		replacement.UID,
 	)
 	if replacement.ProviderSwitch() {
 		message = controllers.FormatEventMessage(
-			"Replaced stale %s Job %s/%s for desired provider %q; previous provider %q; UID %s",
+			"Replaced stale %s Job %s/%s UID %s for desired provider %q; previous provider %q",
 			replacement.Purpose,
 			replacement.Namespace,
 			replacement.Name,
+			replacement.UID,
 			replacement.DesiredValue,
 			replacement.PreviousValue,
-			replacement.UID,
 		)
 	}
 	r.recorder.Event(chainNode,

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -414,7 +414,7 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 		for _, snapshot := range tarballSnapshots {
 			if !utils.SliceContains[string](tarballNames, snapshot) {
 				logger.Info("reconciling orphaned tarball deletion as volumesnapshot does not exist anymore", "snapshot", snapshot)
-				status, deleteErr := exporter.DeleteSnapshot(ctx, snapshot)
+				status, deleteErr := r.deleteTarballWithProvider(ctx, chainNode, exporter, snapshot)
 				if deleteErr != nil {
 					return deleteErr
 				}
@@ -696,7 +696,9 @@ func (r *Reconciler) exportTarball(ctx context.Context, chainNode *appsv1.ChainN
 	if err != nil {
 		return err
 	}
-	return exporter.CreateSnapshot(ctx, getTarballName(chainNode, snapshot), snapshot)
+	err = exporter.CreateSnapshot(ctx, getTarballName(chainNode, snapshot), snapshot)
+	r.recordSnapshotJobReplacement(chainNode, err)
+	return err
 }
 
 func (r *Reconciler) isTarballReady(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) (bool, error) {
@@ -707,6 +709,7 @@ func (r *Reconciler) isTarballReady(ctx context.Context, chainNode *appsv1.Chain
 
 	status, err := exporter.GetSnapshotStatus(ctx, getTarballName(chainNode, snapshot))
 	if err != nil {
+		r.recordSnapshotJobReplacement(chainNode, err)
 		// The upload Job belonged to a previous exporter and was deleted. Clear the export state instead
 		// of letting the next poll see the intentionally removed Job as SnapshotNotFound and charge it as
 		// another failed attempt — that could exhaust the retry limit and permanently mark the export
@@ -833,7 +836,51 @@ func (r *Reconciler) deleteTarball(ctx context.Context, chainNode *appsv1.ChainN
 	if err != nil {
 		return "", err
 	}
-	return exporter.DeleteSnapshot(ctx, getTarballName(chainNode, snapshot))
+	return r.deleteTarballWithProvider(ctx, chainNode, exporter, getTarballName(chainNode, snapshot))
+}
+
+func (r *Reconciler) deleteTarballWithProvider(
+	ctx context.Context,
+	chainNode *appsv1.ChainNode,
+	exporter datasnapshot.SnapshotProvider,
+	name string,
+) (datasnapshot.SnapshotStatus, error) {
+	status, err := exporter.DeleteSnapshot(ctx, name)
+	r.recordSnapshotJobReplacement(chainNode, err)
+	return status, err
+}
+
+func (r *Reconciler) recordSnapshotJobReplacement(chainNode *appsv1.ChainNode, err error) {
+	var replacement *datasnapshot.StaleJobReplacedError
+	if !stderrors.As(err, &replacement) {
+		return
+	}
+	message := controllers.FormatEventMessage(
+		"Replaced stale %s Job %s/%s with conflicting label %q; previous value %q; desired value %q; UID %s",
+		replacement.Purpose,
+		replacement.Namespace,
+		replacement.Name,
+		replacement.ConflictingLabel,
+		replacement.PreviousValue,
+		replacement.DesiredValue,
+		replacement.UID,
+	)
+	if replacement.ProviderSwitch() {
+		message = controllers.FormatEventMessage(
+			"Replaced stale %s Job %s/%s for desired provider %q; previous provider %q; UID %s",
+			replacement.Purpose,
+			replacement.Namespace,
+			replacement.Name,
+			replacement.DesiredValue,
+			replacement.PreviousValue,
+			replacement.UID,
+		)
+	}
+	r.recorder.Event(chainNode,
+		corev1.EventTypeNormal,
+		appsv1.ReasonSnapshotJobReplaced,
+		message,
+	)
 }
 
 func (r *Reconciler) isTarballDeleted(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) (bool, error) {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -3,6 +3,7 @@ package chainnode
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -271,6 +272,7 @@ func TestTarballExportReplacementDoesNotEmitWarningEvent(t *testing.T) {
 	}
 
 	reconciler.recordTarballExportError(&appsv1.ChainNode{}, replacement)
+	reconciler.recordTarballExportError(&appsv1.ChainNode{}, fmt.Errorf("waiting for delete: %w", datasnapshot.ErrStaleJobTerminating))
 
 	assertNoRecordedEvent(t, recorder)
 }

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -194,7 +196,13 @@ func TestStaleUploadJobReplacementDoesNotChargeFailedAttempt(t *testing.T) {
 		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
 			Frequency: "24h",
 			// Now exporting to GCS...
-			ExportTarball: &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+			ExportTarball: &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{
+				Bucket: "snapshots",
+				CredentialsSecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "desired-gcs-credentials"},
+					Key:                  "credentials.json",
+				},
+			}},
 		}}},
 	}
 	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{
@@ -210,7 +218,7 @@ func TestStaleUploadJobReplacementDoesNotChargeFailedAttempt(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "-00010101000000-upload",
 			Namespace: "default",
-			UID:       "stale-uid",
+			UID:       types.UID(strings.Repeat("u", 300)),
 			Labels:    map[string]string{"exporter": "s3-exporter"},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: appsv1.GroupVersion.String(),
@@ -221,12 +229,13 @@ func TestStaleUploadJobReplacementDoesNotChargeFailedAttempt(t *testing.T) {
 			}},
 		},
 	})
+	recorder := record.NewFakeRecorder(10)
 	reconciler := &Reconciler{
 		Client:            controllerClient,
 		snapshotClientSet: clientSet,
 		Scheme:            scheme,
 		opts:              &controllers.ControllerRunOptions{},
-		recorder:          record.NewFakeRecorder(10),
+		recorder:          recorder,
 	}
 
 	ready, err := reconciler.isTarballReady(context.Background(), chainNode, snapshot)
@@ -239,6 +248,188 @@ func TestStaleUploadJobReplacementDoesNotChargeFailedAttempt(t *testing.T) {
 	assert.False(t, exporting, "export state must be cleared so a fresh upload starts")
 	_, attempts := stored.Annotations[controllers.AnnotationTarballExportAttempts]
 	assert.False(t, attempts, "the intentional deletion must not count as a failed attempt")
+
+	event := requireRecordedEvent(t, recorder)
+	assert.Contains(t, event, "Normal "+appsv1.ReasonSnapshotJobReplaced)
+	assert.Contains(t, event, "Replaced stale upload Job default/-00010101000000-upload")
+	assert.Contains(t, event, "s3-exporter")
+	assert.Contains(t, event, "gcs-exporter")
+	assert.NotContains(t, event, "desired-gcs-credentials")
+	assert.NotContains(t, event, "credentials.json")
+	message := strings.TrimPrefix(event, "Normal "+appsv1.ReasonSnapshotJobReplaced+" ")
+	assert.LessOrEqual(t, len(message), 256)
+}
+
+func TestStaleDeleteJobReplacementEmitsEvent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	chainNode := &appsv1.ChainNode{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default", UID: "node-uid"},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency:     "24h",
+			ExportTarball: &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		}}},
+	}
+	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"}}
+	clientSet := fake.NewSimpleClientset(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "-00010101000000-delete",
+		Namespace: "default",
+		UID:       "stale-delete-uid",
+		Labels: map[string]string{
+			"exporter": "s3-exporter",
+			"owner":    "node",
+			"type":     "delete",
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: appsv1.GroupVersion.String(),
+			Kind:       "ChainNode",
+			Name:       "node",
+			UID:        "node-uid",
+			Controller: ptr.To(true),
+		}},
+	}})
+	deleteCalls := 0
+	clientSet.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		deleteCalls++
+		resource := batchv1.SchemeGroupVersion.WithResource("jobs")
+		stored, err := clientSet.Tracker().Get(resource, "default", "-00010101000000-delete")
+		if err != nil {
+			return true, nil, err
+		}
+		terminating := stored.(*batchv1.Job).DeepCopy()
+		deletionTimestamp := metav1.Now()
+		terminating.DeletionTimestamp = &deletionTimestamp
+		if err = clientSet.Tracker().Update(resource, terminating, "default"); err != nil {
+			return true, nil, err
+		}
+		return true, nil, nil
+	})
+	recorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{
+		snapshotClientSet: clientSet,
+		Scheme:            scheme,
+		opts:              &controllers.ControllerRunOptions{},
+		recorder:          recorder,
+	}
+
+	deleted, err := reconciler.isTarballDeleted(context.Background(), chainNode, snapshot)
+	assert.False(t, deleted)
+	require.ErrorIs(t, err, datasnapshot.ErrStaleJobReplaced)
+
+	event := requireRecordedEvent(t, recorder)
+	assert.Contains(t, event, "Normal "+appsv1.ReasonSnapshotJobReplaced)
+	assert.Contains(t, event, "Replaced stale delete Job default/-00010101000000-delete")
+	assert.Contains(t, event, "stale-delete-uid")
+	assert.Contains(t, event, "s3-exporter")
+	assert.Contains(t, event, "gcs-exporter")
+	assert.Equal(t, 1, deleteCalls)
+
+	deleted, err = reconciler.isTarballDeleted(context.Background(), chainNode, snapshot)
+	assert.False(t, deleted)
+	require.ErrorIs(t, err, datasnapshot.ErrStaleJobReplaced)
+	var replacement *datasnapshot.StaleJobReplacedError
+	assert.False(t, errors.As(err, &replacement), "waiting for a terminating Job must not report another successful replacement")
+	assert.Equal(t, 1, deleteCalls)
+	assertNoRecordedEvent(t, recorder)
+}
+
+func TestStaleDeleteJobReplacementDoesNotEmitEventWhenUIDPreconditionConflicts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	chainNode := &appsv1.ChainNode{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default", UID: "node-uid"},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency:     "24h",
+			ExportTarball: &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		}}},
+	}
+	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"}}
+	clientSet := fake.NewSimpleClientset(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "-00010101000000-delete",
+		Namespace: "default",
+		UID:       "stale-delete-uid",
+		Labels: map[string]string{
+			"exporter": "s3-exporter",
+			"owner":    "node",
+			"type":     "delete",
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: appsv1.GroupVersion.String(),
+			Kind:       "ChainNode",
+			Name:       "node",
+			UID:        "node-uid",
+			Controller: ptr.To(true),
+		}},
+	}})
+	clientSet.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewConflict(
+			schema.GroupResource{Group: batchv1.GroupName, Resource: "jobs"},
+			"-00010101000000-delete",
+			errors.New("UID precondition did not match"),
+		)
+	})
+	recorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{
+		snapshotClientSet: clientSet,
+		Scheme:            scheme,
+		opts:              &controllers.ControllerRunOptions{},
+		recorder:          recorder,
+	}
+
+	deleted, err := reconciler.isTarballDeleted(context.Background(), chainNode, snapshot)
+	assert.False(t, deleted)
+	require.True(t, apierrors.IsConflict(err))
+	assertNoRecordedEvent(t, recorder)
+}
+
+func TestStaleDeleteJobReplacementEventReportsActualNonExporterLabelMismatch(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{recorder: recorder}
+	reconciler.recordSnapshotJobReplacement(&appsv1.ChainNode{}, &datasnapshot.StaleJobReplacedError{
+		Purpose:          "delete",
+		Namespace:        "default",
+		Name:             "snapshot-work",
+		UID:              "stale-delete-uid",
+		ConflictingLabel: "owner",
+		PreviousValue:    "previous-node",
+		DesiredValue:     "node",
+	})
+
+	event := requireRecordedEvent(t, recorder)
+	assert.Contains(t, event, "Replaced stale delete Job default/snapshot-work")
+	assert.Contains(t, event, "conflicting label \"owner\"")
+	assert.Contains(t, event, "previous value \"previous-node\"")
+	assert.Contains(t, event, "desired value \"node\"")
+	assert.NotContains(t, event, "desired provider")
+	assert.NotContains(t, event, "previous provider")
+}
+
+func requireRecordedEvent(t *testing.T, recorder *record.FakeRecorder) string {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		return event
+	default:
+		t.Fatal("expected Kubernetes event")
+		return ""
+	}
+}
+
+func assertNoRecordedEvent(t *testing.T, recorder *record.FakeRecorder) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected Kubernetes event: %s", event)
+	default:
+	}
 }
 
 func TestTarballExportFailureWaitsForCleanupBeforeRetry(t *testing.T) {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -365,7 +365,8 @@ func TestStaleDeleteJobReplacementEmitsEvent(t *testing.T) {
 
 	deleted, err = reconciler.isTarballDeleted(context.Background(), chainNode, snapshot)
 	assert.False(t, deleted)
-	require.ErrorIs(t, err, datasnapshot.ErrStaleJobReplaced)
+	require.ErrorIs(t, err, datasnapshot.ErrStaleJobTerminating)
+	assert.NotErrorIs(t, err, datasnapshot.ErrStaleJobReplaced)
 	var replacement *datasnapshot.StaleJobReplacedError
 	assert.False(t, errors.As(err, &replacement), "waiting for a terminating Job must not report another successful replacement")
 	assert.Equal(t, 1, deleteCalls)

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -218,7 +218,7 @@ func TestStaleUploadJobReplacementDoesNotChargeFailedAttempt(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "-00010101000000-upload",
 			Namespace: "default",
-			UID:       types.UID(strings.Repeat("u", 300)),
+			UID:       "11111111-2222-3333-4444-555555555555",
 			Labels:    map[string]string{"exporter": "s3-exporter"},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: appsv1.GroupVersion.String(),
@@ -252,10 +252,45 @@ func TestStaleUploadJobReplacementDoesNotChargeFailedAttempt(t *testing.T) {
 	event := requireRecordedEvent(t, recorder)
 	assert.Contains(t, event, "Normal "+appsv1.ReasonSnapshotJobReplaced)
 	assert.Contains(t, event, "Replaced stale upload Job default/-00010101000000-upload")
+	assert.Contains(t, event, "11111111-2222-3333-4444-555555555555")
 	assert.Contains(t, event, "s3-exporter")
 	assert.Contains(t, event, "gcs-exporter")
 	assert.NotContains(t, event, "desired-gcs-credentials")
 	assert.NotContains(t, event, "credentials.json")
+	message := strings.TrimPrefix(event, "Normal "+appsv1.ReasonSnapshotJobReplaced+" ")
+	assert.LessOrEqual(t, len(message), 256)
+}
+
+func TestTarballExportReplacementDoesNotEmitWarningEvent(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{recorder: recorder}
+	replacement := &datasnapshot.StaleJobReplacedError{
+		Purpose: "upload",
+		Name:    "snapshot-upload",
+		UID:     "11111111-2222-3333-4444-555555555555",
+	}
+
+	reconciler.recordTarballExportError(&appsv1.ChainNode{}, replacement)
+
+	assertNoRecordedEvent(t, recorder)
+}
+
+func TestSnapshotJobReplacementEventPreservesUIDBeforeTruncation(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{recorder: recorder}
+	uid := types.UID("11111111-2222-3333-4444-555555555555")
+	reconciler.recordSnapshotJobReplacement(&appsv1.ChainNode{}, &datasnapshot.StaleJobReplacedError{
+		Purpose:          "upload",
+		Namespace:        strings.Repeat("n", 63),
+		Name:             strings.Repeat("j", 63),
+		UID:              uid,
+		ConflictingLabel: "exporter",
+		PreviousValue:    strings.Repeat("previous-provider-", 20),
+		DesiredValue:     strings.Repeat("desired-provider-", 20),
+	})
+
+	event := requireRecordedEvent(t, recorder)
+	assert.Contains(t, event, string(uid))
 	message := strings.TrimPrefix(event, "Normal "+appsv1.ReasonSnapshotJobReplaced+" ")
 	assert.LessOrEqual(t, len(message), 256)
 }

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -33,11 +34,39 @@ const (
 	typeDelete = "delete"
 )
 
-// ErrStaleJobReplaced reports that an existing snapshot Job was deleted because its labels could not
-// converge to the desired ones — the exporter label encodes the export provider, so a Job left behind
-// by a previous provider never matches again. Callers should requeue instead of failing the reconcile:
-// the replacement Job is created once the stale one is gone.
+// ErrStaleJobReplaced reports that an existing snapshot Job is being deleted because it cannot
+// converge to the desired state. Callers should requeue instead of failing the reconcile; the
+// replacement Job is created once the stale one is gone.
 var ErrStaleJobReplaced = errors.New("stale snapshot job deleted; it will be recreated")
+
+// StaleJobReplacedError describes a stale Job whose deletion was successfully requested.
+type StaleJobReplacedError struct {
+	Purpose          string
+	Namespace        string
+	Name             string
+	UID              types.UID
+	ConflictingLabel string
+	PreviousValue    string
+	DesiredValue     string
+}
+
+func (err *StaleJobReplacedError) Error() string {
+	if err.ProviderSwitch() {
+		return fmt.Sprintf("%s job %s/%s (UID %s) for exporter %q replaced by desired exporter %q: %v",
+			err.Purpose, err.Namespace, err.Name, err.UID, err.PreviousValue, err.DesiredValue, ErrStaleJobReplaced)
+	}
+	return fmt.Sprintf("%s job %s/%s (UID %s) had conflicting label %q: previous value %q, desired value %q: %v",
+		err.Purpose, err.Namespace, err.Name, err.UID, err.ConflictingLabel, err.PreviousValue, err.DesiredValue, ErrStaleJobReplaced)
+}
+
+func (err *StaleJobReplacedError) Unwrap() error {
+	return ErrStaleJobReplaced
+}
+
+// ProviderSwitch reports whether the exporter label caused the replacement.
+func (err *StaleJobReplacedError) ProviderSwitch() bool {
+	return err.ConflictingLabel == labelExporter
+}
 
 type SnapshotProvider interface {
 	CreateSnapshot(context.Context, string, *snapshotv1.VolumeSnapshot) error
@@ -95,13 +124,24 @@ func ensureSnapshotJob(
 	}
 	for key, value := range desired.Labels {
 		if job.Labels[key] != value {
+			if job.DeletionTimestamp != nil {
+				return nil, false, fmt.Errorf("stale %s job %s/%s is terminating: %w", purpose, job.Namespace, job.Name, ErrStaleJobReplaced)
+			}
 			// Labels are set at creation and never updated, so a mismatch can never converge — it means
 			// the Job was created for a different desired state (e.g. another export provider). Exports
 			// and deletions are idempotent, so drop the stale Job and let the next reconcile recreate it.
 			if err = deleteSnapshotJob(ctx, client, job); err != nil {
 				return nil, false, fmt.Errorf("delete stale %s job %s/%s: %w", purpose, job.Namespace, job.Name, err)
 			}
-			return nil, false, fmt.Errorf("%s job %s/%s had conflicting label %s: %w", purpose, job.Namespace, job.Name, key, ErrStaleJobReplaced)
+			return nil, false, &StaleJobReplacedError{
+				Purpose:          purpose,
+				Namespace:        job.Namespace,
+				Name:             job.Name,
+				UID:              job.UID,
+				ConflictingLabel: key,
+				PreviousValue:    job.Labels[key],
+				DesiredValue:     value,
+			}
 		}
 	}
 	return job, false, nil
@@ -135,11 +175,21 @@ func uploadJobStatus(
 			job.Namespace, job.Name, owner.GetName())
 	}
 	if job.Labels[labelExporter] != exporter {
+		if job.DeletionTimestamp != nil {
+			return "", fmt.Errorf("stale upload job %s/%s is terminating: %w", job.Namespace, job.Name, ErrStaleJobReplaced)
+		}
 		if err = deleteSnapshotJob(ctx, client, job); err != nil {
 			return "", fmt.Errorf("delete stale upload job %s/%s: %w", job.Namespace, job.Name, err)
 		}
-		return "", fmt.Errorf("upload job %s/%s belongs to exporter %q, not %q: %w",
-			job.Namespace, job.Name, job.Labels[labelExporter], exporter, ErrStaleJobReplaced)
+		return "", &StaleJobReplacedError{
+			Purpose:          typeUpload,
+			Namespace:        job.Namespace,
+			Name:             job.Name,
+			UID:              job.UID,
+			ConflictingLabel: labelExporter,
+			PreviousValue:    job.Labels[labelExporter],
+			DesiredValue:     exporter,
+		}
 	}
 	return snapshotJobStatus(job), nil
 }
@@ -150,7 +200,7 @@ func deleteSnapshotJob(ctx context.Context, client kubernetes.Interface, job *ba
 		PropagationPolicy: &propagation,
 		Preconditions:     &metav1.Preconditions{UID: &job.UID},
 	})
-	if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -39,6 +39,10 @@ const (
 // replacement Job is created once the stale one is gone.
 var ErrStaleJobReplaced = errors.New("stale snapshot job deleted; it will be recreated")
 
+// ErrStaleJobTerminating reports that a previously replaced stale Job still exists with a deletion
+// timestamp. Callers should use a delayed requeue while foreground deletion finishes.
+var ErrStaleJobTerminating = errors.New("stale snapshot job is still terminating")
+
 // StaleJobReplacedError describes a stale Job whose deletion was successfully requested.
 type StaleJobReplacedError struct {
 	Purpose          string
@@ -125,7 +129,7 @@ func ensureSnapshotJob(
 	for key, value := range desired.Labels {
 		if job.Labels[key] != value {
 			if job.DeletionTimestamp != nil {
-				return nil, false, fmt.Errorf("stale %s job %s/%s is terminating: %w", purpose, job.Namespace, job.Name, ErrStaleJobReplaced)
+				return nil, false, fmt.Errorf("stale %s job %s/%s is terminating: %w", purpose, job.Namespace, job.Name, ErrStaleJobTerminating)
 			}
 			// Labels are set at creation and never updated, so a mismatch can never converge — it means
 			// the Job was created for a different desired state (e.g. another export provider). Exports
@@ -176,7 +180,7 @@ func uploadJobStatus(
 	}
 	if job.Labels[labelExporter] != exporter {
 		if job.DeletionTimestamp != nil {
-			return "", fmt.Errorf("stale upload job %s/%s is terminating: %w", job.Namespace, job.Name, ErrStaleJobReplaced)
+			return "", fmt.Errorf("stale upload job %s/%s is terminating: %w", job.Namespace, job.Name, ErrStaleJobTerminating)
 		}
 		if err = deleteSnapshotJob(ctx, client, job); err != nil {
 			return "", fmt.Errorf("delete stale upload job %s/%s: %w", job.Namespace, job.Name, err)

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
@@ -62,7 +63,7 @@ func TestEnsureSnapshotJobReplacesJobWithUnconvergeableLabels(t *testing.T) {
 	owner := testJobOwner()
 	client := fake.NewSimpleClientset(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "snapshot-delete",
+			Name:            "snapshot-work",
 			Namespace:       "default",
 			UID:             "stale-uid",
 			Labels:          map[string]string{labelExporter: "s3-exporter", labelOwner: "owner", labelType: typeDelete},
@@ -71,18 +72,77 @@ func TestEnsureSnapshotJobReplacesJobWithUnconvergeableLabels(t *testing.T) {
 	})
 
 	desired := desiredDeleteJob(owner, "gcs-exporter")
+	desired.Name = "snapshot-work"
 	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desired, "delete")
 	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	var replacement *StaleJobReplacedError
+	require.ErrorAs(t, err, &replacement)
+	assert.Equal(t, typeDelete, replacement.Purpose)
 	assert.ErrorContains(t, err, labelExporter)
 
 	// The stale Job is gone, so the next reconcile creates the desired one instead of erroring forever.
-	_, err = client.BatchV1().Jobs("default").Get(context.Background(), "snapshot-delete", metav1.GetOptions{})
+	_, err = client.BatchV1().Jobs("default").Get(context.Background(), "snapshot-work", metav1.GetOptions{})
 	assert.True(t, apierrors.IsNotFound(err))
 
 	job, created, err := ensureSnapshotJob(context.Background(), client, owner, desired, "delete")
 	require.NoError(t, err)
 	assert.True(t, created)
 	assert.Equal(t, "gcs-exporter", job.Labels[labelExporter])
+}
+
+func TestEnsureSnapshotJobReportsActualNonExporterLabelMismatch(t *testing.T) {
+	owner := testJobOwner()
+	client := fake.NewSimpleClientset(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "snapshot-work",
+		Namespace: "default",
+		UID:       "stale-uid",
+		Labels: map[string]string{
+			labelExporter: "gcs-exporter",
+			labelOwner:    "previous-owner",
+			labelType:     typeDelete,
+		},
+		OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+	}})
+	desired := desiredDeleteJob(owner, "gcs-exporter")
+	desired.Name = "snapshot-work"
+
+	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desired, typeDelete)
+	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	var replacement *StaleJobReplacedError
+	require.ErrorAs(t, err, &replacement)
+	assert.Equal(t, typeDelete, replacement.Purpose)
+	assert.Equal(t, labelOwner, replacement.ConflictingLabel)
+	assert.Equal(t, "previous-owner", replacement.PreviousValue)
+	assert.Equal(t, owner.Name, replacement.DesiredValue)
+	assert.ErrorContains(t, err, labelOwner)
+	assert.ErrorContains(t, err, "previous-owner")
+	assert.ErrorContains(t, err, owner.Name)
+}
+
+func TestEnsureSnapshotJobWaitsForTerminatingOwnedJob(t *testing.T) {
+	owner := testJobOwner()
+	deletionTimestamp := metav1.Now()
+	client := fake.NewSimpleClientset(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:              "snapshot-work",
+		Namespace:         "default",
+		UID:               "stale-uid",
+		DeletionTimestamp: &deletionTimestamp,
+		Labels:            map[string]string{labelExporter: "s3-exporter", labelOwner: owner.Name, labelType: typeDelete},
+		OwnerReferences:   []metav1.OwnerReference{ownerReferenceTo(owner)},
+	}})
+	deleteCalls := 0
+	client.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		deleteCalls++
+		return false, nil, nil
+	})
+	desired := desiredDeleteJob(owner, "gcs-exporter")
+	desired.Name = "snapshot-work"
+
+	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desired, typeDelete)
+	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	var replacement *StaleJobReplacedError
+	assert.False(t, errors.As(err, &replacement), "a terminating Job was not replaced during this call")
+	assert.Zero(t, deleteCalls)
 }
 
 // TestUploadJobStatusRejectsOtherExportersJob covers the polling path. Upload Jobs are looked up by
@@ -93,7 +153,7 @@ func TestUploadJobStatusRejectsOtherExportersJob(t *testing.T) {
 	owner := testJobOwner()
 	client := fake.NewSimpleClientset(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "snapshot-upload",
+			Name:            "snapshot-work",
 			Namespace:       "default",
 			UID:             "stale-uid",
 			Labels:          map[string]string{labelExporter: "s3-exporter", labelType: typeUpload},
@@ -106,13 +166,57 @@ func TestUploadJobStatusRejectsOtherExportersJob(t *testing.T) {
 		},
 	})
 
-	_, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-upload", "gcs-exporter")
+	_, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-work", "gcs-exporter")
 	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	var replacement *StaleJobReplacedError
+	require.ErrorAs(t, err, &replacement)
+	assert.Equal(t, typeUpload, replacement.Purpose)
 	assert.ErrorContains(t, err, "s3-exporter")
 
 	// Removed, so the next reconcile starts a real upload against the configured provider.
-	_, err = client.BatchV1().Jobs("default").Get(context.Background(), "snapshot-upload", metav1.GetOptions{})
+	_, err = client.BatchV1().Jobs("default").Get(context.Background(), "snapshot-work", metav1.GetOptions{})
 	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestUploadJobStatusWaitsForTerminatingOwnedJob(t *testing.T) {
+	owner := testJobOwner()
+	deletionTimestamp := metav1.Now()
+	client := fake.NewSimpleClientset(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:              "snapshot-work",
+		Namespace:         "default",
+		UID:               "stale-uid",
+		DeletionTimestamp: &deletionTimestamp,
+		Labels:            map[string]string{labelExporter: "s3-exporter", labelType: typeUpload},
+		OwnerReferences:   []metav1.OwnerReference{ownerReferenceTo(owner)},
+	}})
+	deleteCalls := 0
+	client.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		deleteCalls++
+		return false, nil, nil
+	})
+
+	_, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-work", "gcs-exporter")
+	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	var replacement *StaleJobReplacedError
+	assert.False(t, errors.As(err, &replacement), "a terminating Job was not replaced during this call")
+	assert.Zero(t, deleteCalls)
+}
+
+func TestUploadJobStatusDoesNotTreatCurrentExporterTerminationAsReplacement(t *testing.T) {
+	owner := testJobOwner()
+	deletionTimestamp := metav1.Now()
+	client := fake.NewSimpleClientset(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:              "snapshot-work",
+		Namespace:         "default",
+		UID:               "current-uid",
+		DeletionTimestamp: &deletionTimestamp,
+		Labels:            map[string]string{labelExporter: "gcs-exporter", labelType: typeUpload},
+		OwnerReferences:   []metav1.OwnerReference{ownerReferenceTo(owner)},
+	}})
+
+	status, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-work", "gcs-exporter")
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
 }
 
 // TestUploadJobStatusNeverDeletesAnotherOwnersJob guards a cross-node hazard: tarball names derive from
@@ -221,6 +325,32 @@ func TestEnsureSnapshotJobReportsDeleteFailureOfStaleJob(t *testing.T) {
 
 	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desiredDeleteJob(owner, "gcs-exporter"), "delete")
 	require.ErrorContains(t, err, "delete refused")
+	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
+}
+
+func TestEnsureSnapshotJobReportsUIDPreconditionConflict(t *testing.T) {
+	owner := testJobOwner()
+	client := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-work",
+			Namespace:       "default",
+			UID:             "stale-uid",
+			Labels:          map[string]string{labelExporter: "s3-exporter", labelOwner: owner.Name, labelType: typeDelete},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		},
+	})
+	client.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewConflict(
+			schema.GroupResource{Group: batchv1.GroupName, Resource: "jobs"},
+			"snapshot-work",
+			errors.New("UID precondition did not match"),
+		)
+	})
+	desired := desiredDeleteJob(owner, "gcs-exporter")
+	desired.Name = "snapshot-work"
+
+	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desired, typeDelete)
+	require.True(t, apierrors.IsConflict(err))
 	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
 }
 

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -139,7 +139,8 @@ func TestEnsureSnapshotJobWaitsForTerminatingOwnedJob(t *testing.T) {
 	desired.Name = "snapshot-work"
 
 	_, _, err := ensureSnapshotJob(context.Background(), client, owner, desired, typeDelete)
-	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	require.ErrorIs(t, err, ErrStaleJobTerminating)
+	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
 	var replacement *StaleJobReplacedError
 	assert.False(t, errors.As(err, &replacement), "a terminating Job was not replaced during this call")
 	assert.Zero(t, deleteCalls)
@@ -196,7 +197,8 @@ func TestUploadJobStatusWaitsForTerminatingOwnedJob(t *testing.T) {
 	})
 
 	_, err := uploadJobStatus(context.Background(), client, owner, "default", "snapshot-work", "gcs-exporter")
-	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	require.ErrorIs(t, err, ErrStaleJobTerminating)
+	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
 	var replacement *StaleJobReplacedError
 	assert.False(t, errors.As(err, &replacement), "a terminating Job was not replaced during this call")
 	assert.Zero(t, deleteCalls)


### PR DESCRIPTION
## Summary
- emit `SnapshotJobReplaced` on the owning ChainNode when stale upload or delete Jobs are successfully replaced
- include bounded, credential-free diagnostics with purpose, Job identity, provider or conflicting-label transition, and UID
- avoid duplicate events/deletes while foreground deletion is still pending and propagate UID-precondition conflicts

## Tests
- `go test ./internal/datasnapshot ./internal/controllers/chainnode -count=1`
- `make test.unit`

Closes #85

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit Normal `SnapshotJobReplaced` events on the owning `ChainNode` when stale snapshot upload/delete Jobs are replaced, with bounded diagnostics that preserve UID. Back off while stale Jobs are terminating to avoid duplicate work and events, and suppress export warnings for both replacements and terminating Jobs.

- **Bug Fixes**
  - Added `StaleJobReplacedError` with safe details (purpose, ns/name, conflicting label or provider switch, UID); messages are bounded and omit credentials while preserving UID.
  - Centralized eventing and backoff: emit a single Normal `SnapshotJobReplaced` only when a replacement occurs (export, status, delete paths), tailor messages for provider switches vs other label mismatches, suppress `ReasonTarballExportError` warnings for replacements and while stale Jobs are terminating, and requeue after the snapshot check period while Jobs are terminating.
  - Propagate UID precondition conflicts from Job deletions without emitting events; removed the previous reconcile-loop event; expanded tests for upload/delete replacements, UID preservation under truncation, non-exporter label mismatches, no events or warnings during termination, and conflict pass-through.

<sup>Written for commit 89246383b90f159e1afc6afd3657c82118bcde56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

