### PR TITLE
fix: prevent snapshot exporter pod leaks

### DIFF
--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -334,7 +334,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 						"Deleted expired PVC snapshot %s", snapshot.GetName(),
 					)
 					if deleteTarball {
-						r.cleanUpTarballDeletion(ctx, chainNode, &snapshot)
+						if err = r.cleanUpTarballDeletion(ctx, chainNode, &snapshot); err != nil {
+							return err
+						}
 						r.recorder.Eventf(chainNode,
 							corev1.EventTypeNormal,
 							appsv1.ReasonTarballDeleted,
@@ -387,7 +389,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 				"Deleted PVC snapshot %s (exceeded retain count of %d)", snapshot.GetName(), *retainCount,
 			)
 			if deleteTarball {
-				r.cleanUpTarballDeletion(ctx, chainNode, &snapshot)
+				if err = r.cleanUpTarballDeletion(ctx, chainNode, &snapshot); err != nil {
+					return err
+				}
 				r.recorder.Eventf(chainNode,
 					corev1.EventTypeNormal,
 					appsv1.ReasonTarballDeleted,
@@ -905,15 +909,15 @@ func (r *Reconciler) isTarballDeleted(ctx context.Context, chainNode *appsv1.Cha
 	return status == datasnapshot.SnapshotSucceeded, nil
 }
 
-func (r *Reconciler) cleanUpTarballDeletion(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) {
+func (r *Reconciler) cleanUpTarballDeletion(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) error {
 	exporter, err := r.getTarballExportProvider(chainNode)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to get tarball exporter for delete Job cleanup", "snapshot", snapshot.GetName())
-		return
+		return err
 	}
 	if err = exporter.CleanupSnapshotDeletion(ctx, getTarballName(chainNode, snapshot)); err != nil {
-		log.FromContext(ctx).Error(err, "failed to clean up tarball delete Job", "snapshot", snapshot.GetName())
+		return err
 	}
+	return nil
 }
 
 func getTarballName(chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) string {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -145,6 +145,63 @@ func TestGetTarballExportProviderUsesConfiguredDataExporterImage(t *testing.T) {
 	}
 }
 
+func TestCleanUpTarballDeletionWaitsForTerminatingJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	node := &appsv1.ChainNode{
+		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node",
+			Namespace: "default",
+			UID:       "node-uid",
+		},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency: "24h",
+			ExportTarball: &appsv1.ExportTarballConfig{
+				GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"},
+			},
+		}}},
+		Status: appsv1.ChainNodeStatus{ChainID: "chain-1"},
+	}
+	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{
+		Name:              "snapshot",
+		Namespace:         "default",
+		CreationTimestamp: metav1.NewTime(time.Date(2026, time.August, 2, 0, 0, 0, 0, time.UTC)),
+	}}
+	deletionTimestamp := metav1.Now()
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:              getTarballName(node, snapshot) + "-delete",
+		Namespace:         "default",
+		UID:               "delete-job-uid",
+		DeletionTimestamp: &deletionTimestamp,
+		Labels: map[string]string{
+			"exporter": "gcs-exporter",
+			"owner":    node.Name,
+			"type":     "delete",
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: node.APIVersion,
+			Kind:       node.Kind,
+			Name:       node.Name,
+			UID:        node.UID,
+			Controller: ptr.To(true),
+		}},
+	}}
+	clientSet := fake.NewSimpleClientset(job)
+	reconciler := &Reconciler{
+		Scheme:            scheme,
+		snapshotClientSet: clientSet,
+		opts:              &controllers.ControllerRunOptions{},
+	}
+
+	err := reconciler.cleanUpTarballDeletion(context.Background(), node, snapshot)
+	require.ErrorIs(t, err, datasnapshot.ErrStaleJobTerminating)
+	for _, action := range clientSet.Actions() {
+		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "jobs")
+	}
+}
+
 func TestRecordTarballExportFailureStopsAtRetryLimit(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, snapshotv1.AddToScheme(scheme))

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -327,11 +327,7 @@ func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus
 }
 
 func (gcs *GCS) CleanupSnapshotDeletion(ctx context.Context, name string) error {
-	err := gcs.Client.BatchV1().Jobs(gcs.Owner.GetNamespace()).Delete(ctx, fmt.Sprintf("%s-delete", name), metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	return nil
+	return cleanupSnapshotDeletionJob(ctx, gcs.Client, gcs.Owner, name, gcsExporter)
 }
 
 func (gcs *GCS) ListSnapshots(ctx context.Context) ([]string, error) {

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -198,6 +198,37 @@ func TestGCSDeleteSnapshotReportsTerminalStatus(t *testing.T) {
 	}
 }
 
+func TestGCSCleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
+	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-delete",
+			Namespace:       "default",
+			UID:             "gcs-delete-uid",
+			Labels:          map[string]string{labelExporter: gcsExporter, labelType: typeDelete},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(provider.Owner)},
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+		}}},
+	}
+	_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), job, metav1.CreateOptions{})
+	require.NoError(t, err)
+	client := provider.Client.(*fake.Clientset)
+	actionCount := len(client.Actions())
+
+	require.NoError(t, provider.CleanupSnapshotDeletion(context.Background(), "snapshot"))
+
+	deleteAction := requireJobDeleteAction(t, client.Actions()[actionCount:])
+	assert.Equal(t, job.Name, deleteAction.GetName())
+	options := deleteAction.GetDeleteOptions()
+	require.NotNil(t, options.PropagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationForeground, *options.PropagationPolicy)
+	require.NotNil(t, options.Preconditions)
+	require.NotNil(t, options.Preconditions.UID)
+	assert.Equal(t, job.UID, *options.Preconditions.UID)
+}
+
 func TestGCSListSnapshotsIncludesDeletionJobs(t *testing.T) {
 	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
 	status, err := provider.DeleteSnapshot(context.Background(), "snapshot")

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -224,11 +224,7 @@ func (provider *S3) DeleteSnapshot(ctx context.Context, name string) (SnapshotSt
 }
 
 func (provider *S3) CleanupSnapshotDeletion(ctx context.Context, name string) error {
-	err := provider.Client.BatchV1().Jobs(provider.Owner.GetNamespace()).Delete(ctx, fmt.Sprintf("%s-delete", name), metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	return nil
+	return cleanupSnapshotDeletionJob(ctx, provider.Client, provider.Owner, name, s3Exporter)
 }
 
 func (provider *S3) cleanUp(ctx context.Context, name string) error {

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -179,6 +179,40 @@ func TestS3DeleteSnapshotReportsTerminalStatus(t *testing.T) {
 	}
 }
 
+func TestS3CleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
+	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{
+		Bucket: "snapshots",
+		Region: "eu-west-1",
+	}})
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshot-delete",
+			Namespace:       "default",
+			UID:             "s3-delete-uid",
+			Labels:          map[string]string{labelExporter: s3Exporter, labelType: typeDelete},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(provider.Owner)},
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+		}}},
+	}
+	_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), job, metav1.CreateOptions{})
+	require.NoError(t, err)
+	client := provider.Client.(*fake.Clientset)
+	actionCount := len(client.Actions())
+
+	require.NoError(t, provider.CleanupSnapshotDeletion(context.Background(), "snapshot"))
+
+	deleteAction := requireJobDeleteAction(t, client.Actions()[actionCount:])
+	assert.Equal(t, job.Name, deleteAction.GetName())
+	options := deleteAction.GetDeleteOptions()
+	require.NotNil(t, options.PropagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationForeground, *options.PropagationPolicy)
+	require.NotNil(t, options.Preconditions)
+	require.NotNil(t, options.Preconditions.UID)
+	assert.Equal(t, job.UID, *options.Preconditions.UID)
+}
+
 func TestS3ListSnapshotsIncludesDeletionJobs(t *testing.T) {
 	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}})
 	status, err := provider.DeleteSnapshot(context.Background(), "snapshot")

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -198,6 +198,43 @@ func uploadJobStatus(
 	return snapshotJobStatus(job), nil
 }
 
+func cleanupSnapshotDeletionJob(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	name, exporter string,
+) error {
+	namespace := owner.GetNamespace()
+	jobName := fmt.Sprintf("%s-delete", name)
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get snapshot deletion job %s/%s: %w", namespace, jobName, err)
+	}
+	if !metav1.IsControlledBy(job, owner) {
+		return fmt.Errorf("snapshot deletion job %s/%s is not controlled by snapshot owner %s",
+			job.Namespace, job.Name, owner.GetName())
+	}
+	if job.DeletionTimestamp != nil {
+		return fmt.Errorf("snapshot deletion job %s/%s is terminating: %w",
+			job.Namespace, job.Name, ErrStaleJobTerminating)
+	}
+	if actual := job.Labels[labelExporter]; actual != exporter {
+		return fmt.Errorf("snapshot deletion job %s/%s has exporter label %q, expected %q",
+			job.Namespace, job.Name, actual, exporter)
+	}
+	if actual := job.Labels[labelType]; actual != typeDelete {
+		return fmt.Errorf("snapshot deletion job %s/%s has type label %q, expected %q",
+			job.Namespace, job.Name, actual, typeDelete)
+	}
+	if err = deleteSnapshotJob(ctx, client, job); err != nil {
+		return fmt.Errorf("delete snapshot deletion job %s/%s: %w", job.Namespace, job.Name, err)
+	}
+	return nil
+}
+
 func deleteSnapshotJob(ctx context.Context, client kubernetes.Interface, job *batchv1.Job) error {
 	propagation := metav1.DeletePropagationForeground
 	err := client.BatchV1().Jobs(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -221,13 +221,29 @@ func cleanupSnapshotDeletionJob(
 		return fmt.Errorf("snapshot deletion job %s/%s is terminating: %w",
 			job.Namespace, job.Name, ErrStaleJobTerminating)
 	}
-	if actual := job.Labels[labelExporter]; actual != exporter {
-		return fmt.Errorf("snapshot deletion job %s/%s has exporter label %q, expected %q",
-			job.Namespace, job.Name, actual, exporter)
-	}
-	if actual := job.Labels[labelType]; actual != typeDelete {
-		return fmt.Errorf("snapshot deletion job %s/%s has type label %q, expected %q",
-			job.Namespace, job.Name, actual, typeDelete)
+	for _, expected := range []struct {
+		label   string
+		desired string
+	}{
+		{label: labelExporter, desired: exporter},
+		{label: labelType, desired: typeDelete},
+	} {
+		actual := job.Labels[expected.label]
+		if actual == expected.desired {
+			continue
+		}
+		if err = deleteSnapshotJob(ctx, client, job); err != nil {
+			return fmt.Errorf("delete stale snapshot deletion job %s/%s: %w", job.Namespace, job.Name, err)
+		}
+		return &StaleJobReplacedError{
+			Purpose:          typeDelete,
+			Namespace:        job.Namespace,
+			Name:             job.Name,
+			UID:              job.UID,
+			ConflictingLabel: expected.label,
+			PreviousValue:    actual,
+			DesiredValue:     expected.desired,
+		}
 	}
 	if err = deleteSnapshotJob(ctx, client, job); err != nil {
 		return fmt.Errorf("delete snapshot deletion job %s/%s: %w", job.Namespace, job.Name, err)

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -382,37 +382,53 @@ func TestCleanupSnapshotDeletionJobWaitsForTerminatingJob(t *testing.T) {
 	}
 }
 
-func TestCleanupSnapshotDeletionJobRejectsForeignJobs(t *testing.T) {
+func TestCleanupSnapshotDeletionJobRejectsForeignJob(t *testing.T) {
 	owner := testJobOwner()
 	foreignOwner := &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 		ObjectMeta: metav1.ObjectMeta{Name: "other-owner", Namespace: "default", UID: "other-owner-uid"},
 	}
+	job := desiredDeleteJob(owner, gcsExporter)
+	job.UID = "existing-job-uid"
+	job.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(foreignOwner)}
+	client := fake.NewSimpleClientset(job)
+
+	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+	require.ErrorContains(t, err, "not controlled by snapshot owner")
+
+	_, err = client.BatchV1().Jobs("default").Get(context.Background(), job.Name, metav1.GetOptions{})
+	require.NoError(t, err, "foreign Job must survive")
+	for _, action := range client.Actions() {
+		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "jobs")
+	}
+}
+
+func TestCleanupSnapshotDeletionJobReplacesMislabeledOwnedJob(t *testing.T) {
+	owner := testJobOwner()
 	tests := []struct {
-		name        string
-		mutate      func(*batchv1.Job)
-		wantMessage string
+		name         string
+		mutate       func(*batchv1.Job)
+		wantLabel    string
+		wantPrevious string
+		wantDesired  string
 	}{
-		{
-			name: "foreign owner",
-			mutate: func(job *batchv1.Job) {
-				job.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(foreignOwner)}
-			},
-			wantMessage: "not controlled by snapshot owner",
-		},
 		{
 			name: "wrong exporter",
 			mutate: func(job *batchv1.Job) {
 				job.Labels[labelExporter] = s3Exporter
 			},
-			wantMessage: `has exporter label "s3-exporter", expected "gcs-exporter"`,
+			wantLabel:    labelExporter,
+			wantPrevious: s3Exporter,
+			wantDesired:  gcsExporter,
 		},
 		{
 			name: "wrong type",
 			mutate: func(job *batchv1.Job) {
 				job.Labels[labelType] = typeUpload
 			},
-			wantMessage: `has type label "upload", expected "delete"`,
+			wantLabel:    labelType,
+			wantPrevious: typeUpload,
+			wantDesired:  typeDelete,
 		},
 	}
 
@@ -424,13 +440,16 @@ func TestCleanupSnapshotDeletionJobRejectsForeignJobs(t *testing.T) {
 			client := fake.NewSimpleClientset(job)
 
 			err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
-			require.ErrorContains(t, err, tt.wantMessage)
+			require.ErrorIs(t, err, ErrStaleJobReplaced)
+			var replacement *StaleJobReplacedError
+			require.ErrorAs(t, err, &replacement)
+			assert.Equal(t, typeDelete, replacement.Purpose)
+			assert.Equal(t, tt.wantLabel, replacement.ConflictingLabel)
+			assert.Equal(t, tt.wantPrevious, replacement.PreviousValue)
+			assert.Equal(t, tt.wantDesired, replacement.DesiredValue)
 
 			_, err = client.BatchV1().Jobs("default").Get(context.Background(), job.Name, metav1.GetOptions{})
-			require.NoError(t, err, "foreign or mislabeled Job must survive")
-			for _, action := range client.Actions() {
-				assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "jobs")
-			}
+			assert.True(t, apierrors.IsNotFound(err), "mislabeled owned Job must be deleted")
 		})
 	}
 }

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -356,6 +357,117 @@ func TestEnsureSnapshotJobReportsUIDPreconditionConflict(t *testing.T) {
 	assert.NotErrorIs(t, err, ErrStaleJobReplaced)
 }
 
+func TestCleanupSnapshotDeletionJobTreatsNotFoundAsSuccess(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	owner := testJobOwner()
+
+	require.NoError(t, cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter))
+	for _, action := range client.Actions() {
+		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "jobs")
+	}
+}
+
+func TestCleanupSnapshotDeletionJobWaitsForTerminatingJob(t *testing.T) {
+	owner := testJobOwner()
+	job := desiredDeleteJob(owner, gcsExporter)
+	job.UID = "existing-job-uid"
+	job.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	client := fake.NewSimpleClientset(job)
+
+	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+	require.ErrorIs(t, err, ErrStaleJobTerminating)
+
+	for _, action := range client.Actions() {
+		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "jobs")
+	}
+}
+
+func TestCleanupSnapshotDeletionJobRejectsForeignJobs(t *testing.T) {
+	owner := testJobOwner()
+	foreignOwner := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "other-owner", Namespace: "default", UID: "other-owner-uid"},
+	}
+	tests := []struct {
+		name        string
+		mutate      func(*batchv1.Job)
+		wantMessage string
+	}{
+		{
+			name: "foreign owner",
+			mutate: func(job *batchv1.Job) {
+				job.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(foreignOwner)}
+			},
+			wantMessage: "not controlled by snapshot owner",
+		},
+		{
+			name: "wrong exporter",
+			mutate: func(job *batchv1.Job) {
+				job.Labels[labelExporter] = s3Exporter
+			},
+			wantMessage: `has exporter label "s3-exporter", expected "gcs-exporter"`,
+		},
+		{
+			name: "wrong type",
+			mutate: func(job *batchv1.Job) {
+				job.Labels[labelType] = typeUpload
+			},
+			wantMessage: `has type label "upload", expected "delete"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := desiredDeleteJob(owner, gcsExporter)
+			job.UID = "existing-job-uid"
+			tt.mutate(job)
+			client := fake.NewSimpleClientset(job)
+
+			err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+			require.ErrorContains(t, err, tt.wantMessage)
+
+			_, err = client.BatchV1().Jobs("default").Get(context.Background(), job.Name, metav1.GetOptions{})
+			require.NoError(t, err, "foreign or mislabeled Job must survive")
+			for _, action := range client.Actions() {
+				assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "jobs")
+			}
+		})
+	}
+}
+
+func TestCleanupSnapshotDeletionJobReportsGetFailure(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("get refused")
+	})
+
+	err := cleanupSnapshotDeletionJob(context.Background(), client, testJobOwner(), "snapshot", gcsExporter)
+	require.ErrorContains(t, err, "get snapshot deletion job default/snapshot-delete")
+	require.ErrorContains(t, err, "get refused")
+}
+
+func TestCleanupSnapshotDeletionJobReportsUIDPreconditionConflict(t *testing.T) {
+	owner := testJobOwner()
+	job := desiredDeleteJob(owner, gcsExporter)
+	job.UID = "existing-job-uid"
+	client := fake.NewSimpleClientset(job)
+	client.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewConflict(
+			schema.GroupResource{Group: batchv1.GroupName, Resource: "jobs"},
+			job.Name,
+			errors.New("UID precondition did not match"),
+		)
+	})
+
+	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+	require.True(t, apierrors.IsConflict(err))
+	require.ErrorContains(t, err, "delete snapshot deletion job default/snapshot-delete")
+	require.ErrorContains(t, err, "UID precondition did not match")
+
+	_, err = client.BatchV1().Jobs("default").Get(context.Background(), job.Name, metav1.GetOptions{})
+	require.NoError(t, err, "replacement Job must survive a UID precondition conflict")
+}
+
 func testJobOwner() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
@@ -388,4 +500,17 @@ func desiredDeleteJob(owner *corev1.ConfigMap, exporter string) *batchv1.Job {
 			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
 		},
 	}
+}
+
+func requireJobDeleteAction(t *testing.T, actions []k8stesting.Action) k8stesting.DeleteAction {
+	t.Helper()
+	for _, action := range actions {
+		if action.GetVerb() == "delete" && action.GetResource().Resource == "jobs" {
+			deleteAction, ok := action.(k8stesting.DeleteAction)
+			require.True(t, ok)
+			return deleteAction
+		}
+	}
+	require.FailNow(t, "job delete action not found")
+	return nil
 }


### PR DESCRIPTION
## Summary
- clean up completed S3 and GCS snapshot deletion Jobs with foreground propagation so their Pods are garbage-collected deterministically
- guard cleanup by controller ownership, exporter/type labels, and the exact observed Job UID
- wait for already-terminating Jobs instead of repeatedly deleting them or emitting duplicate completion events
- add regression coverage for both providers, foreign/mislabeled Jobs, NotFound, API failures, and UID conflicts

## Test plan
- `go test ./internal/datasnapshot -count=1`
- `go test ./internal/controllers/chainnode -count=1`
- `make test.unit`

## Risk
- foreground deletion can keep a completed Job visible while its Pods terminate; reconciliation now explicitly waits for that state
- live API-server garbage-collection behavior remains covered by CI/e2e rather than the fake clientset

Closes #82

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes exporter Pod leaks by cleaning up completed snapshot deletion Jobs safely using foreground deletion with a UID precondition, and makes the controller wait when a deletion Job is already terminating. Addresses #82 by ensuring Pods are garbage-collected and avoiding duplicate cleanup or premature events.

- **Bug Fixes**
  - Implemented `cleanupSnapshotDeletionJob` with owner check, label guard, foreground deletion, and UID precondition.
  - Treat NotFound as success; replace mislabeled owned Jobs; surface UID conflicts and API errors.
  - Controller now returns errors from `cleanUpTarballDeletion` and waits instead of re-deleting terminating Jobs; added tests for S3/GCS, terminating Jobs, foreign/mislabeled Jobs, API failures, and UID conflicts.

<sup>Written for commit c8308befc2c5d4ec192b0b04c9bf4eb2d479e797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

