### PR TITLE
fix: deduplicate archive deletion jobs

### DIFF
--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -499,6 +499,9 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 				"Failed deleting tarball %s; delete Job retained for inspection", job.Name,
 			)
 		case datasnapshot.SnapshotSucceeded:
+			if err = r.persistPendingTarballDeletionSuccess(ctx, chainNode, job.Name); err != nil {
+				return err
+			}
 			if err = datasnapshot.CleanupSnapshotDeletionResources(ctx, clientSet, chainNode, job); err != nil {
 				return err
 			}
@@ -508,6 +511,36 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 				"Deleted tarball %s", job.Name,
 			)
 		}
+	}
+	return nil
+}
+
+func (r *Reconciler) persistPendingTarballDeletionSuccess(
+	ctx context.Context,
+	chainNode *appsv1.ChainNode,
+	tarballName string,
+) error {
+	snapshots, err := r.listNodeSnapshots(ctx, chainNode)
+	if err != nil {
+		return err
+	}
+	for i := range snapshots {
+		snapshot := &snapshots[i]
+		baseName := fmt.Sprintf("%s-%s", chainNode.Status.ChainID, snapshot.CreationTimestamp.UTC().Format(timeLayout))
+		if tarballName != baseName && !strings.HasPrefix(tarballName, baseName+"-") {
+			continue
+		}
+		if snapshot.Annotations == nil {
+			snapshot.Annotations = make(map[string]string)
+		}
+		if snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] == strconv.FormatBool(true) {
+			return nil
+		}
+		snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] = strconv.FormatBool(true)
+		if err = r.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("persist pending tarball deletion success: %w", err)
+		}
+		return nil
 	}
 	return nil
 }

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -41,6 +41,11 @@ const (
 
 func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv1.ChainNode, nodePodReady bool) error {
 	logger := log.FromContext(ctx)
+	if !chainNode.SnapshotsEnabled() || !chainNode.Spec.Persistence.Snapshots.ShouldExportTarballs() {
+		if err := r.reconcilePendingTarballDeletions(ctx, chainNode); err != nil {
+			return err
+		}
+	}
 
 	if !chainNode.SnapshotsEnabled() {
 		// Snapshot configuration can be removed while a snapshot annotation is
@@ -463,6 +468,47 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 		return r.startNewSnapshot(ctx, chainNode)
 	}
 
+	return nil
+}
+
+func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chainNode *appsv1.ChainNode) error {
+	if r.snapshotClientSet == nil && r.ClientSet == nil {
+		return nil
+	}
+	clientSet := kubernetes.Interface(r.ClientSet)
+	if r.snapshotClientSet != nil {
+		clientSet = r.snapshotClientSet
+	}
+	jobs, err := datasnapshot.ListSnapshotDeletionJobs(ctx, clientSet, chainNode)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if job.Purpose != datasnapshot.SnapshotJobDelete {
+			continue
+		}
+		status, reconcileErr := datasnapshot.ReconcileSnapshotDeletionJob(ctx, clientSet, chainNode, job)
+		if reconcileErr != nil {
+			return reconcileErr
+		}
+		switch status {
+		case datasnapshot.SnapshotFailed:
+			r.recorder.Eventf(chainNode,
+				corev1.EventTypeWarning,
+				appsv1.ReasonTarballDeleteError,
+				"Failed deleting tarball %s; delete Job retained for inspection", job.Name,
+			)
+		case datasnapshot.SnapshotSucceeded:
+			if err = datasnapshot.CleanupSnapshotDeletionResources(ctx, clientSet, chainNode, job); err != nil {
+				return err
+			}
+			r.recorder.Eventf(chainNode,
+				corev1.EventTypeNormal,
+				appsv1.ReasonTarballDeleted,
+				"Deleted tarball %s", job.Name,
+			)
+		}
+	}
 	return nil
 }
 

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -325,7 +325,8 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 						}
 					}
 					logger.Info("deleting expired pvc snapshot", "snapshot", snapshot.GetName(), "retention", snapshot.Annotations[controllers.AnnotationSnapshotRetention])
-					if err = r.Delete(ctx, &snapshot); err != nil {
+					snapshotUID := snapshot.UID
+					if err = r.Delete(ctx, &snapshot, client.Preconditions{UID: &snapshotUID}); err != nil {
 						return err
 					}
 					r.recorder.Eventf(chainNode,
@@ -380,7 +381,8 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 				}
 			}
 			logger.Info("deleting pvc snapshot due to retain count", "snapshot", snapshot.GetName(), "retain", *retainCount)
-			if err = r.Delete(ctx, &snapshot); err != nil {
+			snapshotUID := snapshot.UID
+			if err = r.Delete(ctx, &snapshot, client.Preconditions{UID: &snapshotUID}); err != nil {
 				return err
 			}
 			r.recorder.Eventf(chainNode,
@@ -411,10 +413,23 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 		if err != nil {
 			return err
 		}
-		for _, snapshot := range tarballSnapshots {
-			if !utils.SliceContains[string](tarballNames, snapshot) {
-				logger.Info("reconciling orphaned tarball deletion as volumesnapshot does not exist anymore", "snapshot", snapshot)
-				status, deleteErr := r.deleteTarballWithProvider(ctx, chainNode, exporter, snapshot)
+		for _, snapshotJob := range tarballSnapshots {
+			if !utils.SliceContains[string](tarballNames, snapshotJob.Name) {
+				logger.Info("reconciling orphaned tarball deletion as volumesnapshot does not exist anymore", "snapshot", snapshotJob.Name)
+				var status datasnapshot.SnapshotStatus
+				var deleteErr error
+				switch snapshotJob.Purpose {
+				case datasnapshot.SnapshotJobDelete:
+					status, deleteErr = exporter.GetSnapshotDeletionStatus(ctx, snapshotJob.Name)
+				case datasnapshot.SnapshotJobUpload:
+					if snapshotJob.Terminating {
+						continue
+					}
+					status, deleteErr = exporter.DeleteSnapshotForUpload(ctx, snapshotJob)
+					r.recordSnapshotJobReplacement(chainNode, deleteErr)
+				default:
+					continue
+				}
 				if deleteErr != nil {
 					return deleteErr
 				}
@@ -423,16 +438,16 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 					r.recorder.Eventf(chainNode,
 						corev1.EventTypeWarning,
 						appsv1.ReasonTarballDeleteError,
-						"Failed deleting orphaned tarball %s; delete Job retained for inspection", snapshot,
+						"Failed deleting orphaned tarball %s; delete Job retained for inspection", snapshotJob.Name,
 					)
 				case datasnapshot.SnapshotSucceeded:
-					if err = exporter.CleanupSnapshotDeletion(ctx, snapshot); err != nil {
+					if err = exporter.CleanupSnapshotDeletion(ctx, snapshotJob); err != nil {
 						return err
 					}
 					r.recorder.Eventf(chainNode,
 						corev1.EventTypeNormal,
 						appsv1.ReasonTarballDeleted,
-						"Deleted orphaned tarball %s", snapshot,
+						"Deleted orphaned tarball %s", snapshotJob.Name,
 					)
 				}
 			}
@@ -895,6 +910,10 @@ func (r *Reconciler) recordSnapshotJobReplacement(chainNode *appsv1.ChainNode, e
 }
 
 func (r *Reconciler) isTarballDeleted(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) (bool, error) {
+	if snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] == strconv.FormatBool(true) {
+		return true, nil
+	}
+
 	status, err := r.deleteTarball(ctx, chainNode, snapshot)
 	if err != nil {
 		return false, err
@@ -906,7 +925,24 @@ func (r *Reconciler) isTarballDeleted(ctx context.Context, chainNode *appsv1.Cha
 			"Failed deleting tarball %s; delete Job retained for inspection", getTarballName(chainNode, snapshot),
 		)
 	}
-	return status == datasnapshot.SnapshotSucceeded, nil
+	if status != datasnapshot.SnapshotSucceeded {
+		return false, nil
+	}
+
+	if snapshot.Annotations == nil {
+		snapshot.Annotations = make(map[string]string)
+	}
+	previous, hadPrevious := snapshot.Annotations[controllers.AnnotationTarballDeletionComplete]
+	snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] = strconv.FormatBool(true)
+	if err = r.Update(ctx, snapshot); err != nil {
+		if hadPrevious {
+			snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] = previous
+		} else {
+			delete(snapshot.Annotations, controllers.AnnotationTarballDeletionComplete)
+		}
+		return false, fmt.Errorf("persist tarball deletion success: %w", err)
+	}
+	return true, nil
 }
 
 func (r *Reconciler) cleanUpTarballDeletion(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) error {
@@ -914,7 +950,10 @@ func (r *Reconciler) cleanUpTarballDeletion(ctx context.Context, chainNode *apps
 	if err != nil {
 		return err
 	}
-	if err = exporter.CleanupSnapshotDeletion(ctx, getTarballName(chainNode, snapshot)); err != nil {
+	if err = exporter.CleanupSnapshotDeletion(ctx, datasnapshot.SnapshotJob{
+		Name:    getTarballName(chainNode, snapshot),
+		Purpose: datasnapshot.SnapshotJobDelete,
+	}); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -41,10 +41,12 @@ const (
 
 func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv1.ChainNode, nodePodReady bool) error {
 	logger := log.FromContext(ctx)
-	if !chainNode.SnapshotsEnabled() || !chainNode.Spec.Persistence.Snapshots.ShouldExportTarballs() {
-		if err := r.reconcilePendingTarballDeletions(ctx, chainNode); err != nil {
-			return err
-		}
+	pendingDeletion, err := r.reconcilePendingTarballDeletions(ctx, chainNode)
+	if err != nil {
+		return err
+	}
+	if pendingDeletion {
+		return nil
 	}
 
 	if !chainNode.SnapshotsEnabled() {
@@ -428,7 +430,13 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 				case datasnapshot.SnapshotJobDelete:
 					status, deleteErr = exporter.GetSnapshotDeletionStatus(ctx, snapshotJob)
 				case datasnapshot.SnapshotJobUpload:
-					cleanupJob, status, deleteErr = exporter.DeleteSnapshotForUpload(ctx, snapshotJob)
+					if snapshotJob.Exporter != "" {
+						cleanupJob, status, deleteErr = datasnapshot.DeleteSnapshotForUpload(
+							ctx, r.snapshotClientSet, chainNode, snapshotJob,
+						)
+					} else {
+						cleanupJob, status, deleteErr = exporter.DeleteSnapshotForUpload(ctx, snapshotJob)
+					}
 					r.recordSnapshotJobReplacement(chainNode, deleteErr)
 				default:
 					continue
@@ -471,9 +479,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 	return nil
 }
 
-func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chainNode *appsv1.ChainNode) error {
+func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chainNode *appsv1.ChainNode) (bool, error) {
 	if r.snapshotClientSet == nil && r.ClientSet == nil {
-		return nil
+		return false, nil
 	}
 	clientSet := kubernetes.Interface(r.ClientSet)
 	if r.snapshotClientSet != nil {
@@ -481,17 +489,20 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 	}
 	jobs, err := datasnapshot.ListSnapshotDeletionJobs(ctx, clientSet, chainNode)
 	if err != nil {
-		return err
+		return false, err
 	}
+	pending := false
 	for _, job := range jobs {
 		if job.Purpose != datasnapshot.SnapshotJobDelete {
 			continue
 		}
 		status, reconcileErr := datasnapshot.ReconcileSnapshotDeletionJob(ctx, clientSet, chainNode, job)
 		if reconcileErr != nil {
-			return reconcileErr
+			return pending, reconcileErr
 		}
 		switch status {
+		case datasnapshot.SnapshotActive:
+			pending = true
 		case datasnapshot.SnapshotFailed:
 			r.recorder.Eventf(chainNode,
 				corev1.EventTypeWarning,
@@ -500,10 +511,10 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 			)
 		case datasnapshot.SnapshotSucceeded:
 			if err = r.persistPendingTarballDeletionSuccess(ctx, chainNode, job.Name); err != nil {
-				return err
+				return pending, err
 			}
 			if err = datasnapshot.CleanupSnapshotDeletionResources(ctx, clientSet, chainNode, job); err != nil {
-				return err
+				return pending, err
 			}
 			r.recorder.Eventf(chainNode,
 				corev1.EventTypeNormal,
@@ -512,7 +523,7 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 			)
 		}
 	}
-	return nil
+	return pending, nil
 }
 
 func (r *Reconciler) persistPendingTarballDeletionSuccess(

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -416,16 +416,14 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 		for _, snapshotJob := range tarballSnapshots {
 			if !utils.SliceContains[string](tarballNames, snapshotJob.Name) {
 				logger.Info("reconciling orphaned tarball deletion as volumesnapshot does not exist anymore", "snapshot", snapshotJob.Name)
+				cleanupJob := snapshotJob
 				var status datasnapshot.SnapshotStatus
 				var deleteErr error
 				switch snapshotJob.Purpose {
 				case datasnapshot.SnapshotJobDelete:
-					status, deleteErr = exporter.GetSnapshotDeletionStatus(ctx, snapshotJob.Name)
+					status, deleteErr = exporter.GetSnapshotDeletionStatus(ctx, snapshotJob)
 				case datasnapshot.SnapshotJobUpload:
-					if snapshotJob.Terminating {
-						continue
-					}
-					status, deleteErr = exporter.DeleteSnapshotForUpload(ctx, snapshotJob)
+					cleanupJob, status, deleteErr = exporter.DeleteSnapshotForUpload(ctx, snapshotJob)
 					r.recordSnapshotJobReplacement(chainNode, deleteErr)
 				default:
 					continue
@@ -441,7 +439,7 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 						"Failed deleting orphaned tarball %s; delete Job retained for inspection", snapshotJob.Name,
 					)
 				case datasnapshot.SnapshotSucceeded:
-					if err = exporter.CleanupSnapshotDeletion(ctx, snapshotJob); err != nil {
+					if err = exporter.CleanupSnapshotDeletion(ctx, cleanupJob); err != nil {
 						return err
 					}
 					r.recorder.Eventf(chainNode,

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -432,7 +432,7 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 				case datasnapshot.SnapshotJobUpload:
 					if snapshotJob.Exporter != "" {
 						cleanupJob, status, deleteErr = datasnapshot.DeleteSnapshotForUpload(
-							ctx, r.snapshotClientSet, chainNode, snapshotJob,
+							ctx, r.snapshotKubernetesClient(), chainNode, snapshotJob,
 						)
 					} else {
 						cleanupJob, status, deleteErr = exporter.DeleteSnapshotForUpload(ctx, snapshotJob)
@@ -483,10 +483,7 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 	if r.snapshotClientSet == nil && r.ClientSet == nil {
 		return false, nil
 	}
-	clientSet := kubernetes.Interface(r.ClientSet)
-	if r.snapshotClientSet != nil {
-		clientSet = r.snapshotClientSet
-	}
+	clientSet := r.snapshotKubernetesClient()
 	jobs, err := datasnapshot.ListSnapshotDeletionJobs(ctx, clientSet, chainNode)
 	if err != nil {
 		return false, err
@@ -504,6 +501,7 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 		case datasnapshot.SnapshotActive:
 			pending = true
 		case datasnapshot.SnapshotFailed:
+			pending = true
 			r.recorder.Eventf(chainNode,
 				corev1.EventTypeWarning,
 				appsv1.ReasonTarballDeleteError,
@@ -524,6 +522,13 @@ func (r *Reconciler) reconcilePendingTarballDeletions(ctx context.Context, chain
 		}
 	}
 	return pending, nil
+}
+
+func (r *Reconciler) snapshotKubernetesClient() kubernetes.Interface {
+	if r.snapshotClientSet != nil {
+		return r.snapshotClientSet
+	}
+	return r.ClientSet
 }
 
 func (r *Reconciler) persistPendingTarballDeletionSuccess(

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -45,9 +45,6 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 	if err != nil {
 		return err
 	}
-	if pendingDeletion {
-		return nil
-	}
 
 	if !chainNode.SnapshotsEnabled() {
 		// Snapshot configuration can be removed while a snapshot annotation is
@@ -313,6 +310,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 		// Default case is checking if snapshot has expired (time-based retention).
 		// If tarball is also set for deletion on expire it is also taken care here.
 		default:
+			if pendingDeletion {
+				continue
+			}
 			if chainNode.Spec.Persistence.Snapshots.ShouldPreserveLastSnapshot() && len(snapshots) == 1 {
 				logger.Info("skipping retention check to preserve last snapshot", "snapshot", snapshot.GetName(), "retention", snapshot.Annotations[controllers.AnnotationSnapshotRetention])
 			} else {
@@ -354,6 +354,9 @@ func (r *Reconciler) ensureVolumeSnapshots(ctx context.Context, chainNode *appsv
 				}
 			}
 		}
+	}
+	if pendingDeletion {
+		return nil
 	}
 
 	// Handle count-based retention (retain field). Re-list snapshots since some may have been deleted above.
@@ -549,10 +552,11 @@ func (r *Reconciler) persistPendingTarballDeletionSuccess(
 		if snapshot.Annotations == nil {
 			snapshot.Annotations = make(map[string]string)
 		}
-		if snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] == strconv.FormatBool(true) {
+		if tarballDeletionComplete(snapshot, tarballName, false) {
 			return nil
 		}
 		snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] = strconv.FormatBool(true)
+		snapshot.Annotations[controllers.AnnotationTarballDeletionName] = tarballName
 		if err = r.Update(ctx, snapshot); err != nil {
 			return fmt.Errorf("persist pending tarball deletion success: %w", err)
 		}
@@ -1003,7 +1007,8 @@ func (r *Reconciler) recordSnapshotJobReplacement(chainNode *appsv1.ChainNode, e
 }
 
 func (r *Reconciler) isTarballDeleted(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) (bool, error) {
-	if snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] == strconv.FormatBool(true) {
+	tarballName := getTarballName(chainNode, snapshot)
+	if tarballDeletionComplete(snapshot, tarballName, true) {
 		return true, nil
 	}
 
@@ -1026,16 +1031,31 @@ func (r *Reconciler) isTarballDeleted(ctx context.Context, chainNode *appsv1.Cha
 		snapshot.Annotations = make(map[string]string)
 	}
 	previous, hadPrevious := snapshot.Annotations[controllers.AnnotationTarballDeletionComplete]
+	previousName, hadPreviousName := snapshot.Annotations[controllers.AnnotationTarballDeletionName]
 	snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] = strconv.FormatBool(true)
+	snapshot.Annotations[controllers.AnnotationTarballDeletionName] = tarballName
 	if err = r.Update(ctx, snapshot); err != nil {
 		if hadPrevious {
 			snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] = previous
 		} else {
 			delete(snapshot.Annotations, controllers.AnnotationTarballDeletionComplete)
 		}
+		if hadPreviousName {
+			snapshot.Annotations[controllers.AnnotationTarballDeletionName] = previousName
+		} else {
+			delete(snapshot.Annotations, controllers.AnnotationTarballDeletionName)
+		}
 		return false, fmt.Errorf("persist tarball deletion success: %w", err)
 	}
 	return true, nil
+}
+
+func tarballDeletionComplete(snapshot *snapshotv1.VolumeSnapshot, tarballName string, allowLegacy bool) bool {
+	if snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] != strconv.FormatBool(true) {
+		return false
+	}
+	deletedName := snapshot.Annotations[controllers.AnnotationTarballDeletionName]
+	return deletedName == tarballName || allowLegacy && deletedName == ""
 }
 
 func (r *Reconciler) cleanUpTarballDeletion(ctx context.Context, chainNode *appsv1.ChainNode, snapshot *snapshotv1.VolumeSnapshot) error {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -1897,6 +1897,86 @@ func newOrphanUploadTestReconciler(
 	return reconciler, chainNode, clientSet, uploadJob, uploadPVC
 }
 
+func TestEnsureVolumeSnapshotsResumesPendingDeletionWhenExportsAreDisabled(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, test := range []struct {
+		name    string
+		disable func(*appsv1.ChainNode)
+	}{
+		{
+			name: "tarball export disabled",
+			disable: func(chainNode *appsv1.ChainNode) {
+				chainNode.Spec.Persistence.Snapshots.ExportTarball = nil
+			},
+		},
+		{
+			name: "snapshots disabled",
+			disable: func(chainNode *appsv1.ChainNode) {
+				chainNode.Spec.Persistence.Snapshots = nil
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, snapshotv1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+
+			chainNode := orphanSnapshotTestChainNode(now, &appsv1.ExportTarballConfig{
+				S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"},
+			})
+			test.disable(chainNode)
+			suspended := true
+			deleteJob := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "orphan-tarball-delete",
+					Namespace: chainNode.Namespace,
+					UID:       "orphan-delete-uid",
+					Labels: map[string]string{
+						"exporter":           "s3-exporter",
+						"owner":              chainNode.Name,
+						"type":               "delete",
+						"cleanup-exporter":   "s3-exporter",
+						"cleanup-owner":      chainNode.Name,
+						"cleanup-type":       "upload",
+						"cleanup-upload-uid": "orphan-upload-uid",
+						"cleanup-pvc-uid":    "orphan-pvc-uid",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: chainNode.APIVersion,
+						Kind:       chainNode.Kind,
+						Name:       chainNode.Name,
+						UID:        chainNode.UID,
+						Controller: ptr.To(true),
+					}},
+				},
+				Spec: batchv1.JobSpec{Suspend: &suspended},
+			}
+			controllerClient := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&appsv1.ChainNode{}).
+				WithObjects(chainNode).
+				Build()
+			clientSet := fake.NewSimpleClientset(deleteJob)
+			reconciler := &Reconciler{
+				Client:            controllerClient,
+				snapshotClientSet: clientSet,
+				Scheme:            scheme,
+				opts:              &controllers.ControllerRunOptions{},
+				recorder:          record.NewFakeRecorder(10),
+			}
+
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			stored, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, stored.Spec.Suspend)
+			assert.False(t, *stored.Spec.Suspend)
+		})
+	}
+}
+
 func orphanSnapshotTestChainNode(now time.Time, export *appsv1.ExportTarballConfig) *appsv1.ChainNode {
 	return &appsv1.ChainNode{
 		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -1569,14 +1569,12 @@ func TestEnsureVolumeSnapshotsDoesNotRestartDeletionForTerminatingOrphanUpload(t
 			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
 			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
 
-			createCalls := 0
-			for _, action := range clientSet.Actions() {
-				if action.GetVerb() == "create" && action.GetResource().Resource == "jobs" {
-					createCalls++
-				}
-			}
-			assert.Zero(t, createCalls, "a terminating upload must not restart archive deletion")
-			_, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+			purgeJob, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-purge", metav1.GetOptions{})
+			require.NoError(t, err, "terminal legacy deletion must persist a post-upload cleanup Job")
+			require.NotNil(t, purgeJob.Spec.Suspend)
+			assert.True(t, *purgeJob.Spec.Suspend, "post-upload deletion must remain suspended while the upload terminates")
+			assert.Equal(t, string(uploadJob.UID), purgeJob.Labels["cleanup-upload-uid"])
+			_, err = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
 			require.NoError(t, err, "the foreground-terminating upload Job must be left alone")
 		})
 	}

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -1977,6 +1977,70 @@ func TestEnsureVolumeSnapshotsResumesPendingDeletionWhenExportsAreDisabled(t *te
 	}
 }
 
+func TestEnsureVolumeSnapshotsPersistsPendingDeletionSuccessWhenSnapshotsAreDisabled(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	chainNode := orphanSnapshotTestChainNode(now, &appsv1.ExportTarballConfig{
+		S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"},
+	})
+	chainNode.Spec.Persistence.Snapshots = nil
+	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{
+		Name:              "snapshot",
+		Namespace:         chainNode.Namespace,
+		CreationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+		Labels:            map[string]string{controllers.LabelChainNode: chainNode.Name},
+	}}
+	tarballName := fmt.Sprintf("%s-%s-archive", chainNode.Status.ChainID, snapshot.CreationTimestamp.UTC().Format(timeLayout))
+	deleteJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tarballName + "-delete",
+			Namespace: chainNode.Namespace,
+			UID:       "delete-uid",
+			Labels: map[string]string{
+				"exporter": "s3-exporter",
+				"owner":    chainNode.Name,
+				"type":     "delete",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: chainNode.APIVersion,
+				Kind:       chainNode.Kind,
+				Name:       chainNode.Name,
+				UID:        chainNode.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+		}}},
+	}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, snapshot).
+		Build()
+	clientSet := fake.NewSimpleClientset(deleteJob)
+	reconciler := &Reconciler{
+		Client:            controllerClient,
+		snapshotClientSet: clientSet,
+		Scheme:            scheme,
+		opts:              &controllers.ControllerRunOptions{},
+		recorder:          record.NewFakeRecorder(10),
+	}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+	stored := &snapshotv1.VolumeSnapshot{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(snapshot), stored))
+	assert.Equal(t, "true", stored.Annotations[controllers.AnnotationTarballDeletionComplete])
+	_, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
 func orphanSnapshotTestChainNode(now time.Time, export *appsv1.ExportTarballConfig) *appsv1.ChainNode {
 	return &appsv1.ChainNode{
 		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -2088,6 +2088,60 @@ func TestReconcilePendingTarballDeletionsBlocksFailedWorkflow(t *testing.T) {
 	assert.Equal(t, failedJob.UID, stored.UID)
 }
 
+func TestEnsureVolumeSnapshotsProcessesReadySnapshotBehindFailedDeletion(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	chainNode := orphanSnapshotTestChainNode(now, nil)
+	chainNode.Annotations[controllers.AnnotationPvcSnapshotInProgress] = "true"
+	snapshot := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "snapshot", Namespace: chainNode.Namespace, CreationTimestamp: metav1.NewTime(now),
+			Labels:      map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations: map[string]string{controllers.AnnotationPvcSnapshotReady: "false"},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{
+			ReadyToUse:  ptr.To(true),
+			RestoreSize: resource.NewQuantity(1, resource.BinarySI),
+		},
+	}
+	failedJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "old-delete", Namespace: chainNode.Namespace, UID: "delete-uid",
+		Labels:          map[string]string{"exporter": "s3-exporter", "owner": chainNode.Name, "type": "delete"},
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: chainNode.APIVersion, Kind: chainNode.Kind, Name: chainNode.Name, UID: chainNode.UID, Controller: ptr.To(true)}},
+	}, Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}}}
+	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&appsv1.ChainNode{}).WithObjects(chainNode, snapshot).Build()
+	reconciler := &Reconciler{Client: controllerClient, snapshotClientSet: fake.NewSimpleClientset(failedJob), recorder: record.NewFakeRecorder(10), opts: &controllers.ControllerRunOptions{}}
+
+	require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+	stored := &snapshotv1.VolumeSnapshot{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(snapshot), stored))
+	assert.Equal(t, "true", stored.Annotations[controllers.AnnotationPvcSnapshotReady])
+}
+
+func TestPersistPendingTarballDeletionSuccessScopesMarkerToName(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+	chainNode := orphanSnapshotTestChainNode(now, nil)
+	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{
+		Name: "snapshot", Namespace: chainNode.Namespace, CreationTimestamp: metav1.NewTime(now),
+		Labels: map[string]string{controllers.LabelChainNode: chainNode.Name},
+	}}
+	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(snapshot).Build()
+	reconciler := &Reconciler{Client: controllerClient}
+	oldName := fmt.Sprintf("%s-%s-old", chainNode.Status.ChainID, now.Format(timeLayout))
+	require.NoError(t, reconciler.persistPendingTarballDeletionSuccess(context.Background(), chainNode, oldName))
+	stored := &snapshotv1.VolumeSnapshot{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(snapshot), stored))
+	assert.Equal(t, oldName, stored.Annotations[controllers.AnnotationTarballDeletionName])
+
+	chainNode.Spec.Persistence.Snapshots.ExportTarball = &appsv1.ExportTarballConfig{Suffix: ptr.To("new")}
+	assert.False(t, tarballDeletionComplete(stored, getTarballName(chainNode, stored), true))
+}
+
 func orphanSnapshotTestChainNode(now time.Time, export *appsv1.ExportTarballConfig) *appsv1.ChainNode {
 	return &appsv1.ChainNode{
 		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
@@ -2044,6 +2045,47 @@ func TestEnsureVolumeSnapshotsPersistsPendingDeletionSuccessWhenSnapshotsAreDisa
 	assert.Equal(t, "true", stored.Annotations[controllers.AnnotationTarballDeletionComplete])
 	_, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestSnapshotKubernetesClientFallsBackToProductionClientSet(t *testing.T) {
+	production := &kubernetes.Clientset{}
+	override := fake.NewSimpleClientset()
+	reconciler := &Reconciler{ClientSet: production}
+	assert.Same(t, production, reconciler.snapshotKubernetesClient())
+	reconciler.snapshotClientSet = override
+	assert.Same(t, override, reconciler.snapshotKubernetesClient())
+}
+
+func TestReconcilePendingTarballDeletionsBlocksFailedWorkflow(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	chainNode := orphanSnapshotTestChainNode(now, &appsv1.ExportTarballConfig{
+		GCS: &appsv1.GcsExportConfig{Bucket: "new-bucket"},
+	})
+	failedJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-tarball-delete", Namespace: chainNode.Namespace, UID: "delete-uid",
+			Labels: map[string]string{"exporter": "s3-exporter", "owner": chainNode.Name, "type": "delete"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: chainNode.APIVersion, Kind: chainNode.Kind, Name: chainNode.Name,
+				UID: chainNode.UID, Controller: ptr.To(true),
+			}},
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+		}}},
+	}
+	clientSet := fake.NewSimpleClientset(failedJob)
+	reconciler := &Reconciler{snapshotClientSet: clientSet, recorder: record.NewFakeRecorder(10)}
+
+	pending, err := reconciler.reconcilePendingTarballDeletions(context.Background(), chainNode)
+	require.NoError(t, err)
+	assert.True(t, pending)
+	stored, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), failedJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, failedJob.UID, stored.UID)
 }
 
 func orphanSnapshotTestChainNode(now time.Time, export *appsv1.ExportTarballConfig) *appsv1.ChainNode {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -603,6 +603,7 @@ func TestTarballExportFailureWaitsForCleanupBeforeRetry(t *testing.T) {
 
 func TestIsTarballDeletedWaitsForDeleteJobSuccess(t *testing.T) {
 	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme))
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, batchv1.AddToScheme(scheme))
@@ -616,8 +617,10 @@ func TestIsTarballDeletedWaitsForDeleteJobSuccess(t *testing.T) {
 		}}},
 	}
 	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"}}
+	controllerClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(snapshot).Build()
 	clientSet := fake.NewSimpleClientset()
 	reconciler := &Reconciler{
+		Client:            controllerClient,
 		snapshotClientSet: clientSet,
 		Scheme:            scheme,
 		opts:              &controllers.ControllerRunOptions{},
@@ -646,6 +649,71 @@ func TestIsTarballDeletedWaitsForDeleteJobSuccess(t *testing.T) {
 	deleted, err = reconciler.isTarballDeleted(context.Background(), chainNode, snapshot)
 	require.NoError(t, err)
 	assert.True(t, deleted)
+	stored := &snapshotv1.VolumeSnapshot{}
+	require.NoError(t, controllerClient.Get(context.Background(), client.ObjectKeyFromObject(snapshot), stored))
+	assert.Equal(t, "true", stored.Annotations[controllers.AnnotationTarballDeletionComplete])
+}
+
+func TestIsTarballDeletedRequiresDurableSuccessBeforeReturning(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	chainNode := &appsv1.ChainNode{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+		ObjectMeta: metav1.ObjectMeta{Name: "node", Namespace: "default", UID: "node-uid"},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency:     "24h",
+			ExportTarball: &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		}}},
+	}
+	snapshot := &snapshotv1.VolumeSnapshot{ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"}}
+	baseClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(snapshot).Build()
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "-00010101000000-delete",
+			Namespace: "default",
+			Labels: map[string]string{
+				"exporter": "gcs-exporter",
+				"owner":    chainNode.Name,
+				"type":     "delete",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: chainNode.APIVersion,
+				Kind:       chainNode.Kind,
+				Name:       chainNode.Name,
+				UID:        chainNode.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+	clientSet := fake.NewSimpleClientset(job)
+	reconciler := &Reconciler{
+		Client:            &updateFailingClient{Client: baseClient},
+		snapshotClientSet: clientSet,
+		Scheme:            scheme,
+		opts:              &controllers.ControllerRunOptions{},
+		recorder:          record.NewFakeRecorder(10),
+	}
+
+	deleted, err := reconciler.isTarballDeleted(context.Background(), chainNode, snapshot)
+	assert.False(t, deleted)
+	require.ErrorContains(t, err, "update failed")
+
+	stored := &snapshotv1.VolumeSnapshot{}
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(snapshot), stored))
+	_, complete := stored.Annotations[controllers.AnnotationTarballDeletionComplete]
+	assert.False(t, complete)
+	_, complete = snapshot.Annotations[controllers.AnnotationTarballDeletionComplete]
+	assert.False(t, complete)
+	_, err = clientSet.BatchV1().Jobs("default").Get(context.Background(), job.Name, metav1.GetOptions{})
+	require.NoError(t, err)
 }
 
 func TestFinishTarballExportPersistsBeforeCleanup(t *testing.T) {
@@ -813,6 +881,834 @@ type updateFailingClient struct {
 
 func (c *updateFailingClient) Update(context.Context, client.Object, ...client.UpdateOption) error {
 	return errors.New("update failed")
+}
+
+type replaceSnapshotBeforeDeleteClient struct {
+	client.Client
+	replacement     *snapshotv1.VolumeSnapshot
+	markerPersisted bool
+	deleteUID       types.UID
+}
+
+func (c *replaceSnapshotBeforeDeleteClient) Update(ctx context.Context, object client.Object, opts ...client.UpdateOption) error {
+	if err := c.Client.Update(ctx, object, opts...); err != nil {
+		return err
+	}
+	if snapshot, ok := object.(*snapshotv1.VolumeSnapshot); ok &&
+		snapshot.Annotations[controllers.AnnotationTarballDeletionComplete] == strconv.FormatBool(true) {
+		c.markerPersisted = true
+	}
+	return nil
+}
+
+func (c *replaceSnapshotBeforeDeleteClient) Delete(ctx context.Context, object client.Object, opts ...client.DeleteOption) error {
+	snapshot, ok := object.(*snapshotv1.VolumeSnapshot)
+	if !ok {
+		return c.Client.Delete(ctx, object, opts...)
+	}
+	if !c.markerPersisted {
+		return errors.New("snapshot deleted before tarball deletion marker was persisted")
+	}
+	if err := c.Client.Delete(ctx, snapshot); err != nil {
+		return err
+	}
+	if err := c.Client.Create(ctx, c.replacement.DeepCopy()); err != nil {
+		return err
+	}
+
+	deleteOptions := (&client.DeleteOptions{}).ApplyOptions(opts)
+	if deleteOptions.Preconditions != nil && deleteOptions.Preconditions.UID != nil {
+		c.deleteUID = *deleteOptions.Preconditions.UID
+	}
+	if c.deleteUID != c.replacement.UID {
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshots"},
+			snapshot.Name,
+			errors.New("UID precondition did not match"),
+		)
+	}
+	return c.Client.Delete(ctx, c.replacement)
+}
+
+func TestEnsureVolumeSnapshotsDoesNotDeleteSameNameReplacementAfterTarballMarker(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	retention := "1h"
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	chainNode := &appsv1.ChainNode{
+		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node",
+			Namespace:         "default",
+			UID:               "node-uid",
+			CreationTimestamp: metav1.NewTime(now),
+			Annotations: map[string]string{
+				controllers.AnnotationLastPvcSnapshot: now.Format(timeLayout),
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency:            "24h",
+			Retention:            &retention,
+			PreserveLastSnapshot: ptr.To(false),
+			ExportTarball: &appsv1.ExportTarballConfig{
+				DeleteOnExpire: ptr.To(true),
+				GCS:            &appsv1.GcsExportConfig{Bucket: "snapshots"},
+			},
+		}}},
+		Status: appsv1.ChainNodeStatus{
+			Phase:        appsv1.PhaseChainNodeRunning,
+			ChainID:      "chain-1",
+			PvcSize:      "1Gi",
+			LatestHeight: 1,
+		},
+	}
+	snapshot := &snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "snapshot",
+			Namespace:         chainNode.Namespace,
+			UID:               "original-snapshot-uid",
+			CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
+			Labels:            map[string]string{controllers.LabelChainNode: chainNode.Name},
+			Annotations: map[string]string{
+				controllers.AnnotationPvcSnapshotReady:  "true",
+				controllers.AnnotationExportingTarball:  tarballFinished,
+				controllers.AnnotationSnapshotRetention: retention,
+			},
+		},
+		Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+	}
+	replacement := snapshot.DeepCopy()
+	replacement.UID = "replacement-snapshot-uid"
+	replacement.ResourceVersion = ""
+	replacement.CreationTimestamp = metav1.NewTime(now)
+	baseClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode, snapshot).
+		Build()
+	tracingClient := &replaceSnapshotBeforeDeleteClient{Client: baseClient, replacement: replacement}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getTarballName(chainNode, snapshot) + "-delete",
+			Namespace: chainNode.Namespace,
+			Labels: map[string]string{
+				"exporter": "gcs-exporter",
+				"owner":    chainNode.Name,
+				"type":     "delete",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: chainNode.APIVersion,
+				Kind:       chainNode.Kind,
+				Name:       chainNode.Name,
+				UID:        chainNode.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+		}}},
+	}
+	reconciler := &Reconciler{
+		Client:            tracingClient,
+		snapshotClientSet: fake.NewSimpleClientset(job),
+		Scheme:            scheme,
+		opts:              &controllers.ControllerRunOptions{},
+		recorder:          record.NewFakeRecorder(10),
+	}
+
+	err := reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true)
+	require.True(t, apierrors.IsConflict(err))
+	assert.True(t, tracingClient.markerPersisted)
+	assert.Equal(t, snapshot.UID, tracingClient.deleteUID)
+	stored := &snapshotv1.VolumeSnapshot{}
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(replacement), stored))
+	assert.Equal(t, replacement.UID, stored.UID)
+}
+
+func TestEnsureVolumeSnapshotsHonorsTarballDeletionMarkerForRetention(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	retention := "1h"
+	retain := int32(1)
+	tests := []struct {
+		name      string
+		export    *appsv1.ExportTarballConfig
+		retention *string
+		retain    *int32
+		times     []time.Time
+	}{
+		{
+			name:      "time-based GCS retention",
+			export:    &appsv1.ExportTarballConfig{DeleteOnExpire: ptr.To(true), GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+			retention: &retention,
+			times:     []time.Time{now.Add(-2 * time.Hour)},
+		},
+		{
+			name:   "count-based S3 retention",
+			export: &appsv1.ExportTarballConfig{DeleteOnExpire: ptr.To(true), S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}},
+			retain: &retain,
+			times:  []time.Time{now.Add(-2 * time.Hour), now.Add(-time.Hour)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, snapshotv1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+
+			chainNode := &appsv1.ChainNode{
+				TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node",
+					Namespace:         "default",
+					UID:               "node-uid",
+					CreationTimestamp: metav1.NewTime(now),
+					Annotations: map[string]string{
+						controllers.AnnotationLastPvcSnapshot: tt.times[len(tt.times)-1].Format(timeLayout),
+					},
+				},
+				Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+					Frequency:            "240h",
+					Retention:            tt.retention,
+					Retain:               tt.retain,
+					PreserveLastSnapshot: ptr.To(false),
+					ExportTarball:        tt.export,
+				}}},
+				Status: appsv1.ChainNodeStatus{
+					Phase:        appsv1.PhaseChainNodeRunning,
+					ChainID:      "chain-1",
+					PvcSize:      "1Gi",
+					LatestHeight: 1,
+				},
+			}
+			objects := []client.Object{chainNode}
+			for i, createdAt := range tt.times {
+				annotations := map[string]string{
+					controllers.AnnotationPvcSnapshotReady: "true",
+					controllers.AnnotationExportingTarball: tarballFinished,
+				}
+				if i == 0 {
+					annotations[controllers.AnnotationTarballDeletionComplete] = "true"
+				}
+				if tt.retention != nil {
+					annotations[controllers.AnnotationSnapshotRetention] = *tt.retention
+				}
+				objects = append(objects, &snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              fmt.Sprintf("snapshot-%d", i),
+						Namespace:         chainNode.Namespace,
+						UID:               types.UID(fmt.Sprintf("snapshot-%d-uid", i)),
+						CreationTimestamp: metav1.NewTime(createdAt),
+						Labels:            map[string]string{controllers.LabelChainNode: chainNode.Name},
+						Annotations:       annotations,
+					},
+					Status: &snapshotv1.VolumeSnapshotStatus{ReadyToUse: ptr.To(true)},
+				})
+			}
+			controllerClient := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&appsv1.ChainNode{}).
+				WithObjects(objects...).
+				Build()
+			clientSet := fake.NewSimpleClientset()
+			reconciler := &Reconciler{
+				Client:            controllerClient,
+				snapshotClientSet: clientSet,
+				Scheme:            scheme,
+				opts:              &controllers.ControllerRunOptions{},
+				recorder:          record.NewFakeRecorder(10),
+			}
+
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			oldest := &snapshotv1.VolumeSnapshot{}
+			err := controllerClient.Get(context.Background(), types.NamespacedName{Name: "snapshot-0", Namespace: chainNode.Namespace}, oldest)
+			assert.True(t, apierrors.IsNotFound(err))
+			jobs, err := clientSet.BatchV1().Jobs(chainNode.Namespace).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Empty(t, jobs.Items, "a durable deletion marker must not schedule another delete Job")
+		})
+	}
+}
+
+func TestEnsureVolumeSnapshotsReconcilesOrphanJobs(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	providers := []struct {
+		name     string
+		exporter string
+		export   *appsv1.ExportTarballConfig
+	}{
+		{
+			name:     "GCS",
+			exporter: "gcs-exporter",
+			export:   &appsv1.ExportTarballConfig{DeleteOnExpire: ptr.To(true), GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		},
+		{
+			name:     "S3",
+			exporter: "s3-exporter",
+			export:   &appsv1.ExportTarballConfig{DeleteOnExpire: ptr.To(true), S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}},
+		},
+	}
+	scenarios := []struct {
+		name            string
+		purpose         string
+		status          batchv1.JobStatus
+		disappearOnList bool
+		wantCreateCalls int
+		wantDeletionJob bool
+	}{
+		{
+			name:    "cleans successful deletion Job without creating first",
+			purpose: "delete",
+			status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+				Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+			}}},
+		},
+		{
+			name:            "does not recreate deletion Job that disappears after listing",
+			purpose:         "delete",
+			disappearOnList: true,
+		},
+		{
+			name:            "starts deletion for orphan upload Job",
+			purpose:         "upload",
+			wantCreateCalls: 1,
+			wantDeletionJob: true,
+		},
+	}
+
+	for _, provider := range providers {
+		for _, scenario := range scenarios {
+			t.Run(provider.name+"/"+scenario.name, func(t *testing.T) {
+				scheme := runtime.NewScheme()
+				require.NoError(t, snapshotv1.AddToScheme(scheme))
+				require.NoError(t, appsv1.AddToScheme(scheme))
+				require.NoError(t, corev1.AddToScheme(scheme))
+				require.NoError(t, batchv1.AddToScheme(scheme))
+
+				chainNode := &appsv1.ChainNode{
+					TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node",
+						Namespace:         "default",
+						UID:               "node-uid",
+						CreationTimestamp: metav1.NewTime(now),
+						Annotations: map[string]string{
+							controllers.AnnotationLastPvcSnapshot: now.Format(timeLayout),
+						},
+					},
+					Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+						Frequency:     "24h",
+						ExportTarball: provider.export,
+					}}},
+					Status: appsv1.ChainNodeStatus{
+						Phase:        appsv1.PhaseChainNodeRunning,
+						ChainID:      "chain-1",
+						PvcSize:      "1Gi",
+						LatestHeight: 1,
+					},
+				}
+				jobName := "orphan-tarball-" + scenario.purpose
+				controllerClient := fakeclient.NewClientBuilder().
+					WithScheme(scheme).
+					WithStatusSubresource(&appsv1.ChainNode{}).
+					WithObjects(chainNode).
+					Build()
+				job := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      jobName,
+						Namespace: chainNode.Namespace,
+						UID:       "orphan-job-uid",
+						Labels: map[string]string{
+							"exporter": provider.exporter,
+							"owner":    chainNode.Name,
+							"type":     scenario.purpose,
+						},
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: chainNode.APIVersion,
+							Kind:       chainNode.Kind,
+							Name:       chainNode.Name,
+							UID:        chainNode.UID,
+							Controller: ptr.To(true),
+						}},
+					},
+					Status: scenario.status,
+				}
+				objects := []runtime.Object{job}
+				if scenario.purpose == "upload" {
+					objects = append(objects, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+						Name:      job.Name,
+						Namespace: job.Namespace,
+						UID:       "orphan-pvc-uid",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: batchv1.SchemeGroupVersion.String(),
+							Kind:       "Job",
+							Name:       job.Name,
+							UID:        job.UID,
+							Controller: ptr.To(true),
+						}},
+					}})
+				}
+				clientSet := fake.NewSimpleClientset(objects...)
+				if scenario.disappearOnList {
+					listedJob := job.DeepCopy()
+					clientSet.PrependReactor("list", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+						err := clientSet.Tracker().Delete(batchv1.SchemeGroupVersion.WithResource("jobs"), chainNode.Namespace, job.Name)
+						require.NoError(t, err)
+						return true, &batchv1.JobList{Items: []batchv1.Job{*listedJob}}, nil
+					})
+				}
+				if scenario.purpose == "upload" {
+					clientSet.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+						createAction, ok := action.(k8stesting.CreateAction)
+						require.True(t, ok)
+						createdJob, ok := createAction.GetObject().(*batchv1.Job)
+						require.True(t, ok)
+						createdJob.UID = "orphan-delete-job-uid"
+						return false, nil, nil
+					})
+				}
+				reconciler := &Reconciler{
+					Client:            controllerClient,
+					snapshotClientSet: clientSet,
+					Scheme:            scheme,
+					opts:              &controllers.ControllerRunOptions{},
+					recorder:          record.NewFakeRecorder(10),
+				}
+
+				require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+				createCalls := 0
+				for _, action := range clientSet.Actions() {
+					if action.GetVerb() == "create" && action.GetResource().Resource == "jobs" {
+						createCalls++
+					}
+				}
+				assert.Equal(t, scenario.wantCreateCalls, createCalls)
+				if scenario.purpose == "upload" {
+					storedUploadJob, getErr := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
+					require.NoError(t, getErr, "the upload Job must remain while archive deletion runs")
+					assert.Equal(t, job.UID, storedUploadJob.UID)
+					storedUploadPVC, getErr := clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
+					require.NoError(t, getErr, "the upload PVC must remain while archive deletion runs")
+					assert.Equal(t, types.UID("orphan-pvc-uid"), storedUploadPVC.UID)
+					deleteJob, getErr := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-delete", metav1.GetOptions{})
+					require.NoError(t, getErr)
+					assert.Equal(t, types.UID("orphan-delete-job-uid"), deleteJob.UID)
+					for _, action := range clientSet.Actions() {
+						assert.NotEqual(t, "delete", action.GetVerb(), "upload resources must remain until deletion succeeds")
+					}
+
+					deleteJob.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+					_, getErr = clientSet.BatchV1().Jobs(chainNode.Namespace).UpdateStatus(context.Background(), deleteJob, metav1.UpdateOptions{})
+					require.NoError(t, getErr)
+					require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+					require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+					createCalls = 0
+					deleteActions := make([]k8stesting.DeleteAction, 0, 3)
+					for _, action := range clientSet.Actions() {
+						switch action.GetVerb() {
+						case "create":
+							if action.GetResource().Resource == "jobs" {
+								createCalls++
+							}
+						case "delete":
+							deleteAction, ok := action.(k8stesting.DeleteAction)
+							require.True(t, ok)
+							deleteActions = append(deleteActions, deleteAction)
+						}
+					}
+					assert.Equal(t, 1, createCalls, "a successful deletion must not be scheduled twice")
+					require.Len(t, deleteActions, 3)
+					assertGuardedDeleteAction(t, deleteActions[0], "persistentvolumeclaims", job.Name, "orphan-pvc-uid")
+					assertGuardedDeleteAction(t, deleteActions[1], "jobs", job.Name, job.UID)
+					assertGuardedDeleteAction(t, deleteActions[2], "jobs", deleteJob.Name, deleteJob.UID)
+
+					_, getErr = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
+					assert.True(t, apierrors.IsNotFound(getErr), "orphan upload Job must be cleaned up after deletion succeeds")
+					_, getErr = clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
+					assert.True(t, apierrors.IsNotFound(getErr), "orphan upload PVC must be cleaned up after deletion succeeds")
+					_, getErr = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+					assert.True(t, apierrors.IsNotFound(getErr), "successful deletion Job must be cleaned up last")
+					return
+				}
+				_, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-upload", metav1.GetOptions{})
+				assert.True(t, apierrors.IsNotFound(err), "orphan upload Job must be cleaned up")
+				_, err = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-delete", metav1.GetOptions{})
+				if scenario.wantDeletionJob {
+					require.NoError(t, err)
+				} else {
+					assert.True(t, apierrors.IsNotFound(err), "completed or disappeared deletion Job must not be recreated")
+				}
+			})
+		}
+	}
+}
+
+func TestEnsureVolumeSnapshotsResumesOrphanDeletionAfterCrashFollowingDeleteJobCreation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	providers := []struct {
+		name     string
+		exporter string
+		export   *appsv1.ExportTarballConfig
+	}{
+		{
+			name:     "GCS",
+			exporter: "gcs-exporter",
+			export:   &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		},
+		{
+			name:     "S3",
+			exporter: "s3-exporter",
+			export:   &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}},
+		},
+	}
+
+	for _, provider := range providers {
+		t.Run(provider.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, snapshotv1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+
+			chainNode := orphanSnapshotTestChainNode(now, provider.export)
+			ownerReference := metav1.OwnerReference{
+				APIVersion: chainNode.APIVersion,
+				Kind:       chainNode.Kind,
+				Name:       chainNode.Name,
+				UID:        chainNode.UID,
+				Controller: ptr.To(true),
+			}
+			uploadJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:            "orphan-tarball-upload",
+				Namespace:       chainNode.Namespace,
+				UID:             "upload-job-uid",
+				Labels:          map[string]string{"exporter": provider.exporter, "owner": chainNode.Name, "type": "upload"},
+				OwnerReferences: []metav1.OwnerReference{ownerReference},
+			}}
+			uploadPVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Name:      uploadJob.Name,
+				Namespace: uploadJob.Namespace,
+				UID:       "upload-pvc-uid",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: batchv1.SchemeGroupVersion.String(),
+					Kind:       "Job",
+					Name:       uploadJob.Name,
+					UID:        uploadJob.UID,
+					Controller: ptr.To(true),
+				}},
+			}}
+			controllerClient := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&appsv1.ChainNode{}).
+				WithObjects(chainNode).
+				Build()
+			clientSet := fake.NewSimpleClientset(uploadJob, uploadPVC)
+			crashErr := errors.New("simulated crash after delete Job creation")
+			createdDeleteUIDs := make([]types.UID, 0, 1)
+			clientSet.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				createAction, ok := action.(k8stesting.CreateAction)
+				require.True(t, ok)
+				job, ok := createAction.GetObject().(*batchv1.Job)
+				require.True(t, ok)
+				if job.Labels["type"] != "delete" {
+					return false, nil, nil
+				}
+
+				uid := types.UID(fmt.Sprintf("delete-job-uid-%d", len(createdDeleteUIDs)+1))
+				createdDeleteUIDs = append(createdDeleteUIDs, uid)
+				job.UID = uid
+				if len(createdDeleteUIDs) != 1 {
+					return false, nil, nil
+				}
+
+				created := job.DeepCopy()
+				require.NoError(t, clientSet.Tracker().Create(
+					batchv1.SchemeGroupVersion.WithResource("jobs"), created, created.Namespace,
+				))
+				return true, nil, crashErr
+			})
+			reconciler := &Reconciler{
+				Client:            controllerClient,
+				snapshotClientSet: clientSet,
+				Scheme:            scheme,
+				opts:              &controllers.ControllerRunOptions{},
+				recorder:          record.NewFakeRecorder(10),
+			}
+
+			err := reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true)
+			require.ErrorIs(t, err, crashErr)
+			_, err = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+			require.NoError(t, err, "the upload Job is the durable cleanup state while deletion runs")
+			_, err = clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), uploadPVC.Name, metav1.GetOptions{})
+			require.NoError(t, err, "the upload PVC is the durable cleanup state while deletion runs")
+
+			deleteJob, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-delete", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, types.UID("delete-job-uid-1"), deleteJob.UID)
+			deleteJob.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+			_, err = clientSet.BatchV1().Jobs(chainNode.Namespace).UpdateStatus(context.Background(), deleteJob, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			for range 3 {
+				require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+			}
+
+			assert.Equal(t, []types.UID{"delete-job-uid-1"}, createdDeleteUIDs,
+				"the successful external deletion must never be scheduled a second time")
+			deleteActions := make([]k8stesting.DeleteAction, 0, 3)
+			for _, action := range clientSet.Actions() {
+				if action.GetVerb() != "delete" {
+					continue
+				}
+				deleteAction, ok := action.(k8stesting.DeleteAction)
+				require.True(t, ok)
+				deleteActions = append(deleteActions, deleteAction)
+			}
+			require.Len(t, deleteActions, 3)
+			assertGuardedDeleteAction(t, deleteActions[0], "persistentvolumeclaims", uploadPVC.Name, uploadPVC.UID)
+			assertGuardedDeleteAction(t, deleteActions[1], "jobs", uploadJob.Name, uploadJob.UID)
+			assertGuardedDeleteAction(t, deleteActions[2], "jobs", deleteJob.Name, deleteJob.UID)
+
+			jobs, err := clientSet.BatchV1().Jobs(chainNode.Namespace).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Empty(t, jobs.Items)
+			_, err = clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), uploadPVC.Name, metav1.GetOptions{})
+			assert.True(t, apierrors.IsNotFound(err))
+		})
+	}
+}
+
+func TestEnsureVolumeSnapshotsDoesNotRestartDeletionForTerminatingOrphanUpload(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	deletionTimestamp := metav1.NewTime(now.Add(-time.Minute))
+	providers := []struct {
+		name     string
+		exporter string
+		export   *appsv1.ExportTarballConfig
+	}{
+		{
+			name:     "GCS",
+			exporter: "gcs-exporter",
+			export:   &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		},
+		{
+			name:     "S3",
+			exporter: "s3-exporter",
+			export:   &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}},
+		},
+	}
+
+	for _, provider := range providers {
+		t.Run(provider.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, snapshotv1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+
+			chainNode := orphanSnapshotTestChainNode(now, provider.export)
+			ownerReference := metav1.OwnerReference{
+				APIVersion: chainNode.APIVersion,
+				Kind:       chainNode.Kind,
+				Name:       chainNode.Name,
+				UID:        chainNode.UID,
+				Controller: ptr.To(true),
+			}
+			uploadJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:              "orphan-tarball-upload",
+				Namespace:         chainNode.Namespace,
+				UID:               "orphan-upload-uid",
+				DeletionTimestamp: &deletionTimestamp,
+				Finalizers:        []string{"foregroundDeletion"},
+				Labels: map[string]string{
+					"exporter": provider.exporter,
+					"owner":    chainNode.Name,
+					"type":     "upload",
+				},
+				OwnerReferences: []metav1.OwnerReference{ownerReference},
+			}}
+			deleteJob := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "orphan-tarball-delete",
+					Namespace:       chainNode.Namespace,
+					UID:             "orphan-delete-uid",
+					Labels:          map[string]string{"exporter": provider.exporter, "owner": chainNode.Name, "type": "delete"},
+					OwnerReferences: []metav1.OwnerReference{ownerReference},
+				},
+				Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+				}}},
+			}
+			controllerClient := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&appsv1.ChainNode{}).
+				WithObjects(chainNode).
+				Build()
+			clientSet := fake.NewSimpleClientset(uploadJob, deleteJob)
+			reconciler := &Reconciler{
+				Client:            controllerClient,
+				snapshotClientSet: clientSet,
+				Scheme:            scheme,
+				opts:              &controllers.ControllerRunOptions{},
+				recorder:          record.NewFakeRecorder(10),
+			}
+
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			createCalls := 0
+			for _, action := range clientSet.Actions() {
+				if action.GetVerb() == "create" && action.GetResource().Resource == "jobs" {
+					createCalls++
+				}
+			}
+			assert.Zero(t, createCalls, "a terminating upload must not restart archive deletion")
+			_, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+			require.NoError(t, err, "the foreground-terminating upload Job must be left alone")
+		})
+	}
+}
+
+func TestEnsureVolumeSnapshotsDoesNotActOnSameNameOrphanUploadReplacement(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	providers := []struct {
+		name     string
+		exporter string
+		export   *appsv1.ExportTarballConfig
+	}{
+		{
+			name:     "GCS",
+			exporter: "gcs-exporter",
+			export:   &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		},
+		{
+			name:     "S3",
+			exporter: "s3-exporter",
+			export:   &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}},
+		},
+	}
+
+	for _, provider := range providers {
+		t.Run(provider.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, snapshotv1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+
+			chainNode := orphanSnapshotTestChainNode(now, provider.export)
+			ownerReference := metav1.OwnerReference{
+				APIVersion: chainNode.APIVersion,
+				Kind:       chainNode.Kind,
+				Name:       chainNode.Name,
+				UID:        chainNode.UID,
+				Controller: ptr.To(true),
+			}
+			originalJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:            "orphan-tarball-upload",
+				Namespace:       chainNode.Namespace,
+				UID:             "listed-upload-uid",
+				Labels:          map[string]string{"exporter": provider.exporter, "owner": chainNode.Name, "type": "upload"},
+				OwnerReferences: []metav1.OwnerReference{ownerReference},
+			}}
+			originalPVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Name:      originalJob.Name,
+				Namespace: originalJob.Namespace,
+				UID:       "listed-pvc-uid",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: batchv1.SchemeGroupVersion.String(),
+					Kind:       "Job",
+					Name:       originalJob.Name,
+					UID:        originalJob.UID,
+					Controller: ptr.To(true),
+				}},
+			}}
+			replacementJob := originalJob.DeepCopy()
+			replacementJob.UID = "replacement-upload-uid"
+			replacementPVC := originalPVC.DeepCopy()
+			replacementPVC.UID = "replacement-pvc-uid"
+			replacementPVC.OwnerReferences[0].UID = replacementJob.UID
+			controllerClient := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&appsv1.ChainNode{}).
+				WithObjects(chainNode).
+				Build()
+			clientSet := fake.NewSimpleClientset(originalJob, originalPVC)
+			listedJob := originalJob.DeepCopy()
+			clientSet.PrependReactor("list", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+				require.NoError(t, clientSet.Tracker().Delete(batchv1.SchemeGroupVersion.WithResource("jobs"), chainNode.Namespace, originalJob.Name))
+				require.NoError(t, clientSet.Tracker().Delete(corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"), chainNode.Namespace, originalPVC.Name))
+				require.NoError(t, clientSet.Tracker().Create(batchv1.SchemeGroupVersion.WithResource("jobs"), replacementJob.DeepCopy(), chainNode.Namespace))
+				require.NoError(t, clientSet.Tracker().Create(corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"), replacementPVC.DeepCopy(), chainNode.Namespace))
+				return true, &batchv1.JobList{Items: []batchv1.Job{*listedJob}}, nil
+			})
+			reconciler := &Reconciler{
+				Client:            controllerClient,
+				snapshotClientSet: clientSet,
+				Scheme:            scheme,
+				opts:              &controllers.ControllerRunOptions{},
+				recorder:          record.NewFakeRecorder(10),
+			}
+
+			err := reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true)
+			require.ErrorContains(t, err, "UID")
+
+			for _, action := range clientSet.Actions() {
+				assert.False(t, action.GetVerb() == "create" && action.GetResource().Resource == "jobs",
+					"a stale listing must not create an archive deletion Job")
+				assert.NotEqual(t, "delete", action.GetVerb(), "replacement resources must not be deleted")
+			}
+			storedJob, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), replacementJob.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, replacementJob.UID, storedJob.UID)
+			storedPVC, err := clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), replacementPVC.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, replacementPVC.UID, storedPVC.UID)
+		})
+	}
+}
+
+func orphanSnapshotTestChainNode(now time.Time, export *appsv1.ExportTarballConfig) *appsv1.ChainNode {
+	return &appsv1.ChainNode{
+		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node",
+			Namespace:         "default",
+			UID:               "node-uid",
+			CreationTimestamp: metav1.NewTime(now),
+			Annotations: map[string]string{
+				controllers.AnnotationLastPvcSnapshot: now.Format(timeLayout),
+			},
+		},
+		Spec: appsv1.ChainNodeSpec{Persistence: &appsv1.Persistence{Snapshots: &appsv1.VolumeSnapshotsConfig{
+			Frequency:     "24h",
+			ExportTarball: export,
+		}}},
+		Status: appsv1.ChainNodeStatus{
+			Phase:        appsv1.PhaseChainNodeRunning,
+			ChainID:      "chain-1",
+			PvcSize:      "1Gi",
+			LatestHeight: 1,
+		},
+	}
+}
+
+func assertGuardedDeleteAction(t *testing.T, action k8stesting.DeleteAction, resource, name string, uid types.UID) {
+	t.Helper()
+	assert.Equal(t, resource, action.GetResource().Resource)
+	assert.Equal(t, name, action.GetName())
+	options := action.GetDeleteOptions()
+	require.NotNil(t, options.Preconditions)
+	require.NotNil(t, options.Preconditions.UID)
+	assert.Equal(t, uid, *options.Preconditions.UID)
 }
 
 func TestIsSnapshotReady(t *testing.T) {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -1260,7 +1260,9 @@ func TestEnsureVolumeSnapshotsReconcilesOrphanJobs(t *testing.T) {
 					listedJob := job.DeepCopy()
 					clientSet.PrependReactor("list", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
 						err := clientSet.Tracker().Delete(batchv1.SchemeGroupVersion.WithResource("jobs"), chainNode.Namespace, job.Name)
-						require.NoError(t, err)
+						if err != nil && !apierrors.IsNotFound(err) {
+							require.NoError(t, err)
+						}
 						return true, &batchv1.JobList{Items: []batchv1.Job{*listedJob}}, nil
 					})
 				}
@@ -1720,9 +1722,12 @@ func TestEnsureVolumeSnapshotsRecoversWhenListedUploadJobVanishedButPVCRemains(t
 			)
 			listedUpload := uploadJob.DeepCopy()
 			clientSet.PrependReactor("list", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
-				require.NoError(t, clientSet.Tracker().Delete(
+				err := clientSet.Tracker().Delete(
 					batchv1.SchemeGroupVersion.WithResource("jobs"), chainNode.Namespace, uploadJob.Name,
-				))
+				)
+				if err != nil && !apierrors.IsNotFound(err) {
+					require.NoError(t, err)
+				}
 				return true, &batchv1.JobList{Items: []batchv1.Job{*listedUpload}}, nil
 			})
 			clientSet.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -1291,18 +1291,20 @@ func TestEnsureVolumeSnapshotsReconcilesOrphanJobs(t *testing.T) {
 				}
 				assert.Equal(t, scenario.wantCreateCalls, createCalls)
 				if scenario.purpose == "upload" {
-					storedUploadJob, getErr := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
-					require.NoError(t, getErr, "the upload Job must remain while archive deletion runs")
-					assert.Equal(t, job.UID, storedUploadJob.UID)
-					storedUploadPVC, getErr := clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
-					require.NoError(t, getErr, "the upload PVC must remain while archive deletion runs")
-					assert.Equal(t, types.UID("orphan-pvc-uid"), storedUploadPVC.UID)
+					_, getErr := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
+					assert.True(t, apierrors.IsNotFound(getErr), "the upload Job must be absent before archive deletion starts")
+					_, getErr = clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
+					assert.True(t, apierrors.IsNotFound(getErr), "the upload PVC must be torn down before archive deletion starts")
 					deleteJob, getErr := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-delete", metav1.GetOptions{})
 					require.NoError(t, getErr)
 					assert.Equal(t, types.UID("orphan-delete-job-uid"), deleteJob.UID)
-					for _, action := range clientSet.Actions() {
-						assert.NotEqual(t, "delete", action.GetVerb(), "upload resources must remain until deletion succeeds")
-					}
+					require.NotNil(t, deleteJob.Spec.Suspend)
+					assert.False(t, *deleteJob.Spec.Suspend)
+					assert.Equal(t, string(job.UID), deleteJob.Labels["cleanup-upload-uid"])
+					assert.Equal(t, "orphan-pvc-uid", deleteJob.Labels["cleanup-pvc-uid"])
+					assert.Equal(t, provider.exporter, deleteJob.Labels["cleanup-exporter"])
+					assert.Equal(t, chainNode.Name, deleteJob.Labels["cleanup-owner"])
+					assert.Equal(t, "upload", deleteJob.Labels["cleanup-type"])
 
 					deleteJob.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
 					_, getErr = clientSet.BatchV1().Jobs(chainNode.Namespace).UpdateStatus(context.Background(), deleteJob, metav1.UpdateOptions{})
@@ -1326,8 +1328,8 @@ func TestEnsureVolumeSnapshotsReconcilesOrphanJobs(t *testing.T) {
 					}
 					assert.Equal(t, 1, createCalls, "a successful deletion must not be scheduled twice")
 					require.Len(t, deleteActions, 3)
-					assertGuardedDeleteAction(t, deleteActions[0], "persistentvolumeclaims", job.Name, "orphan-pvc-uid")
-					assertGuardedDeleteAction(t, deleteActions[1], "jobs", job.Name, job.UID)
+					assertGuardedDeleteAction(t, deleteActions[0], "jobs", job.Name, job.UID)
+					assertGuardedDeleteAction(t, deleteActions[1], "persistentvolumeclaims", job.Name, "orphan-pvc-uid")
 					assertGuardedDeleteAction(t, deleteActions[2], "jobs", deleteJob.Name, deleteJob.UID)
 
 					_, getErr = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), job.Name, metav1.GetOptions{})
@@ -1473,8 +1475,8 @@ func TestEnsureVolumeSnapshotsResumesOrphanDeletionAfterCrashFollowingDeleteJobC
 				deleteActions = append(deleteActions, deleteAction)
 			}
 			require.Len(t, deleteActions, 3)
-			assertGuardedDeleteAction(t, deleteActions[0], "persistentvolumeclaims", uploadPVC.Name, uploadPVC.UID)
-			assertGuardedDeleteAction(t, deleteActions[1], "jobs", uploadJob.Name, uploadJob.UID)
+			assertGuardedDeleteAction(t, deleteActions[0], "jobs", uploadJob.Name, uploadJob.UID)
+			assertGuardedDeleteAction(t, deleteActions[1], "persistentvolumeclaims", uploadPVC.Name, uploadPVC.UID)
 			assertGuardedDeleteAction(t, deleteActions[2], "jobs", deleteJob.Name, deleteJob.UID)
 
 			jobs, err := clientSet.BatchV1().Jobs(chainNode.Namespace).List(context.Background(), metav1.ListOptions{})
@@ -1674,6 +1676,225 @@ func TestEnsureVolumeSnapshotsDoesNotActOnSameNameOrphanUploadReplacement(t *tes
 			assert.Equal(t, replacementPVC.UID, storedPVC.UID)
 		})
 	}
+}
+
+func TestEnsureVolumeSnapshotsCleansImmediateOrphanDeletionSuccessWithPairedIdentity(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, provider := range orphanSnapshotProviderCases() {
+		t.Run(provider.name, func(t *testing.T) {
+			reconciler, chainNode, clientSet, uploadJob, uploadPVC := newOrphanUploadTestReconciler(
+				t, now, provider.exporter, provider.export,
+			)
+			clientSet.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				createAction, ok := action.(k8stesting.CreateAction)
+				require.True(t, ok)
+				job, ok := createAction.GetObject().(*batchv1.Job)
+				require.True(t, ok)
+				if job.Labels["type"] == "delete" {
+					job.UID = "orphan-delete-uid"
+					job.Status.Conditions = []batchv1.JobCondition{{
+						Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+					}}
+				}
+				return false, nil, nil
+			})
+
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			_, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+			assert.True(t, apierrors.IsNotFound(err))
+			_, err = clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), uploadPVC.Name, metav1.GetOptions{})
+			assert.True(t, apierrors.IsNotFound(err))
+			_, err = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-delete", metav1.GetOptions{})
+			assert.True(t, apierrors.IsNotFound(err))
+		})
+	}
+}
+
+func TestEnsureVolumeSnapshotsRecoversWhenListedUploadJobVanishedButPVCRemains(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, provider := range orphanSnapshotProviderCases() {
+		t.Run(provider.name, func(t *testing.T) {
+			reconciler, chainNode, clientSet, uploadJob, uploadPVC := newOrphanUploadTestReconciler(
+				t, now, provider.exporter, provider.export,
+			)
+			listedUpload := uploadJob.DeepCopy()
+			clientSet.PrependReactor("list", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+				require.NoError(t, clientSet.Tracker().Delete(
+					batchv1.SchemeGroupVersion.WithResource("jobs"), chainNode.Namespace, uploadJob.Name,
+				))
+				return true, &batchv1.JobList{Items: []batchv1.Job{*listedUpload}}, nil
+			})
+			clientSet.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				createAction, ok := action.(k8stesting.CreateAction)
+				require.True(t, ok)
+				job, ok := createAction.GetObject().(*batchv1.Job)
+				require.True(t, ok)
+				if job.Labels["type"] == "delete" {
+					job.UID = "orphan-delete-uid"
+					job.Status.Conditions = []batchv1.JobCondition{{
+						Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+					}}
+				}
+				return false, nil, nil
+			})
+
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			_, err := clientSet.CoreV1().PersistentVolumeClaims(chainNode.Namespace).Get(context.Background(), uploadPVC.Name, metav1.GetOptions{})
+			assert.True(t, apierrors.IsNotFound(err))
+			deleteActions := make([]k8stesting.DeleteAction, 0, 2)
+			for _, action := range clientSet.Actions() {
+				if action.GetVerb() == "delete" {
+					deleteAction, ok := action.(k8stesting.DeleteAction)
+					require.True(t, ok)
+					deleteActions = append(deleteActions, deleteAction)
+				}
+			}
+			require.Len(t, deleteActions, 2)
+			assertGuardedDeleteAction(t, deleteActions[0], "persistentvolumeclaims", uploadPVC.Name, uploadPVC.UID)
+			assertGuardedDeleteAction(t, deleteActions[1], "jobs", "orphan-tarball-delete", "orphan-delete-uid")
+		})
+	}
+}
+
+func TestEnsureVolumeSnapshotsWaitsForForegroundUploadTerminationBeforeArchiveDeletion(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, provider := range orphanSnapshotProviderCases() {
+		t.Run(provider.name, func(t *testing.T) {
+			reconciler, chainNode, clientSet, uploadJob, _ := newOrphanUploadTestReconciler(
+				t, now, provider.exporter, provider.export,
+			)
+			clientSet.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				createAction, ok := action.(k8stesting.CreateAction)
+				require.True(t, ok)
+				job, ok := createAction.GetObject().(*batchv1.Job)
+				require.True(t, ok)
+				if job.Labels["type"] == "delete" {
+					job.UID = "orphan-delete-uid"
+				}
+				return false, nil, nil
+			})
+			clientSet.PrependReactor("delete", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				deleteAction, ok := action.(k8stesting.DeleteAction)
+				require.True(t, ok)
+				if deleteAction.GetName() != uploadJob.Name {
+					return false, nil, nil
+				}
+				terminating := uploadJob.DeepCopy()
+				deletionTimestamp := metav1.Now()
+				terminating.DeletionTimestamp = &deletionTimestamp
+				terminating.Finalizers = []string{"foregroundDeletion"}
+				require.NoError(t, clientSet.Tracker().Update(
+					batchv1.SchemeGroupVersion.WithResource("jobs"), terminating, terminating.Namespace,
+				))
+				return true, nil, nil
+			})
+
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			deleteJob, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), "orphan-tarball-delete", metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, deleteJob.Spec.Suspend)
+			assert.True(t, *deleteJob.Spec.Suspend, "external deletion must remain suspended while the upload Job exists")
+			storedUpload, err := clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, storedUpload.DeletionTimestamp)
+
+			require.NoError(t, clientSet.Tracker().Delete(
+				batchv1.SchemeGroupVersion.WithResource("jobs"), chainNode.Namespace, uploadJob.Name,
+			))
+			require.NoError(t, reconciler.ensureVolumeSnapshots(context.Background(), chainNode, true))
+
+			deleteJob, err = clientSet.BatchV1().Jobs(chainNode.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, deleteJob.Spec.Suspend)
+			assert.False(t, *deleteJob.Spec.Suspend, "external deletion may start only after the upload Job is absent")
+		})
+	}
+}
+
+type orphanSnapshotProviderCase struct {
+	name     string
+	exporter string
+	export   *appsv1.ExportTarballConfig
+}
+
+func orphanSnapshotProviderCases() []orphanSnapshotProviderCase {
+	return []orphanSnapshotProviderCase{
+		{
+			name:     "GCS",
+			exporter: "gcs-exporter",
+			export:   &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}},
+		},
+		{
+			name:     "S3",
+			exporter: "s3-exporter",
+			export: &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{
+				Bucket: "snapshots", Region: "eu-west-1",
+			}},
+		},
+	}
+}
+
+func newOrphanUploadTestReconciler(
+	t *testing.T,
+	now time.Time,
+	exporter string,
+	export *appsv1.ExportTarballConfig,
+) (*Reconciler, *appsv1.ChainNode, *fake.Clientset, *batchv1.Job, *corev1.PersistentVolumeClaim) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, snapshotv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	chainNode := orphanSnapshotTestChainNode(now, export)
+	ownerReference := metav1.OwnerReference{
+		APIVersion: chainNode.APIVersion,
+		Kind:       chainNode.Kind,
+		Name:       chainNode.Name,
+		UID:        chainNode.UID,
+		Controller: ptr.To(true),
+	}
+	uploadJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "orphan-tarball-upload",
+		Namespace: chainNode.Namespace,
+		UID:       "orphan-upload-uid",
+		Labels: map[string]string{
+			"exporter": exporter,
+			"owner":    chainNode.Name,
+			"type":     "upload",
+		},
+		OwnerReferences: []metav1.OwnerReference{ownerReference},
+	}}
+	uploadPVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:      uploadJob.Name,
+		Namespace: uploadJob.Namespace,
+		UID:       "orphan-pvc-uid",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       "Job",
+			Name:       uploadJob.Name,
+			UID:        uploadJob.UID,
+			Controller: ptr.To(true),
+		}},
+	}}
+	controllerClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&appsv1.ChainNode{}).
+		WithObjects(chainNode).
+		Build()
+	clientSet := fake.NewSimpleClientset(uploadJob, uploadPVC)
+	reconciler := &Reconciler{
+		Client:            controllerClient,
+		snapshotClientSet: clientSet,
+		Scheme:            scheme,
+		opts:              &controllers.ControllerRunOptions{},
+		recorder:          record.NewFakeRecorder(10),
+	}
+	return reconciler, chainNode, clientSet, uploadJob, uploadPVC
 }
 
 func orphanSnapshotTestChainNode(now time.Time, export *appsv1.ExportTarballConfig) *appsv1.ChainNode {

--- a/internal/controllers/constant.go
+++ b/internal/controllers/constant.go
@@ -31,6 +31,7 @@ const (
 	AnnotationExportingTarball        = "cosmopilot.voluzi.com/exporting-tarball"
 	AnnotationTarballExportAttempts   = "cosmopilot.voluzi.com/tarball-export-attempts"
 	AnnotationTarballDeletionComplete = "cosmopilot.voluzi.com/tarball-deletion-complete"
+	AnnotationTarballDeletionName     = "cosmopilot.voluzi.com/tarball-deletion-name"
 	AnnotationSnapshotIntegrityStatus = "cosmopilot.voluzi.com/snapshot-integrity-status"
 	AnnotationPodSpecHash             = "cosmopilot.voluzi.com/pod-spec-hash"
 	AnnotationChainNodeGeneration     = "cosmopilot.voluzi.com/chainnode-generation"

--- a/internal/controllers/constant.go
+++ b/internal/controllers/constant.go
@@ -30,6 +30,7 @@ const (
 	AnnotationPvcSnapshotReady        = "cosmopilot.voluzi.com/snapshot-ready"
 	AnnotationExportingTarball        = "cosmopilot.voluzi.com/exporting-tarball"
 	AnnotationTarballExportAttempts   = "cosmopilot.voluzi.com/tarball-export-attempts"
+	AnnotationTarballDeletionComplete = "cosmopilot.voluzi.com/tarball-deletion-complete"
 	AnnotationSnapshotIntegrityStatus = "cosmopilot.voluzi.com/snapshot-integrity-status"
 	AnnotationPodSpecHash             = "cosmopilot.voluzi.com/pod-spec-hash"
 	AnnotationChainNodeGeneration     = "cosmopilot.voluzi.com/chainnode-generation"

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -240,8 +240,8 @@ func (gcs *GCS) GetSnapshotStatus(ctx context.Context, name string) (SnapshotSta
 	return uploadJobStatus(ctx, gcs.Client, gcs.Owner, gcs.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), gcsExporter)
 }
 
-func (gcs *GCS) GetSnapshotDeletionStatus(ctx context.Context, name string) (SnapshotStatus, error) {
-	return deletionJobStatus(ctx, gcs.Client, gcs.Owner, gcs.Owner.GetNamespace(), fmt.Sprintf("%s-delete", name), gcsExporter)
+func (gcs *GCS) GetSnapshotDeletionStatus(ctx context.Context, snapshotJob SnapshotJob) (SnapshotStatus, error) {
+	return reconcileSnapshotDeletionJob(ctx, gcs.Client, gcs.Owner, snapshotJob, gcsExporter)
 }
 
 func (gcs *GCS) CleanupSnapshot(ctx context.Context, name string) error {
@@ -273,36 +273,46 @@ func (gcs *GCS) cleanUp(ctx context.Context, name string) error {
 }
 
 func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus, error) {
-	status, err := gcs.ensureSnapshotDeletion(ctx, name)
+	job, err := gcs.ensureSnapshotDeletion(ctx, name, nil)
 	if err != nil {
 		return "", err
 	}
 	if err = gcs.cleanUp(ctx, name); err != nil {
 		return "", err
 	}
-	return status, nil
+	return snapshotJobStatus(job), nil
 }
 
-func (gcs *GCS) DeleteSnapshotForUpload(ctx context.Context, upload SnapshotJob) (SnapshotStatus, error) {
-	job, _, err := getSnapshotUploadResources(ctx, gcs.Client, gcs.Owner, upload, gcsExporter)
+func (gcs *GCS) DeleteSnapshotForUpload(ctx context.Context, upload SnapshotJob) (SnapshotJob, SnapshotStatus, error) {
+	if upload.Purpose != SnapshotJobUpload {
+		return SnapshotJob{}, "", fmt.Errorf("snapshot job %q has purpose %q, expected %q",
+			upload.Name, upload.Purpose, SnapshotJobUpload)
+	}
+	uploadIdentity := SnapshotJobIdentity{UID: upload.UID, Terminating: upload.Terminating}
+	_, pvc, err := getSnapshotUploadResources(ctx, gcs.Client, gcs.Owner, upload.Name, uploadIdentity, gcsExporter)
 	if err != nil {
-		return "", err
+		return SnapshotJob{}, "", err
 	}
-	if job == nil {
-		return SnapshotNotFound, nil
+	if pvc != nil {
+		uploadIdentity.PVCUID = pvc.UID
 	}
-	if job.DeletionTimestamp != nil {
-		return "", fmt.Errorf("orphan upload job %s/%s is terminating: %w",
-			job.Namespace, job.Name, ErrStaleJobTerminating)
-	}
-	status, err := gcs.ensureSnapshotDeletion(ctx, upload.Name)
+	job, err := gcs.ensureSnapshotDeletion(ctx, upload.Name, &uploadIdentity)
 	if err != nil {
-		return "", err
+		return SnapshotJob{}, "", err
 	}
-	return status, nil
+	deletion := snapshotJobFromJob(job)
+	status, err := reconcileSnapshotDeletionJob(ctx, gcs.Client, gcs.Owner, deletion, gcsExporter)
+	if err != nil {
+		return deletion, "", err
+	}
+	return deletion, status, nil
 }
 
-func (gcs *GCS) ensureSnapshotDeletion(ctx context.Context, name string) (SnapshotStatus, error) {
+func (gcs *GCS) ensureSnapshotDeletion(
+	ctx context.Context,
+	name string,
+	upload *SnapshotJobIdentity,
+) (*batchv1.Job, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-delete", name),
@@ -346,14 +356,17 @@ func (gcs *GCS) ensureSnapshotDeletion(ctx context.Context, name string) (Snapsh
 
 	err := controllerutil.SetControllerReference(gcs.Owner, job, gcs.Scheme)
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+	if upload != nil {
+		setSnapshotDeletionUploadIdentity(job, gcs.Owner, gcsExporter, *upload)
 	}
 
 	job, _, err = ensureSnapshotJob(ctx, gcs.Client, gcs.Owner, job, "delete")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return snapshotJobStatus(job), nil
+	return job, nil
 }
 
 func (gcs *GCS) CleanupSnapshotDeletion(ctx context.Context, snapshotJob SnapshotJob) error {

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -241,7 +240,7 @@ func (gcs *GCS) GetSnapshotStatus(ctx context.Context, name string) (SnapshotSta
 }
 
 func (gcs *GCS) GetSnapshotDeletionStatus(ctx context.Context, snapshotJob SnapshotJob) (SnapshotStatus, error) {
-	return reconcileSnapshotDeletionJob(ctx, gcs.Client, gcs.Owner, snapshotJob, gcsExporter)
+	return reconcileSnapshotDeletionJob(ctx, gcs.Client, gcs.Owner, snapshotJob, snapshotJobExporter(snapshotJob, gcsExporter))
 }
 
 func (gcs *GCS) CleanupSnapshot(ctx context.Context, name string) error {
@@ -370,20 +369,9 @@ func (gcs *GCS) ensureSnapshotDeletion(
 }
 
 func (gcs *GCS) CleanupSnapshotDeletion(ctx context.Context, snapshotJob SnapshotJob) error {
-	return cleanupSnapshotDeletionResources(ctx, gcs.Client, gcs.Owner, snapshotJob, gcsExporter)
+	return cleanupSnapshotDeletionResources(ctx, gcs.Client, gcs.Owner, snapshotJob, snapshotJobExporter(snapshotJob, gcsExporter))
 }
 
 func (gcs *GCS) ListSnapshots(ctx context.Context) ([]SnapshotJob, error) {
-	listOptions := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			labelExporter: gcsExporter,
-			labelOwner:    gcs.Owner.GetName(),
-		}).String(),
-	}
-	list, err := gcs.Client.BatchV1().Jobs(gcs.Owner.GetNamespace()).List(ctx, listOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	return snapshotJobsFromJobs(list.Items), nil
+	return listSnapshotJobs(ctx, gcs.Client, gcs.Owner, gcsExporter)
 }

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -3,7 +3,6 @@ package datasnapshot
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -241,6 +240,10 @@ func (gcs *GCS) GetSnapshotStatus(ctx context.Context, name string) (SnapshotSta
 	return uploadJobStatus(ctx, gcs.Client, gcs.Owner, gcs.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), gcsExporter)
 }
 
+func (gcs *GCS) GetSnapshotDeletionStatus(ctx context.Context, name string) (SnapshotStatus, error) {
+	return deletionJobStatus(ctx, gcs.Client, gcs.Owner, gcs.Owner.GetNamespace(), fmt.Sprintf("%s-delete", name), gcsExporter)
+}
+
 func (gcs *GCS) CleanupSnapshot(ctx context.Context, name string) error {
 	return gcs.cleanUp(ctx, name)
 }
@@ -270,6 +273,36 @@ func (gcs *GCS) cleanUp(ctx context.Context, name string) error {
 }
 
 func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus, error) {
+	status, err := gcs.ensureSnapshotDeletion(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if err = gcs.cleanUp(ctx, name); err != nil {
+		return "", err
+	}
+	return status, nil
+}
+
+func (gcs *GCS) DeleteSnapshotForUpload(ctx context.Context, upload SnapshotJob) (SnapshotStatus, error) {
+	job, _, err := getSnapshotUploadResources(ctx, gcs.Client, gcs.Owner, upload, gcsExporter)
+	if err != nil {
+		return "", err
+	}
+	if job == nil {
+		return SnapshotNotFound, nil
+	}
+	if job.DeletionTimestamp != nil {
+		return "", fmt.Errorf("orphan upload job %s/%s is terminating: %w",
+			job.Namespace, job.Name, ErrStaleJobTerminating)
+	}
+	status, err := gcs.ensureSnapshotDeletion(ctx, upload.Name)
+	if err != nil {
+		return "", err
+	}
+	return status, nil
+}
+
+func (gcs *GCS) ensureSnapshotDeletion(ctx context.Context, name string) (SnapshotStatus, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-delete", name),
@@ -320,17 +353,14 @@ func (gcs *GCS) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus
 	if err != nil {
 		return "", err
 	}
-	if err = gcs.cleanUp(ctx, name); err != nil {
-		return "", err
-	}
 	return snapshotJobStatus(job), nil
 }
 
-func (gcs *GCS) CleanupSnapshotDeletion(ctx context.Context, name string) error {
-	return cleanupSnapshotDeletionJob(ctx, gcs.Client, gcs.Owner, name, gcsExporter)
+func (gcs *GCS) CleanupSnapshotDeletion(ctx context.Context, snapshotJob SnapshotJob) error {
+	return cleanupSnapshotDeletionResources(ctx, gcs.Client, gcs.Owner, snapshotJob, gcsExporter)
 }
 
-func (gcs *GCS) ListSnapshots(ctx context.Context) ([]string, error) {
+func (gcs *GCS) ListSnapshots(ctx context.Context) ([]SnapshotJob, error) {
 	listOptions := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			labelExporter: gcsExporter,
@@ -342,14 +372,5 @@ func (gcs *GCS) ListSnapshots(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	names := make(map[string]struct{}, len(list.Items))
-	for _, job := range list.Items {
-		names[snapshotNameFromJob(&job)] = struct{}{}
-	}
-	snapshotNames := make([]string, 0, len(names))
-	for name := range names {
-		snapshotNames = append(snapshotNames, name)
-	}
-	sort.Strings(snapshotNames)
-	return snapshotNames, nil
+	return snapshotJobsFromJobs(list.Items), nil
 }

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -217,7 +217,9 @@ func TestGCSCleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 	client := provider.Client.(*fake.Clientset)
 	actionCount := len(client.Actions())
 
-	require.NoError(t, provider.CleanupSnapshotDeletion(context.Background(), "snapshot"))
+	require.NoError(t, provider.CleanupSnapshotDeletion(context.Background(), SnapshotJob{
+		Name: "snapshot", UID: job.UID, Purpose: SnapshotJobDelete,
+	}))
 
 	deleteAction := requireJobDeleteAction(t, client.Actions()[actionCount:])
 	assert.Equal(t, job.Name, deleteAction.GetName())
@@ -229,24 +231,35 @@ func TestGCSCleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 	assert.Equal(t, job.UID, *options.Preconditions.UID)
 }
 
-func TestGCSListSnapshotsIncludesDeletionJobs(t *testing.T) {
+func TestGCSListSnapshotsDistinguishesDeletionJobs(t *testing.T) {
 	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
 	status, err := provider.DeleteSnapshot(context.Background(), "snapshot")
 	require.NoError(t, err)
 	assert.Equal(t, SnapshotActive, status)
 
-	names, err := provider.ListSnapshots(context.Background())
+	jobs, err := provider.ListSnapshots(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"snapshot"}, names)
+	assert.Equal(t, []SnapshotJob{{Name: "snapshot", Purpose: SnapshotJobDelete}}, jobs)
 }
 
 func TestGCSListSnapshotsPreservesDeleteSuffixInArchiveName(t *testing.T) {
 	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
 	require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot-delete", testVolumeSnapshot()))
 
-	names, err := provider.ListSnapshots(context.Background())
+	jobs, err := provider.ListSnapshots(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"snapshot-delete"}, names)
+	assert.Equal(t, []SnapshotJob{{Name: "snapshot-delete", Purpose: SnapshotJobUpload}}, jobs)
+}
+
+func TestGCSGetSnapshotDeletionStatusDoesNotCreateMissingJob(t *testing.T) {
+	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
+
+	status, err := provider.GetSnapshotDeletionStatus(context.Background(), "snapshot")
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotNotFound, status)
+	for _, action := range provider.Client.(*fake.Clientset).Actions() {
+		assert.False(t, action.GetVerb() == "create" && action.GetResource().Resource == "jobs")
+	}
 }
 
 func TestGCSGetSnapshotStatusPreservesUploadResources(t *testing.T) {

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -205,7 +205,7 @@ func TestGCSCleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 			Name:            "snapshot-delete",
 			Namespace:       "default",
 			UID:             "gcs-delete-uid",
-			Labels:          map[string]string{labelExporter: gcsExporter, labelType: typeDelete},
+			Labels:          map[string]string{labelExporter: gcsExporter, labelOwner: provider.Owner.GetName(), labelType: typeDelete},
 			OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(provider.Owner)},
 		},
 		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
@@ -231,6 +231,45 @@ func TestGCSCleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 	assert.Equal(t, job.UID, *options.Preconditions.UID)
 }
 
+func TestGCSDeleteSnapshotForUploadReturnsPairedActivatedDeletion(t *testing.T) {
+	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
+	uploadJob, uploadPVC := testOrphanUploadResources(provider.Owner, gcsExporter)
+	_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), uploadJob, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = provider.Client.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), uploadPVC, metav1.CreateOptions{})
+	require.NoError(t, err)
+	client := provider.Client.(*fake.Clientset)
+	client.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateAction)
+		require.True(t, ok)
+		job, ok := createAction.GetObject().(*batchv1.Job)
+		require.True(t, ok)
+		if job.Labels[labelType] == typeDelete {
+			job.UID = "delete-uid"
+		}
+		return false, nil, nil
+	})
+
+	deletion, status, err := provider.DeleteSnapshotForUpload(context.Background(), SnapshotJob{
+		Name: "snapshot", UID: uploadJob.UID, Purpose: SnapshotJobUpload,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	assert.Equal(t, SnapshotJob{
+		Name: "snapshot", UID: "delete-uid", Purpose: SnapshotJobDelete,
+		Upload: &SnapshotJobIdentity{UID: uploadJob.UID, PVCUID: uploadPVC.UID},
+	}, deletion)
+
+	deleteJob := getJob(t, provider, "snapshot-delete")
+	require.NotNil(t, deleteJob.Spec.Suspend)
+	assert.False(t, *deleteJob.Spec.Suspend)
+	assert.Equal(t, gcsExporter, deleteJob.Labels[labelCleanupExporter])
+	assert.Equal(t, provider.Owner.GetName(), deleteJob.Labels[labelCleanupOwner])
+	assert.Equal(t, typeUpload, deleteJob.Labels[labelCleanupType])
+	assert.Equal(t, string(uploadJob.UID), deleteJob.Labels[labelCleanupUploadUID])
+	assert.Equal(t, string(uploadPVC.UID), deleteJob.Labels[labelCleanupPVCUID])
+}
+
 func TestGCSListSnapshotsDistinguishesDeletionJobs(t *testing.T) {
 	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
 	status, err := provider.DeleteSnapshot(context.Background(), "snapshot")
@@ -254,7 +293,9 @@ func TestGCSListSnapshotsPreservesDeleteSuffixInArchiveName(t *testing.T) {
 func TestGCSGetSnapshotDeletionStatusDoesNotCreateMissingJob(t *testing.T) {
 	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
 
-	status, err := provider.GetSnapshotDeletionStatus(context.Background(), "snapshot")
+	status, err := provider.GetSnapshotDeletionStatus(context.Background(), SnapshotJob{
+		Name: "snapshot", Purpose: SnapshotJobDelete,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, SnapshotNotFound, status)
 	for _, action := range provider.Client.(*fake.Clientset).Actions() {

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -281,6 +281,55 @@ func TestGCSListSnapshotsDistinguishesDeletionJobs(t *testing.T) {
 	assert.Equal(t, []SnapshotJob{{Name: "snapshot", Purpose: SnapshotJobDelete}}, jobs)
 }
 
+func TestGCSResumesS3DeletionWorkflowAfterProviderSwitch(t *testing.T) {
+	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
+	uploadJob, uploadPVC := testOrphanUploadResources(provider.Owner, s3Exporter)
+	deleteJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snapshot-delete",
+			Namespace: "default",
+			UID:       "s3-delete-uid",
+			Labels: map[string]string{
+				labelExporter:         s3Exporter,
+				labelOwner:            provider.Owner.GetName(),
+				labelType:             typeDelete,
+				labelCleanupExporter:  s3Exporter,
+				labelCleanupOwner:     provider.Owner.GetName(),
+				labelCleanupType:      typeUpload,
+				labelCleanupUploadUID: string(uploadJob.UID),
+				labelCleanupPVCUID:    string(uploadPVC.UID),
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(provider.Owner)},
+		},
+		Spec: batchv1.JobSpec{Suspend: ptr.To(true)},
+	}
+	_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), uploadJob, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = provider.Client.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), uploadPVC, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = provider.Client.BatchV1().Jobs("default").Create(context.Background(), deleteJob, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	jobs, err := provider.ListSnapshots(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []SnapshotJob{{
+		Name: "snapshot", UID: deleteJob.UID, Purpose: SnapshotJobDelete, Exporter: s3Exporter,
+		Upload: &SnapshotJobIdentity{UID: uploadJob.UID, PVCUID: uploadPVC.UID},
+	}}, jobs)
+
+	status, err := provider.GetSnapshotDeletionStatus(context.Background(), jobs[0])
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	activated := getJob(t, provider, deleteJob.Name)
+	require.NotNil(t, activated.Spec.Suspend)
+	assert.False(t, *activated.Spec.Suspend)
+	assert.Equal(t, s3Exporter, activated.Labels[labelExporter])
+	_, err = provider.Client.BatchV1().Jobs("default").Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+	_, err = provider.Client.CoreV1().PersistentVolumeClaims("default").Get(context.Background(), uploadPVC.Name, metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
 func TestGCSListSnapshotsPreservesDeleteSuffixInArchiveName(t *testing.T) {
 	provider := newTestGCSProvider(t, &appsv1.ExportTarballConfig{GCS: &appsv1.GcsExportConfig{Bucket: "snapshots"}})
 	require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot-delete", testVolumeSnapshot()))

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -3,7 +3,6 @@ package datasnapshot
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -173,11 +172,45 @@ func (provider *S3) GetSnapshotStatus(ctx context.Context, name string) (Snapsho
 	return uploadJobStatus(ctx, provider.Client, provider.Owner, provider.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), s3Exporter)
 }
 
+func (provider *S3) GetSnapshotDeletionStatus(ctx context.Context, name string) (SnapshotStatus, error) {
+	return deletionJobStatus(ctx, provider.Client, provider.Owner, provider.Owner.GetNamespace(), fmt.Sprintf("%s-delete", name), s3Exporter)
+}
+
 func (provider *S3) CleanupSnapshot(ctx context.Context, name string) error {
 	return provider.cleanUp(ctx, name)
 }
 
 func (provider *S3) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus, error) {
+	status, err := provider.ensureSnapshotDeletion(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if err = provider.cleanUp(ctx, name); err != nil {
+		return "", err
+	}
+	return status, nil
+}
+
+func (provider *S3) DeleteSnapshotForUpload(ctx context.Context, upload SnapshotJob) (SnapshotStatus, error) {
+	job, _, err := getSnapshotUploadResources(ctx, provider.Client, provider.Owner, upload, s3Exporter)
+	if err != nil {
+		return "", err
+	}
+	if job == nil {
+		return SnapshotNotFound, nil
+	}
+	if job.DeletionTimestamp != nil {
+		return "", fmt.Errorf("orphan upload job %s/%s is terminating: %w",
+			job.Namespace, job.Name, ErrStaleJobTerminating)
+	}
+	status, err := provider.ensureSnapshotDeletion(ctx, upload.Name)
+	if err != nil {
+		return "", err
+	}
+	return status, nil
+}
+
+func (provider *S3) ensureSnapshotDeletion(ctx context.Context, name string) (SnapshotStatus, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-delete", name),
@@ -217,14 +250,11 @@ func (provider *S3) DeleteSnapshot(ctx context.Context, name string) (SnapshotSt
 	if err != nil {
 		return "", err
 	}
-	if err = provider.cleanUp(ctx, name); err != nil {
-		return "", err
-	}
 	return snapshotJobStatus(job), nil
 }
 
-func (provider *S3) CleanupSnapshotDeletion(ctx context.Context, name string) error {
-	return cleanupSnapshotDeletionJob(ctx, provider.Client, provider.Owner, name, s3Exporter)
+func (provider *S3) CleanupSnapshotDeletion(ctx context.Context, snapshotJob SnapshotJob) error {
+	return cleanupSnapshotDeletionResources(ctx, provider.Client, provider.Owner, snapshotJob, s3Exporter)
 }
 
 func (provider *S3) cleanUp(ctx context.Context, name string) error {
@@ -242,7 +272,7 @@ func (provider *S3) cleanUp(ctx context.Context, name string) error {
 	return nil
 }
 
-func (provider *S3) ListSnapshots(ctx context.Context) ([]string, error) {
+func (provider *S3) ListSnapshots(ctx context.Context) ([]SnapshotJob, error) {
 	selector := labels.SelectorFromSet(map[string]string{
 		labelExporter: s3Exporter,
 		labelOwner:    provider.Owner.GetName(),
@@ -251,14 +281,5 @@ func (provider *S3) ListSnapshots(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	uniqueNames := make(map[string]struct{}, len(list.Items))
-	for _, job := range list.Items {
-		uniqueNames[snapshotNameFromJob(&job)] = struct{}{}
-	}
-	names := make([]string, 0, len(uniqueNames))
-	for name := range uniqueNames {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names, nil
+	return snapshotJobsFromJobs(list.Items), nil
 }

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -172,8 +172,8 @@ func (provider *S3) GetSnapshotStatus(ctx context.Context, name string) (Snapsho
 	return uploadJobStatus(ctx, provider.Client, provider.Owner, provider.Owner.GetNamespace(), fmt.Sprintf("%s-upload", name), s3Exporter)
 }
 
-func (provider *S3) GetSnapshotDeletionStatus(ctx context.Context, name string) (SnapshotStatus, error) {
-	return deletionJobStatus(ctx, provider.Client, provider.Owner, provider.Owner.GetNamespace(), fmt.Sprintf("%s-delete", name), s3Exporter)
+func (provider *S3) GetSnapshotDeletionStatus(ctx context.Context, snapshotJob SnapshotJob) (SnapshotStatus, error) {
+	return reconcileSnapshotDeletionJob(ctx, provider.Client, provider.Owner, snapshotJob, s3Exporter)
 }
 
 func (provider *S3) CleanupSnapshot(ctx context.Context, name string) error {
@@ -181,36 +181,46 @@ func (provider *S3) CleanupSnapshot(ctx context.Context, name string) error {
 }
 
 func (provider *S3) DeleteSnapshot(ctx context.Context, name string) (SnapshotStatus, error) {
-	status, err := provider.ensureSnapshotDeletion(ctx, name)
+	job, err := provider.ensureSnapshotDeletion(ctx, name, nil)
 	if err != nil {
 		return "", err
 	}
 	if err = provider.cleanUp(ctx, name); err != nil {
 		return "", err
 	}
-	return status, nil
+	return snapshotJobStatus(job), nil
 }
 
-func (provider *S3) DeleteSnapshotForUpload(ctx context.Context, upload SnapshotJob) (SnapshotStatus, error) {
-	job, _, err := getSnapshotUploadResources(ctx, provider.Client, provider.Owner, upload, s3Exporter)
+func (provider *S3) DeleteSnapshotForUpload(ctx context.Context, upload SnapshotJob) (SnapshotJob, SnapshotStatus, error) {
+	if upload.Purpose != SnapshotJobUpload {
+		return SnapshotJob{}, "", fmt.Errorf("snapshot job %q has purpose %q, expected %q",
+			upload.Name, upload.Purpose, SnapshotJobUpload)
+	}
+	uploadIdentity := SnapshotJobIdentity{UID: upload.UID, Terminating: upload.Terminating}
+	_, pvc, err := getSnapshotUploadResources(ctx, provider.Client, provider.Owner, upload.Name, uploadIdentity, s3Exporter)
 	if err != nil {
-		return "", err
+		return SnapshotJob{}, "", err
 	}
-	if job == nil {
-		return SnapshotNotFound, nil
+	if pvc != nil {
+		uploadIdentity.PVCUID = pvc.UID
 	}
-	if job.DeletionTimestamp != nil {
-		return "", fmt.Errorf("orphan upload job %s/%s is terminating: %w",
-			job.Namespace, job.Name, ErrStaleJobTerminating)
-	}
-	status, err := provider.ensureSnapshotDeletion(ctx, upload.Name)
+	job, err := provider.ensureSnapshotDeletion(ctx, upload.Name, &uploadIdentity)
 	if err != nil {
-		return "", err
+		return SnapshotJob{}, "", err
 	}
-	return status, nil
+	deletion := snapshotJobFromJob(job)
+	status, err := reconcileSnapshotDeletionJob(ctx, provider.Client, provider.Owner, deletion, s3Exporter)
+	if err != nil {
+		return deletion, "", err
+	}
+	return deletion, status, nil
 }
 
-func (provider *S3) ensureSnapshotDeletion(ctx context.Context, name string) (SnapshotStatus, error) {
+func (provider *S3) ensureSnapshotDeletion(
+	ctx context.Context,
+	name string,
+	upload *SnapshotJobIdentity,
+) (*batchv1.Job, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-delete", name),
@@ -244,13 +254,16 @@ func (provider *S3) ensureSnapshotDeletion(ctx context.Context, name string) (Sn
 		},
 	}
 	if err := controllerutil.SetControllerReference(provider.Owner, job, provider.Scheme); err != nil {
-		return "", err
+		return nil, err
+	}
+	if upload != nil {
+		setSnapshotDeletionUploadIdentity(job, provider.Owner, s3Exporter, *upload)
 	}
 	job, _, err := ensureSnapshotJob(ctx, provider.Client, provider.Owner, job, "delete")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return snapshotJobStatus(job), nil
+	return job, nil
 }
 
 func (provider *S3) CleanupSnapshotDeletion(ctx context.Context, snapshotJob SnapshotJob) error {

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -173,7 +172,7 @@ func (provider *S3) GetSnapshotStatus(ctx context.Context, name string) (Snapsho
 }
 
 func (provider *S3) GetSnapshotDeletionStatus(ctx context.Context, snapshotJob SnapshotJob) (SnapshotStatus, error) {
-	return reconcileSnapshotDeletionJob(ctx, provider.Client, provider.Owner, snapshotJob, s3Exporter)
+	return reconcileSnapshotDeletionJob(ctx, provider.Client, provider.Owner, snapshotJob, snapshotJobExporter(snapshotJob, s3Exporter))
 }
 
 func (provider *S3) CleanupSnapshot(ctx context.Context, name string) error {
@@ -267,7 +266,7 @@ func (provider *S3) ensureSnapshotDeletion(
 }
 
 func (provider *S3) CleanupSnapshotDeletion(ctx context.Context, snapshotJob SnapshotJob) error {
-	return cleanupSnapshotDeletionResources(ctx, provider.Client, provider.Owner, snapshotJob, s3Exporter)
+	return cleanupSnapshotDeletionResources(ctx, provider.Client, provider.Owner, snapshotJob, snapshotJobExporter(snapshotJob, s3Exporter))
 }
 
 func (provider *S3) cleanUp(ctx context.Context, name string) error {
@@ -286,13 +285,5 @@ func (provider *S3) cleanUp(ctx context.Context, name string) error {
 }
 
 func (provider *S3) ListSnapshots(ctx context.Context) ([]SnapshotJob, error) {
-	selector := labels.SelectorFromSet(map[string]string{
-		labelExporter: s3Exporter,
-		labelOwner:    provider.Owner.GetName(),
-	}).String()
-	list, err := provider.Client.BatchV1().Jobs(provider.Owner.GetNamespace()).List(ctx, metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		return nil, err
-	}
-	return snapshotJobsFromJobs(list.Items), nil
+	return listSnapshotJobs(ctx, provider.Client, provider.Owner, s3Exporter)
 }

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -201,7 +201,9 @@ func TestS3CleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 	client := provider.Client.(*fake.Clientset)
 	actionCount := len(client.Actions())
 
-	require.NoError(t, provider.CleanupSnapshotDeletion(context.Background(), "snapshot"))
+	require.NoError(t, provider.CleanupSnapshotDeletion(context.Background(), SnapshotJob{
+		Name: "snapshot", UID: job.UID, Purpose: SnapshotJobDelete,
+	}))
 
 	deleteAction := requireJobDeleteAction(t, client.Actions()[actionCount:])
 	assert.Equal(t, job.Name, deleteAction.GetName())
@@ -213,24 +215,35 @@ func TestS3CleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 	assert.Equal(t, job.UID, *options.Preconditions.UID)
 }
 
-func TestS3ListSnapshotsIncludesDeletionJobs(t *testing.T) {
+func TestS3ListSnapshotsDistinguishesDeletionJobs(t *testing.T) {
 	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}})
 	status, err := provider.DeleteSnapshot(context.Background(), "snapshot")
 	require.NoError(t, err)
 	assert.Equal(t, SnapshotActive, status)
 
-	names, err := provider.ListSnapshots(context.Background())
+	jobs, err := provider.ListSnapshots(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"snapshot"}, names)
+	assert.Equal(t, []SnapshotJob{{Name: "snapshot", Purpose: SnapshotJobDelete}}, jobs)
 }
 
 func TestS3ListSnapshotsPreservesDeleteSuffixInArchiveName(t *testing.T) {
 	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}})
 	require.NoError(t, provider.CreateSnapshot(context.Background(), "snapshot-delete", testVolumeSnapshot()))
 
-	names, err := provider.ListSnapshots(context.Background())
+	jobs, err := provider.ListSnapshots(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"snapshot-delete"}, names)
+	assert.Equal(t, []SnapshotJob{{Name: "snapshot-delete", Purpose: SnapshotJobUpload}}, jobs)
+}
+
+func TestS3GetSnapshotDeletionStatusDoesNotCreateMissingJob(t *testing.T) {
+	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}})
+
+	status, err := provider.GetSnapshotDeletionStatus(context.Background(), "snapshot")
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotNotFound, status)
+	for _, action := range provider.Client.(*fake.Clientset).Actions() {
+		assert.False(t, action.GetVerb() == "create" && action.GetResource().Resource == "jobs")
+	}
 }
 
 func TestS3GetSnapshotStatusPreservesUploadResources(t *testing.T) {

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -189,7 +189,7 @@ func TestS3CleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 			Name:            "snapshot-delete",
 			Namespace:       "default",
 			UID:             "s3-delete-uid",
-			Labels:          map[string]string{labelExporter: s3Exporter, labelType: typeDelete},
+			Labels:          map[string]string{labelExporter: s3Exporter, labelOwner: provider.Owner.GetName(), labelType: typeDelete},
 			OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(provider.Owner)},
 		},
 		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
@@ -215,6 +215,47 @@ func TestS3CleanupSnapshotDeletionUsesForegroundUIDPrecondition(t *testing.T) {
 	assert.Equal(t, job.UID, *options.Preconditions.UID)
 }
 
+func TestS3DeleteSnapshotForUploadReturnsPairedActivatedDeletion(t *testing.T) {
+	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{
+		Bucket: "snapshots", Region: "eu-west-1",
+	}})
+	uploadJob, uploadPVC := testOrphanUploadResources(provider.Owner, s3Exporter)
+	_, err := provider.Client.BatchV1().Jobs("default").Create(context.Background(), uploadJob, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = provider.Client.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), uploadPVC, metav1.CreateOptions{})
+	require.NoError(t, err)
+	client := provider.Client.(*fake.Clientset)
+	client.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateAction)
+		require.True(t, ok)
+		job, ok := createAction.GetObject().(*batchv1.Job)
+		require.True(t, ok)
+		if job.Labels[labelType] == typeDelete {
+			job.UID = "delete-uid"
+		}
+		return false, nil, nil
+	})
+
+	deletion, status, err := provider.DeleteSnapshotForUpload(context.Background(), SnapshotJob{
+		Name: "snapshot", UID: uploadJob.UID, Purpose: SnapshotJobUpload,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	assert.Equal(t, SnapshotJob{
+		Name: "snapshot", UID: "delete-uid", Purpose: SnapshotJobDelete,
+		Upload: &SnapshotJobIdentity{UID: uploadJob.UID, PVCUID: uploadPVC.UID},
+	}, deletion)
+
+	deleteJob := getS3Job(t, provider, "snapshot-delete")
+	require.NotNil(t, deleteJob.Spec.Suspend)
+	assert.False(t, *deleteJob.Spec.Suspend)
+	assert.Equal(t, s3Exporter, deleteJob.Labels[labelCleanupExporter])
+	assert.Equal(t, provider.Owner.GetName(), deleteJob.Labels[labelCleanupOwner])
+	assert.Equal(t, typeUpload, deleteJob.Labels[labelCleanupType])
+	assert.Equal(t, string(uploadJob.UID), deleteJob.Labels[labelCleanupUploadUID])
+	assert.Equal(t, string(uploadPVC.UID), deleteJob.Labels[labelCleanupPVCUID])
+}
+
 func TestS3ListSnapshotsDistinguishesDeletionJobs(t *testing.T) {
 	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}})
 	status, err := provider.DeleteSnapshot(context.Background(), "snapshot")
@@ -238,7 +279,9 @@ func TestS3ListSnapshotsPreservesDeleteSuffixInArchiveName(t *testing.T) {
 func TestS3GetSnapshotDeletionStatusDoesNotCreateMissingJob(t *testing.T) {
 	provider := newTestS3Provider(t, &appsv1.ExportTarballConfig{S3: &appsv1.S3ExportConfig{Bucket: "snapshots", Region: "eu-west-1"}})
 
-	status, err := provider.GetSnapshotDeletionStatus(context.Background(), "snapshot")
+	status, err := provider.GetSnapshotDeletionStatus(context.Background(), SnapshotJob{
+		Name: "snapshot", Purpose: SnapshotJobDelete,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, SnapshotNotFound, status)
 	for _, action := range provider.Client.(*fake.Clientset).Actions() {

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -422,6 +422,45 @@ func listSnapshotJobs(
 	return snapshotJobsFromJobs(jobs, exporter), nil
 }
 
+// ListSnapshotDeletionJobs returns owner-labelled deletion Jobs regardless of
+// the currently configured exporter. Deletion Jobs are self-contained and may
+// need to finish after tarball exports or snapshots have been disabled.
+func ListSnapshotDeletionJobs(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+) ([]SnapshotJob, error) {
+	return listSnapshotJobs(ctx, client, owner, "")
+}
+
+// ReconcileSnapshotDeletionJob resumes and reports a previously created
+// deletion Job using the exporter identity persisted on the Job itself.
+func ReconcileSnapshotDeletionJob(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	job SnapshotJob,
+) (SnapshotStatus, error) {
+	if job.Exporter == "" {
+		return "", fmt.Errorf("snapshot deletion job %q is missing its exporter identity", job.Name)
+	}
+	return reconcileSnapshotDeletionJob(ctx, client, owner, job, job.Exporter)
+}
+
+// CleanupSnapshotDeletionResources removes a completed deletion Job and any
+// paired upload resources using the identities persisted on the deletion Job.
+func CleanupSnapshotDeletionResources(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	job SnapshotJob,
+) error {
+	if job.Exporter == "" {
+		return fmt.Errorf("snapshot deletion job %q is missing its exporter identity", job.Name)
+	}
+	return cleanupSnapshotDeletionResources(ctx, client, owner, job, job.Exporter)
+}
+
 func snapshotJobExporter(job SnapshotJob, currentExporter string) string {
 	if job.Exporter != "" {
 		return job.Exporter

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -38,6 +38,9 @@ type SnapshotJob struct {
 	Purpose     SnapshotJobPurpose
 	Terminating bool
 	Upload      *SnapshotJobIdentity
+	// Source preserves the listed upload configuration if the live Job vanishes
+	// before previous-provider orphan recovery can derive its deletion Job.
+	Source *batchv1.Job
 	// Exporter is set when a listed deletion Job belongs to a previously configured
 	// provider. Deletion Jobs are self-contained, so they can still be resumed and
 	// cleaned up after the ChainNode switches providers.
@@ -359,6 +362,7 @@ func snapshotJobsFromJobs(jobs []batchv1.Job, currentExporter ...string) []Snaps
 		preferredExporter string
 		upload            *SnapshotJobIdentity
 		uploadExporter    string
+		uploadSource      *batchv1.Job
 	}
 
 	uniqueJobs := make(map[string]groupedSnapshotJobs, len(jobs))
@@ -369,6 +373,7 @@ func snapshotJobsFromJobs(jobs []batchv1.Job, currentExporter ...string) []Snaps
 		if snapshotJob.Purpose == SnapshotJobUpload {
 			group.upload = &SnapshotJobIdentity{UID: snapshotJob.UID, Terminating: snapshotJob.Terminating}
 			group.uploadExporter = job.Labels[labelExporter]
+			group.uploadSource = job.DeepCopy()
 		}
 		if group.preferred.Purpose != SnapshotJobDelete || snapshotJob.Purpose == SnapshotJobDelete {
 			group.preferred = snapshotJob
@@ -390,6 +395,9 @@ func snapshotJobsFromJobs(jobs []batchv1.Job, currentExporter ...string) []Snaps
 		if len(currentExporter) > 0 && group.preferredExporter != "" &&
 			group.preferredExporter != currentExporter[0] {
 			group.preferred.Exporter = group.preferredExporter
+			if group.preferred.Purpose == SnapshotJobUpload {
+				group.preferred.Source = group.uploadSource
+			}
 		}
 		result = append(result, group.preferred)
 	}
@@ -492,7 +500,10 @@ func DeleteSnapshotForUpload(
 		return SnapshotJob{}, "", err
 	}
 	if uploadJob == nil {
-		return SnapshotJob{}, SnapshotNotFound, nil
+		if pvc == nil || upload.Source == nil || upload.Source.UID != upload.UID {
+			return SnapshotJob{}, SnapshotNotFound, nil
+		}
+		uploadJob = upload.Source.DeepCopy()
 	}
 	if pvc != nil {
 		identity.PVCUID = pvc.UID

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -13,6 +13,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -35,6 +36,10 @@ type SnapshotJob struct {
 	Purpose     SnapshotJobPurpose
 	Terminating bool
 	Upload      *SnapshotJobIdentity
+	// Exporter is set when a listed deletion Job belongs to a previously configured
+	// provider. Deletion Jobs are self-contained, so they can still be resumed and
+	// cleaned up after the ChainNode switches providers.
+	Exporter string
 }
 
 const (
@@ -346,10 +351,12 @@ func snapshotJobFromJob(job *batchv1.Job) SnapshotJob {
 	return snapshotJob
 }
 
-func snapshotJobsFromJobs(jobs []batchv1.Job) []SnapshotJob {
+func snapshotJobsFromJobs(jobs []batchv1.Job, currentExporter ...string) []SnapshotJob {
 	type groupedSnapshotJobs struct {
-		preferred SnapshotJob
-		upload    *SnapshotJobIdentity
+		preferred         SnapshotJob
+		preferredExporter string
+		upload            *SnapshotJobIdentity
+		uploadExporter    string
 	}
 
 	uniqueJobs := make(map[string]groupedSnapshotJobs, len(jobs))
@@ -359,20 +366,28 @@ func snapshotJobsFromJobs(jobs []batchv1.Job) []SnapshotJob {
 		group := uniqueJobs[snapshotJob.Name]
 		if snapshotJob.Purpose == SnapshotJobUpload {
 			group.upload = &SnapshotJobIdentity{UID: snapshotJob.UID, Terminating: snapshotJob.Terminating}
+			group.uploadExporter = job.Labels[labelExporter]
 		}
 		if group.preferred.Purpose != SnapshotJobDelete || snapshotJob.Purpose == SnapshotJobDelete {
 			group.preferred = snapshotJob
+			group.preferredExporter = job.Labels[labelExporter]
 		}
 		uniqueJobs[snapshotJob.Name] = group
 	}
 
 	result := make([]SnapshotJob, 0, len(uniqueJobs))
 	for _, group := range uniqueJobs {
-		if group.preferred.Purpose == SnapshotJobDelete && group.preferred.Upload == nil {
+		if group.preferred.Purpose == SnapshotJobDelete && group.preferred.Upload == nil &&
+			group.preferredExporter == group.uploadExporter {
 			group.preferred.Upload = group.upload
 		} else if group.preferred.Purpose == SnapshotJobDelete && group.upload != nil &&
+			group.preferredExporter == group.uploadExporter &&
 			group.preferred.Upload.UID == group.upload.UID {
 			group.preferred.Upload.Terminating = group.upload.Terminating
+		}
+		if len(currentExporter) > 0 && group.preferred.Purpose == SnapshotJobDelete &&
+			group.preferredExporter != "" && group.preferredExporter != currentExporter[0] {
+			group.preferred.Exporter = group.preferredExporter
 		}
 		result = append(result, group.preferred)
 	}
@@ -380,6 +395,38 @@ func snapshotJobsFromJobs(jobs []batchv1.Job) []SnapshotJob {
 		return result[i].Name < result[j].Name
 	})
 	return result
+}
+
+func listSnapshotJobs(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	exporter string,
+) ([]SnapshotJob, error) {
+	selector := labels.SelectorFromSet(map[string]string{labelOwner: owner.GetName()}).String()
+	list, err := client.BatchV1().Jobs(owner.GetNamespace()).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]batchv1.Job, 0, len(list.Items))
+	for i := range list.Items {
+		job := list.Items[i]
+		// Upload Jobs need the currently configured provider to construct a matching
+		// deletion workflow. Existing deletion Jobs are self-contained and must stay
+		// discoverable after a provider switch so suspended workflows can resume.
+		if job.Labels[labelExporter] == exporter || job.Labels[labelType] == typeDelete {
+			jobs = append(jobs, job)
+		}
+	}
+	return snapshotJobsFromJobs(jobs, exporter), nil
+}
+
+func snapshotJobExporter(job SnapshotJob, currentExporter string) string {
+	if job.Exporter != "" {
+		return job.Exporter
+	}
+	return currentExporter
 }
 
 func getSnapshotUploadResources(

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -17,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -385,8 +387,8 @@ func snapshotJobsFromJobs(jobs []batchv1.Job, currentExporter ...string) []Snaps
 			group.preferred.Upload.UID == group.upload.UID {
 			group.preferred.Upload.Terminating = group.upload.Terminating
 		}
-		if len(currentExporter) > 0 && group.preferred.Purpose == SnapshotJobDelete &&
-			group.preferredExporter != "" && group.preferredExporter != currentExporter[0] {
+		if len(currentExporter) > 0 && group.preferredExporter != "" &&
+			group.preferredExporter != currentExporter[0] {
 			group.preferred.Exporter = group.preferredExporter
 		}
 		result = append(result, group.preferred)
@@ -418,10 +420,10 @@ func listSnapshotJobs(
 		if !metav1.IsControlledBy(&job, owner) {
 			continue
 		}
-		// Upload Jobs need the currently configured provider to construct a matching
-		// deletion workflow. Existing deletion Jobs are self-contained and must stay
-		// discoverable after a provider switch so suspended workflows can resume.
-		if job.Labels[labelExporter] == exporter || job.Labels[labelType] == typeDelete {
+		// Jobs remain discoverable after a provider switch. Upload Jobs retain the
+		// previous provider's pod configuration, which is enough to derive a matching
+		// deletion workflow without using the newly configured credentials.
+		if job.Labels[labelType] == typeUpload || job.Labels[labelType] == typeDelete {
 			jobs = append(jobs, job)
 		}
 	}
@@ -436,7 +438,13 @@ func ListSnapshotDeletionJobs(
 	client kubernetes.Interface,
 	owner metav1.Object,
 ) ([]SnapshotJob, error) {
-	return listSnapshotJobs(ctx, client, owner, "")
+	jobs, err := listSnapshotJobs(ctx, client, owner, "")
+	if err != nil {
+		return nil, err
+	}
+	return slices.DeleteFunc(jobs, func(job SnapshotJob) bool {
+		return job.Purpose != SnapshotJobDelete
+	}), nil
 }
 
 // ReconcileSnapshotDeletionJob resumes and reports a previously created
@@ -465,6 +473,81 @@ func CleanupSnapshotDeletionResources(
 		return fmt.Errorf("snapshot deletion job %q is missing its exporter identity", job.Name)
 	}
 	return cleanupSnapshotDeletionResources(ctx, client, owner, job, job.Exporter)
+}
+
+// DeleteSnapshotForUpload creates a deletion workflow from an upload Job that
+// belongs to a previously configured exporter.
+func DeleteSnapshotForUpload(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	upload SnapshotJob,
+) (SnapshotJob, SnapshotStatus, error) {
+	if upload.Purpose != SnapshotJobUpload || upload.Exporter == "" {
+		return SnapshotJob{}, "", fmt.Errorf("snapshot upload job %q is missing its previous exporter identity", upload.Name)
+	}
+	identity := SnapshotJobIdentity{UID: upload.UID, Terminating: upload.Terminating}
+	uploadJob, pvc, err := getSnapshotUploadResources(ctx, client, owner, upload.Name, identity, upload.Exporter)
+	if err != nil {
+		return SnapshotJob{}, "", err
+	}
+	if uploadJob == nil {
+		return SnapshotJob{}, SnapshotNotFound, nil
+	}
+	if pvc != nil {
+		identity.PVCUID = pvc.UID
+	}
+	deletionJob, err := deletionJobFromUpload(uploadJob, owner, upload.Exporter, identity)
+	if err != nil {
+		return SnapshotJob{}, "", err
+	}
+	deletionJob, _, err = ensureSnapshotJob(ctx, client, owner, deletionJob, typeDelete)
+	if err != nil {
+		return SnapshotJob{}, "", err
+	}
+	deletion := snapshotJobFromJob(deletionJob)
+	deletion.Exporter = upload.Exporter
+	status, err := reconcileSnapshotDeletionJob(ctx, client, owner, deletion, upload.Exporter)
+	return deletion, status, err
+}
+
+func deletionJobFromUpload(
+	upload *batchv1.Job,
+	owner metav1.Object,
+	exporter string,
+	identity SnapshotJobIdentity,
+) (*batchv1.Job, error) {
+	if len(upload.Spec.Template.Spec.Containers) != 1 {
+		return nil, fmt.Errorf("snapshot upload job %s/%s has %d containers, expected 1",
+			upload.Namespace, upload.Name, len(upload.Spec.Template.Spec.Containers))
+	}
+	container := upload.Spec.Template.Spec.Containers[0]
+	provider := strings.TrimSuffix(exporter, "-exporter")
+	if len(container.Args) < 5 || container.Args[0] != provider || container.Args[1] != typeUpload {
+		return nil, fmt.Errorf("snapshot upload job %s/%s has unexpected exporter arguments", upload.Namespace, upload.Name)
+	}
+	name := snapshotNameFromJob(upload)
+	container.Args = []string{provider, typeDelete, container.Args[3], name}
+	container.WorkingDir = "/app"
+	container.VolumeMounts = slices.DeleteFunc(container.VolumeMounts, func(mount corev1.VolumeMount) bool {
+		return mount.Name == "data"
+	})
+	template := *upload.Spec.Template.DeepCopy()
+	template.Spec.Containers = []corev1.Container{container}
+	template.Spec.Volumes = slices.DeleteFunc(template.Spec.Volumes, func(volume corev1.Volume) bool {
+		return volume.Name == "data"
+	})
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name + "-delete",
+			Namespace:       upload.Namespace,
+			Labels:          map[string]string{labelExporter: exporter, labelOwner: owner.GetName(), labelType: typeDelete},
+			OwnerReferences: append([]metav1.OwnerReference(nil), upload.OwnerReferences...),
+		},
+		Spec: batchv1.JobSpec{BackoffLimit: ptr.To[int32](5), Template: template},
+	}
+	setSnapshotDeletionUploadIdentity(job, owner, exporter, identity)
+	return job, nil
 }
 
 func snapshotJobExporter(job SnapshotJob, currentExporter string) string {
@@ -676,6 +759,24 @@ func getSnapshotDeletionJob(
 	if err != nil {
 		return nil, nil, err
 	}
+	if upload == nil && expected.Upload != nil {
+		// Legacy deletion Jobs did not persist the paired upload identity. They
+		// cannot safely finish while an active co-listed upload may still write the
+		// archive, so replace them with a suspended paired workflow.
+		if !expected.Upload.Terminating {
+			if err = deleteSnapshotJob(ctx, client, job); err != nil {
+				return nil, nil, fmt.Errorf("replace unpaired snapshot deletion job %s/%s: %w", job.Namespace, job.Name, err)
+			}
+			return nil, nil, &StaleJobReplacedError{
+				Purpose:          typeDelete,
+				Namespace:        job.Namespace,
+				Name:             job.Name,
+				UID:              job.UID,
+				ConflictingLabel: labelCleanupUploadUID,
+				DesiredValue:     string(expected.Upload.UID),
+			}
+		}
+	}
 	if expected.Upload != nil && upload != nil {
 		if expected.Upload.UID != upload.UID {
 			return nil, nil, fmt.Errorf("snapshot deletion job %s/%s records upload UID %s, expected %s",
@@ -759,6 +860,9 @@ func cleanupSnapshotDeletionResources(
 	exporter string,
 ) error {
 	if expected.Upload == nil {
+		if err := cleanupDanglingUploadPVC(ctx, client, owner.GetNamespace(), expected.Name); err != nil {
+			return err
+		}
 		return cleanupSnapshotDeletionJob(ctx, client, owner, expected, exporter)
 	}
 
@@ -794,6 +898,34 @@ func cleanupSnapshotDeletionResources(
 	}
 	if err = deleteSnapshotJob(ctx, client, deletionJob); err != nil {
 		return fmt.Errorf("delete snapshot deletion job %s/%s: %w", deletionJob.Namespace, deletionJob.Name, err)
+	}
+	return nil
+}
+
+func cleanupDanglingUploadPVC(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	jobName := name + "-upload"
+	if _, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{}); err == nil {
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get legacy upload job %s/%s: %w", namespace, jobName, err)
+	}
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get dangling upload PVC %s/%s: %w", namespace, jobName, err)
+	}
+	controller := metav1.GetControllerOfNoCopy(pvc)
+	if controller == nil || controller.APIVersion != batchv1.SchemeGroupVersion.String() ||
+		controller.Kind != "Job" || controller.Name != jobName || controller.UID == "" {
+		return fmt.Errorf("dangling upload PVC %s/%s lacks a verified upload Job controller", namespace, jobName)
+	}
+	err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, jobName, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &pvc.UID},
+	})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete dangling upload PVC %s/%s: %w", namespace, jobName, err)
 	}
 	return nil
 }

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -57,17 +57,20 @@ const (
 	labelOwner    = "owner"
 	labelType     = "type"
 
-	labelCleanupExporter  = "cleanup-exporter"
-	labelCleanupOwner     = "cleanup-owner"
-	labelCleanupType      = "cleanup-type"
-	labelCleanupUploadUID = "cleanup-upload-uid"
-	labelCleanupPVCUID    = "cleanup-pvc-uid"
+	labelCleanupExporter    = "cleanup-exporter"
+	labelCleanupOwner       = "cleanup-owner"
+	labelCleanupType        = "cleanup-type"
+	labelCleanupUploadUID   = "cleanup-upload-uid"
+	labelCleanupPVCUID      = "cleanup-pvc-uid"
+	labelCleanupAfterUpload = "cleanup-after-upload"
+	labelCleanupDeletionUID = "cleanup-deletion-uid"
 
 	SnapshotJobUpload SnapshotJobPurpose = "upload"
 	SnapshotJobDelete SnapshotJobPurpose = "delete"
 
-	typeUpload = string(SnapshotJobUpload)
-	typeDelete = string(SnapshotJobDelete)
+	typeUpload           = string(SnapshotJobUpload)
+	typeDelete           = string(SnapshotJobDelete)
+	typePostUploadDelete = "post-upload-delete"
 )
 
 // ErrStaleJobReplaced reports that an existing snapshot Job is being deleted because it cannot
@@ -668,15 +671,70 @@ func setSnapshotDeletionUploadIdentity(
 	exporter string,
 	upload SnapshotJobIdentity,
 ) {
+	setSnapshotDeletionUploadIdentityLabels(job, owner, exporter, upload)
+	suspend := true
+	job.Spec.Suspend = &suspend
+}
+
+func setSnapshotDeletionUploadIdentityLabels(
+	job *batchv1.Job,
+	owner metav1.Object,
+	exporter string,
+	upload SnapshotJobIdentity,
+) {
+	if job.Labels == nil {
+		job.Labels = make(map[string]string)
+	}
 	job.Labels[labelCleanupExporter] = exporter
 	job.Labels[labelCleanupOwner] = owner.GetName()
 	job.Labels[labelCleanupType] = typeUpload
 	job.Labels[labelCleanupUploadUID] = string(upload.UID)
 	if upload.PVCUID != "" {
 		job.Labels[labelCleanupPVCUID] = string(upload.PVCUID)
+	} else {
+		delete(job.Labels, labelCleanupPVCUID)
 	}
-	suspend := true
-	job.Spec.Suspend = &suspend
+}
+
+func postUploadDeletionJob(
+	marker *batchv1.Job,
+	owner metav1.Object,
+	exporter string,
+	upload SnapshotJobIdentity,
+) *batchv1.Job {
+	spec := *marker.Spec.DeepCopy()
+	spec.Selector = nil
+	spec.ManualSelector = nil
+	for _, label := range []string{
+		"controller-uid",
+		"job-name",
+		"batch.kubernetes.io/controller-uid",
+		"batch.kubernetes.io/job-name",
+	} {
+		delete(spec.Template.Labels, label)
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.TrimSuffix(marker.Name, "-delete") + "-purge",
+			Namespace: marker.Namespace,
+			Labels: map[string]string{
+				labelExporter:           exporter,
+				labelOwner:              owner.GetName(),
+				labelType:               typePostUploadDelete,
+				labelCleanupDeletionUID: string(marker.UID),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: batchv1.SchemeGroupVersion.String(),
+				Kind:       "Job",
+				Name:       marker.Name,
+				UID:        marker.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: spec,
+	}
+	setSnapshotDeletionUploadIdentity(job, owner, exporter, upload)
+	return job
 }
 
 func snapshotDeletionUploadIdentity(
@@ -779,52 +837,38 @@ func getSnapshotDeletionJob(
 		return nil, nil, err
 	}
 	if upload == nil && expected.Upload != nil {
-		// Legacy deletion Jobs did not persist the paired upload identity. They
-		// cannot safely finish while a co-listed upload may still write the
-		// archive. Upgrade an active legacy Job in place so the suspended cleanup
-		// workflow is durable before upload teardown starts. This also covers an
-		// upload that is already terminating: its pods may still be writing until
-		// foreground deletion completes.
-		if snapshotJobStatus(job) == SnapshotActive {
-			identity := *expected.Upload
-			_, pvc, resourceErr := getSnapshotUploadResources(ctx, client, owner, expected.Name, identity, exporter)
-			if resourceErr != nil {
-				return nil, nil, resourceErr
-			}
-			if pvc != nil {
-				identity.PVCUID = pvc.UID
-			}
-			updated := job.DeepCopy()
-			setSnapshotDeletionUploadIdentity(updated, owner, exporter, identity)
-			updated, err = client.BatchV1().Jobs(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
-			if err != nil {
-				return nil, nil, fmt.Errorf("pair legacy snapshot deletion job %s/%s with upload UID %s: %w",
-					job.Namespace, job.Name, expected.Upload.UID, err)
-			}
-			if updated.UID != job.UID {
-				return nil, nil, fmt.Errorf("paired snapshot deletion job %s/%s has UID %s, expected %s",
-					updated.Namespace, updated.Name, updated.UID, job.UID)
-			}
-			job = updated
-			upload = &identity
-		} else if expected.Upload.Terminating {
-			// The legacy deletion already reached a terminal state, so there is no
-			// running deletion to suspend. Keep its durable marker until the
-			// foreground-terminating upload disappears; the orphan-upload path will
-			// then decide whether another external deletion is required.
-		} else {
-			if err = deleteSnapshotJob(ctx, client, job); err != nil {
-				return nil, nil, fmt.Errorf("replace unpaired snapshot deletion job %s/%s: %w", job.Namespace, job.Name, err)
-			}
-			return nil, nil, &StaleJobReplacedError{
-				Purpose:          typeDelete,
-				Namespace:        job.Namespace,
-				Name:             job.Name,
-				UID:              job.UID,
-				ConflictingLabel: labelCleanupUploadUID,
-				DesiredValue:     string(expected.Upload.UID),
-			}
+		identity := *expected.Upload
+		_, pvc, resourceErr := getSnapshotUploadResources(ctx, client, owner, expected.Name, identity, exporter)
+		if resourceErr != nil {
+			return nil, nil, resourceErr
 		}
+		if pvc != nil {
+			identity.PVCUID = pvc.UID
+		}
+		updated := job.DeepCopy()
+		if snapshotJobStatus(job) == SnapshotActive {
+			setSnapshotDeletionUploadIdentity(updated, owner, exporter, identity)
+		} else {
+			// A completed Job cannot run again. Keep it as the durable marker for a
+			// hidden suspended successor that is activated after the upload vanishes.
+			setSnapshotDeletionUploadIdentityLabels(updated, owner, exporter, identity)
+			updated.Labels[labelCleanupAfterUpload] = "true"
+			// Terminal deletion Jobs normally have a TTL. Disable it atomically with
+			// the cleanup identity so the marker cannot disappear and cascade-delete
+			// its post-upload worker before that worker finishes.
+			updated.Spec.TTLSecondsAfterFinished = nil
+		}
+		updated, err = client.BatchV1().Jobs(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, nil, fmt.Errorf("pair legacy snapshot deletion job %s/%s with upload UID %s: %w",
+				job.Namespace, job.Name, expected.Upload.UID, err)
+		}
+		if updated.UID != job.UID {
+			return nil, nil, fmt.Errorf("paired snapshot deletion job %s/%s has UID %s, expected %s",
+				updated.Namespace, updated.Name, updated.UID, job.UID)
+		}
+		job = updated
+		upload = &identity
 	}
 	if expected.Upload != nil && upload != nil {
 		if expected.Upload.UID != upload.UID {
@@ -835,6 +879,23 @@ func getSnapshotDeletionJob(
 			return nil, nil, fmt.Errorf("snapshot deletion job %s/%s records upload PVC UID %s, expected %s",
 				job.Namespace, job.Name, upload.PVCUID, expected.Upload.PVCUID)
 		}
+	}
+	if afterUpload := job.Labels[labelCleanupAfterUpload]; afterUpload != "" {
+		if afterUpload != "true" {
+			return nil, nil, fmt.Errorf("snapshot deletion job %s/%s has %s label %q, expected %q",
+				job.Namespace, job.Name, labelCleanupAfterUpload, afterUpload, "true")
+		}
+		if upload == nil {
+			return nil, nil, fmt.Errorf("snapshot deletion job %s/%s is missing its post-upload cleanup identity",
+				job.Namespace, job.Name)
+		}
+		worker, _, workerErr := ensureSnapshotJob(
+			ctx, client, job, postUploadDeletionJob(job, owner, exporter, *upload), typePostUploadDelete,
+		)
+		if workerErr != nil {
+			return nil, nil, workerErr
+		}
+		return worker, upload, nil
 	}
 	return job, upload, nil
 }
@@ -944,6 +1005,9 @@ func cleanupSnapshotDeletionResources(
 	}
 	if deletionJob == nil {
 		return nil
+	}
+	if deletionJob.Name != fmt.Sprintf("%s-delete", expected.Name) {
+		return cleanupSnapshotDeletionJob(ctx, client, owner, expected, exporter)
 	}
 	if err = deleteSnapshotJob(ctx, client, deletionJob); err != nil {
 		return fmt.Errorf("delete snapshot deletion job %s/%s: %w", deletionJob.Namespace, deletionJob.Name, err)

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -412,6 +412,12 @@ func listSnapshotJobs(
 	jobs := make([]batchv1.Job, 0, len(list.Items))
 	for i := range list.Items {
 		job := list.Items[i]
+		// The owner label is name-based and can survive a delete/recreate race.
+		// Ignore Jobs controlled by a previous object with the same name; the old
+		// owner's garbage collection must handle them.
+		if !metav1.IsControlledBy(&job, owner) {
+			continue
+		}
 		// Upload Jobs need the currently configured provider to construct a matching
 		// deletion workflow. Existing deletion Jobs are self-contained and must stay
 		// discoverable after a provider switch so suspended workflows can resume.

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -25,6 +25,7 @@ type SnapshotJobPurpose string
 
 type SnapshotJobIdentity struct {
 	UID         types.UID
+	PVCUID      types.UID
 	Terminating bool
 }
 
@@ -45,6 +46,12 @@ const (
 	labelExporter = "exporter"
 	labelOwner    = "owner"
 	labelType     = "type"
+
+	labelCleanupExporter  = "cleanup-exporter"
+	labelCleanupOwner     = "cleanup-owner"
+	labelCleanupType      = "cleanup-type"
+	labelCleanupUploadUID = "cleanup-upload-uid"
+	labelCleanupPVCUID    = "cleanup-pvc-uid"
 
 	SnapshotJobUpload SnapshotJobPurpose = "upload"
 	SnapshotJobDelete SnapshotJobPurpose = "delete"
@@ -94,10 +101,10 @@ func (err *StaleJobReplacedError) ProviderSwitch() bool {
 type SnapshotProvider interface {
 	CreateSnapshot(context.Context, string, *snapshotv1.VolumeSnapshot) error
 	GetSnapshotStatus(context.Context, string) (SnapshotStatus, error)
-	GetSnapshotDeletionStatus(context.Context, string) (SnapshotStatus, error)
+	GetSnapshotDeletionStatus(context.Context, SnapshotJob) (SnapshotStatus, error)
 	CleanupSnapshot(context.Context, string) error
 	DeleteSnapshot(context.Context, string) (SnapshotStatus, error)
-	DeleteSnapshotForUpload(context.Context, SnapshotJob) (SnapshotStatus, error)
+	DeleteSnapshotForUpload(context.Context, SnapshotJob) (SnapshotJob, SnapshotStatus, error)
 	CleanupSnapshotDeletion(context.Context, SnapshotJob) error
 	ListSnapshots(ctx context.Context) ([]SnapshotJob, error)
 }
@@ -219,34 +226,6 @@ func uploadJobStatus(
 	return snapshotJobStatus(job), nil
 }
 
-func deletionJobStatus(
-	ctx context.Context,
-	client kubernetes.Interface,
-	owner metav1.Object,
-	namespace, name, exporter string,
-) (SnapshotStatus, error) {
-	job, err := client.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return SnapshotNotFound, nil
-		}
-		return "", err
-	}
-	if !metav1.IsControlledBy(job, owner) {
-		return "", fmt.Errorf("snapshot deletion job %s/%s is not controlled by snapshot owner %s",
-			job.Namespace, job.Name, owner.GetName())
-	}
-	if job.Labels[labelExporter] != exporter {
-		return "", fmt.Errorf("snapshot deletion job %s/%s has exporter label %q, expected %q",
-			job.Namespace, job.Name, job.Labels[labelExporter], exporter)
-	}
-	if job.Labels[labelType] != typeDelete {
-		return "", fmt.Errorf("snapshot deletion job %s/%s has type label %q, expected %q",
-			job.Namespace, job.Name, job.Labels[labelType], typeDelete)
-	}
-	return snapshotJobStatus(job), nil
-}
-
 func cleanupSnapshotDeletionJob(
 	ctx context.Context,
 	client kubernetes.Interface,
@@ -283,6 +262,7 @@ func cleanupSnapshotDeletionJob(
 		desired string
 	}{
 		{label: labelExporter, desired: exporter},
+		{label: labelOwner, desired: owner.GetName()},
 		{label: labelType, desired: typeDelete},
 	} {
 		actual := job.Labels[expected.label]
@@ -350,6 +330,22 @@ func snapshotNameFromJob(job *batchv1.Job) string {
 	}
 }
 
+func snapshotJobFromJob(job *batchv1.Job) SnapshotJob {
+	snapshotJob := SnapshotJob{
+		Name:        snapshotNameFromJob(job),
+		UID:         job.UID,
+		Purpose:     SnapshotJobPurpose(job.Labels[labelType]),
+		Terminating: job.DeletionTimestamp != nil,
+	}
+	if snapshotJob.Purpose == SnapshotJobDelete && job.Labels[labelCleanupUploadUID] != "" {
+		snapshotJob.Upload = &SnapshotJobIdentity{
+			UID:    types.UID(job.Labels[labelCleanupUploadUID]),
+			PVCUID: types.UID(job.Labels[labelCleanupPVCUID]),
+		}
+	}
+	return snapshotJob
+}
+
 func snapshotJobsFromJobs(jobs []batchv1.Job) []SnapshotJob {
 	type groupedSnapshotJobs struct {
 		preferred SnapshotJob
@@ -359,12 +355,7 @@ func snapshotJobsFromJobs(jobs []batchv1.Job) []SnapshotJob {
 	uniqueJobs := make(map[string]groupedSnapshotJobs, len(jobs))
 	for i := range jobs {
 		job := &jobs[i]
-		snapshotJob := SnapshotJob{
-			Name:        snapshotNameFromJob(job),
-			UID:         job.UID,
-			Purpose:     SnapshotJobPurpose(job.Labels[labelType]),
-			Terminating: job.DeletionTimestamp != nil,
-		}
+		snapshotJob := snapshotJobFromJob(job)
 		group := uniqueJobs[snapshotJob.Name]
 		if snapshotJob.Purpose == SnapshotJobUpload {
 			group.upload = &SnapshotJobIdentity{UID: snapshotJob.UID, Terminating: snapshotJob.Terminating}
@@ -377,8 +368,11 @@ func snapshotJobsFromJobs(jobs []batchv1.Job) []SnapshotJob {
 
 	result := make([]SnapshotJob, 0, len(uniqueJobs))
 	for _, group := range uniqueJobs {
-		if group.preferred.Purpose == SnapshotJobDelete {
+		if group.preferred.Purpose == SnapshotJobDelete && group.preferred.Upload == nil {
 			group.preferred.Upload = group.upload
+		} else if group.preferred.Purpose == SnapshotJobDelete && group.upload != nil &&
+			group.preferred.Upload.UID == group.upload.UID {
+			group.preferred.Upload.Terminating = group.upload.Terminating
 		}
 		result = append(result, group.preferred)
 	}
@@ -392,18 +386,16 @@ func getSnapshotUploadResources(
 	ctx context.Context,
 	client kubernetes.Interface,
 	owner metav1.Object,
-	expected SnapshotJob,
+	name string,
+	expected SnapshotJobIdentity,
 	exporter string,
 ) (*batchv1.Job, *corev1.PersistentVolumeClaim, error) {
-	if expected.Purpose != SnapshotJobUpload {
-		return nil, nil, fmt.Errorf("snapshot job %q has purpose %q, expected %q", expected.Name, expected.Purpose, SnapshotJobUpload)
-	}
 	if expected.UID == "" {
-		return nil, nil, fmt.Errorf("snapshot upload job %q is missing its listed UID", expected.Name)
+		return nil, nil, fmt.Errorf("snapshot upload job %q is missing its listed UID", name)
 	}
 
 	namespace := owner.GetNamespace()
-	jobName := fmt.Sprintf("%s-upload", expected.Name)
+	jobName := fmt.Sprintf("%s-upload", name)
 	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -447,6 +439,10 @@ func getSnapshotUploadResources(
 		return nil, nil, fmt.Errorf("orphan upload PVC %s/%s is not controlled by upload job UID %s",
 			pvc.Namespace, pvc.Name, expected.UID)
 	}
+	if expected.PVCUID != "" && pvc.UID != expected.PVCUID {
+		return nil, nil, fmt.Errorf("orphan upload PVC %s/%s has UID %s, expected recorded UID %s",
+			pvc.Namespace, pvc.Name, pvc.UID, expected.PVCUID)
+	}
 	return job, pvc, nil
 }
 
@@ -456,6 +452,11 @@ func cleanupSnapshotUploadResources(
 	job *batchv1.Job,
 	pvc *corev1.PersistentVolumeClaim,
 ) error {
+	if job != nil && job.DeletionTimestamp == nil {
+		if err := deleteSnapshotJob(ctx, client, job); err != nil {
+			return fmt.Errorf("delete orphan upload job %s/%s: %w", job.Namespace, job.Name, err)
+		}
+	}
 	if pvc != nil {
 		err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{
 			Preconditions: &metav1.Preconditions{UID: &pvc.UID},
@@ -464,24 +465,85 @@ func cleanupSnapshotUploadResources(
 			return fmt.Errorf("delete orphan upload PVC %s/%s: %w", pvc.Namespace, pvc.Name, err)
 		}
 	}
-	if job == nil || job.DeletionTimestamp != nil {
-		return nil
-	}
-	if err := deleteSnapshotJob(ctx, client, job); err != nil {
-		return fmt.Errorf("delete orphan upload job %s/%s: %w", job.Namespace, job.Name, err)
-	}
 	return nil
 }
 
-func getSnapshotDeletionJobForCleanup(
+func setSnapshotDeletionUploadIdentity(
+	job *batchv1.Job,
+	owner metav1.Object,
+	exporter string,
+	upload SnapshotJobIdentity,
+) {
+	job.Labels[labelCleanupExporter] = exporter
+	job.Labels[labelCleanupOwner] = owner.GetName()
+	job.Labels[labelCleanupType] = typeUpload
+	job.Labels[labelCleanupUploadUID] = string(upload.UID)
+	if upload.PVCUID != "" {
+		job.Labels[labelCleanupPVCUID] = string(upload.PVCUID)
+	}
+	suspend := true
+	job.Spec.Suspend = &suspend
+}
+
+func snapshotDeletionUploadIdentity(
+	job *batchv1.Job,
+	owner metav1.Object,
+	exporter string,
+) (*SnapshotJobIdentity, error) {
+	hasCleanupIdentity := false
+	for _, label := range []string{
+		labelCleanupExporter,
+		labelCleanupOwner,
+		labelCleanupType,
+		labelCleanupUploadUID,
+		labelCleanupPVCUID,
+	} {
+		if job.Labels[label] != "" {
+			hasCleanupIdentity = true
+			break
+		}
+	}
+	if !hasCleanupIdentity {
+		if job.Spec.Suspend != nil && *job.Spec.Suspend {
+			return nil, fmt.Errorf("suspended snapshot deletion job %s/%s is missing its upload cleanup identity",
+				job.Namespace, job.Name)
+		}
+		return nil, nil
+	}
+
+	for _, expectedLabel := range []struct {
+		name  string
+		value string
+	}{
+		{name: labelCleanupExporter, value: exporter},
+		{name: labelCleanupOwner, value: owner.GetName()},
+		{name: labelCleanupType, value: typeUpload},
+	} {
+		if job.Labels[expectedLabel.name] != expectedLabel.value {
+			return nil, fmt.Errorf("snapshot deletion job %s/%s has %s label %q, expected %q",
+				job.Namespace, job.Name, expectedLabel.name, job.Labels[expectedLabel.name], expectedLabel.value)
+		}
+	}
+	uploadUID := types.UID(job.Labels[labelCleanupUploadUID])
+	if uploadUID == "" {
+		return nil, fmt.Errorf("snapshot deletion job %s/%s is missing %s label",
+			job.Namespace, job.Name, labelCleanupUploadUID)
+	}
+	return &SnapshotJobIdentity{
+		UID:    uploadUID,
+		PVCUID: types.UID(job.Labels[labelCleanupPVCUID]),
+	}, nil
+}
+
+func getSnapshotDeletionJob(
 	ctx context.Context,
 	client kubernetes.Interface,
 	owner metav1.Object,
 	expected SnapshotJob,
 	exporter string,
-) (*batchv1.Job, error) {
+) (*batchv1.Job, *SnapshotJobIdentity, error) {
 	if expected.Purpose != SnapshotJobDelete {
-		return nil, fmt.Errorf("snapshot job %q has purpose %q, expected %q", expected.Name, expected.Purpose, SnapshotJobDelete)
+		return nil, nil, fmt.Errorf("snapshot job %q has purpose %q, expected %q", expected.Name, expected.Purpose, SnapshotJobDelete)
 	}
 
 	namespace := owner.GetNamespace()
@@ -489,20 +551,20 @@ func getSnapshotDeletionJobForCleanup(
 	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, nil
+			return nil, expected.Upload, nil
 		}
-		return nil, fmt.Errorf("get snapshot deletion job %s/%s: %w", namespace, jobName, err)
+		return nil, nil, fmt.Errorf("get snapshot deletion job %s/%s: %w", namespace, jobName, err)
 	}
-	if job.UID != expected.UID {
-		return nil, fmt.Errorf("snapshot deletion job %s/%s has UID %s, expected listed UID %s",
+	if expected.UID != "" && job.UID != expected.UID {
+		return nil, nil, fmt.Errorf("snapshot deletion job %s/%s has UID %s, expected listed UID %s",
 			job.Namespace, job.Name, job.UID, expected.UID)
 	}
 	if !metav1.IsControlledBy(job, owner) {
-		return nil, fmt.Errorf("snapshot deletion job %s/%s is not controlled by snapshot owner %s",
+		return nil, nil, fmt.Errorf("snapshot deletion job %s/%s is not controlled by snapshot owner %s",
 			job.Namespace, job.Name, owner.GetName())
 	}
 	if job.DeletionTimestamp != nil {
-		return nil, fmt.Errorf("snapshot deletion job %s/%s is terminating: %w",
+		return nil, nil, fmt.Errorf("snapshot deletion job %s/%s is terminating: %w",
 			job.Namespace, job.Name, ErrStaleJobTerminating)
 	}
 	for _, expectedLabel := range []struct {
@@ -510,14 +572,91 @@ func getSnapshotDeletionJobForCleanup(
 		value string
 	}{
 		{name: labelExporter, value: exporter},
+		{name: labelOwner, value: owner.GetName()},
 		{name: labelType, value: typeDelete},
 	} {
 		if job.Labels[expectedLabel.name] != expectedLabel.value {
-			return nil, fmt.Errorf("snapshot deletion job %s/%s has %s label %q, expected %q",
+			return nil, nil, fmt.Errorf("snapshot deletion job %s/%s has %s label %q, expected %q",
 				job.Namespace, job.Name, expectedLabel.name, job.Labels[expectedLabel.name], expectedLabel.value)
 		}
 	}
-	return job, nil
+	upload, err := snapshotDeletionUploadIdentity(job, owner, exporter)
+	if err != nil {
+		return nil, nil, err
+	}
+	if expected.Upload != nil && upload != nil {
+		if expected.Upload.UID != upload.UID {
+			return nil, nil, fmt.Errorf("snapshot deletion job %s/%s records upload UID %s, expected %s",
+				job.Namespace, job.Name, upload.UID, expected.Upload.UID)
+		}
+		if expected.Upload.PVCUID != "" && upload.PVCUID != expected.Upload.PVCUID {
+			return nil, nil, fmt.Errorf("snapshot deletion job %s/%s records upload PVC UID %s, expected %s",
+				job.Namespace, job.Name, upload.PVCUID, expected.Upload.PVCUID)
+		}
+	}
+	return job, upload, nil
+}
+
+func reconcileSnapshotDeletionJob(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	expected SnapshotJob,
+	exporter string,
+) (SnapshotStatus, error) {
+	deletionJob, upload, err := getSnapshotDeletionJob(ctx, client, owner, expected, exporter)
+	if err != nil {
+		return "", err
+	}
+	if deletionJob == nil {
+		return SnapshotNotFound, nil
+	}
+	if upload == nil {
+		return snapshotJobStatus(deletionJob), nil
+	}
+
+	uploadJob, pvc, err := getSnapshotUploadResources(ctx, client, owner, expected.Name, *upload, exporter)
+	if err != nil {
+		return "", err
+	}
+	suspended := deletionJob.Spec.Suspend != nil && *deletionJob.Spec.Suspend
+	if !suspended {
+		if uploadJob != nil {
+			return "", fmt.Errorf("snapshot deletion job %s/%s is active while upload job %s/%s UID %s still exists",
+				deletionJob.Namespace, deletionJob.Name, uploadJob.Namespace, uploadJob.Name, uploadJob.UID)
+		}
+		if pvc != nil {
+			if err = cleanupSnapshotUploadResources(ctx, client, nil, pvc); err != nil {
+				return "", err
+			}
+		}
+		return snapshotJobStatus(deletionJob), nil
+	}
+
+	if err = cleanupSnapshotUploadResources(ctx, client, uploadJob, pvc); err != nil {
+		return "", err
+	}
+	uploadJob, _, err = getSnapshotUploadResources(ctx, client, owner, expected.Name, *upload, exporter)
+	if err != nil {
+		return "", err
+	}
+	if uploadJob != nil {
+		return SnapshotActive, nil
+	}
+
+	updated := deletionJob.DeepCopy()
+	activate := false
+	updated.Spec.Suspend = &activate
+	updated, err = client.BatchV1().Jobs(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("activate snapshot deletion job %s/%s UID %s: %w",
+			deletionJob.Namespace, deletionJob.Name, deletionJob.UID, err)
+	}
+	if updated.UID != deletionJob.UID {
+		return "", fmt.Errorf("activated snapshot deletion job %s/%s has UID %s, expected %s",
+			updated.Namespace, updated.Name, updated.UID, deletionJob.UID)
+	}
+	return snapshotJobStatus(updated), nil
 }
 
 func cleanupSnapshotDeletionResources(
@@ -531,22 +670,32 @@ func cleanupSnapshotDeletionResources(
 		return cleanupSnapshotDeletionJob(ctx, client, owner, expected, exporter)
 	}
 
-	deletionJob, err := getSnapshotDeletionJobForCleanup(ctx, client, owner, expected, exporter)
+	deletionJob, upload, err := getSnapshotDeletionJob(ctx, client, owner, expected, exporter)
 	if err != nil {
 		return err
 	}
-	upload := SnapshotJob{
-		Name:        expected.Name,
-		UID:         expected.Upload.UID,
-		Purpose:     SnapshotJobUpload,
-		Terminating: expected.Upload.Terminating,
+	if upload == nil {
+		upload = expected.Upload
 	}
-	job, pvc, err := getSnapshotUploadResources(ctx, client, owner, upload, exporter)
+	if upload == nil {
+		return cleanupSnapshotDeletionJob(ctx, client, owner, expected, exporter)
+	}
+	if deletionJob != nil && deletionJob.Spec.Suspend != nil && *deletionJob.Spec.Suspend {
+		return fmt.Errorf("snapshot deletion job %s/%s is still suspended", deletionJob.Namespace, deletionJob.Name)
+	}
+	job, pvc, err := getSnapshotUploadResources(ctx, client, owner, expected.Name, *upload, exporter)
 	if err != nil {
 		return err
 	}
 	if err = cleanupSnapshotUploadResources(ctx, client, job, pvc); err != nil {
 		return err
+	}
+	job, _, err = getSnapshotUploadResources(ctx, client, owner, expected.Name, *upload, exporter)
+	if err != nil {
+		return err
+	}
+	if job != nil {
+		return nil
 	}
 	if deletionJob == nil {
 		return nil

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
@@ -20,6 +21,21 @@ import (
 
 type SnapshotStatus string
 
+type SnapshotJobPurpose string
+
+type SnapshotJobIdentity struct {
+	UID         types.UID
+	Terminating bool
+}
+
+type SnapshotJob struct {
+	Name        string
+	UID         types.UID
+	Purpose     SnapshotJobPurpose
+	Terminating bool
+	Upload      *SnapshotJobIdentity
+}
+
 const (
 	SnapshotSucceeded SnapshotStatus = "succeeded"
 	SnapshotFailed    SnapshotStatus = "failed"
@@ -30,8 +46,11 @@ const (
 	labelOwner    = "owner"
 	labelType     = "type"
 
-	typeUpload = "upload"
-	typeDelete = "delete"
+	SnapshotJobUpload SnapshotJobPurpose = "upload"
+	SnapshotJobDelete SnapshotJobPurpose = "delete"
+
+	typeUpload = string(SnapshotJobUpload)
+	typeDelete = string(SnapshotJobDelete)
 )
 
 // ErrStaleJobReplaced reports that an existing snapshot Job is being deleted because it cannot
@@ -75,10 +94,12 @@ func (err *StaleJobReplacedError) ProviderSwitch() bool {
 type SnapshotProvider interface {
 	CreateSnapshot(context.Context, string, *snapshotv1.VolumeSnapshot) error
 	GetSnapshotStatus(context.Context, string) (SnapshotStatus, error)
+	GetSnapshotDeletionStatus(context.Context, string) (SnapshotStatus, error)
 	CleanupSnapshot(context.Context, string) error
 	DeleteSnapshot(context.Context, string) (SnapshotStatus, error)
-	CleanupSnapshotDeletion(context.Context, string) error
-	ListSnapshots(ctx context.Context) ([]string, error)
+	DeleteSnapshotForUpload(context.Context, SnapshotJob) (SnapshotStatus, error)
+	CleanupSnapshotDeletion(context.Context, SnapshotJob) error
+	ListSnapshots(ctx context.Context) ([]SnapshotJob, error)
 }
 
 func ensureUploadResources(
@@ -198,20 +219,56 @@ func uploadJobStatus(
 	return snapshotJobStatus(job), nil
 }
 
+func deletionJobStatus(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	namespace, name, exporter string,
+) (SnapshotStatus, error) {
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return SnapshotNotFound, nil
+		}
+		return "", err
+	}
+	if !metav1.IsControlledBy(job, owner) {
+		return "", fmt.Errorf("snapshot deletion job %s/%s is not controlled by snapshot owner %s",
+			job.Namespace, job.Name, owner.GetName())
+	}
+	if job.Labels[labelExporter] != exporter {
+		return "", fmt.Errorf("snapshot deletion job %s/%s has exporter label %q, expected %q",
+			job.Namespace, job.Name, job.Labels[labelExporter], exporter)
+	}
+	if job.Labels[labelType] != typeDelete {
+		return "", fmt.Errorf("snapshot deletion job %s/%s has type label %q, expected %q",
+			job.Namespace, job.Name, job.Labels[labelType], typeDelete)
+	}
+	return snapshotJobStatus(job), nil
+}
+
 func cleanupSnapshotDeletionJob(
 	ctx context.Context,
 	client kubernetes.Interface,
 	owner metav1.Object,
-	name, exporter string,
+	expected SnapshotJob,
+	exporter string,
 ) error {
+	if expected.Purpose != SnapshotJobDelete {
+		return fmt.Errorf("snapshot job %q has purpose %q, expected %q", expected.Name, expected.Purpose, SnapshotJobDelete)
+	}
 	namespace := owner.GetNamespace()
-	jobName := fmt.Sprintf("%s-delete", name)
+	jobName := fmt.Sprintf("%s-delete", expected.Name)
 	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("get snapshot deletion job %s/%s: %w", namespace, jobName, err)
+	}
+	if expected.UID != "" && job.UID != expected.UID {
+		return fmt.Errorf("snapshot deletion job %s/%s has UID %s, expected listed UID %s",
+			job.Namespace, job.Name, job.UID, expected.UID)
 	}
 	if !metav1.IsControlledBy(job, owner) {
 		return fmt.Errorf("snapshot deletion job %s/%s is not controlled by snapshot owner %s",
@@ -291,6 +348,213 @@ func snapshotNameFromJob(job *batchv1.Job) string {
 	default:
 		return job.Name
 	}
+}
+
+func snapshotJobsFromJobs(jobs []batchv1.Job) []SnapshotJob {
+	type groupedSnapshotJobs struct {
+		preferred SnapshotJob
+		upload    *SnapshotJobIdentity
+	}
+
+	uniqueJobs := make(map[string]groupedSnapshotJobs, len(jobs))
+	for i := range jobs {
+		job := &jobs[i]
+		snapshotJob := SnapshotJob{
+			Name:        snapshotNameFromJob(job),
+			UID:         job.UID,
+			Purpose:     SnapshotJobPurpose(job.Labels[labelType]),
+			Terminating: job.DeletionTimestamp != nil,
+		}
+		group := uniqueJobs[snapshotJob.Name]
+		if snapshotJob.Purpose == SnapshotJobUpload {
+			group.upload = &SnapshotJobIdentity{UID: snapshotJob.UID, Terminating: snapshotJob.Terminating}
+		}
+		if group.preferred.Purpose != SnapshotJobDelete || snapshotJob.Purpose == SnapshotJobDelete {
+			group.preferred = snapshotJob
+		}
+		uniqueJobs[snapshotJob.Name] = group
+	}
+
+	result := make([]SnapshotJob, 0, len(uniqueJobs))
+	for _, group := range uniqueJobs {
+		if group.preferred.Purpose == SnapshotJobDelete {
+			group.preferred.Upload = group.upload
+		}
+		result = append(result, group.preferred)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func getSnapshotUploadResources(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	expected SnapshotJob,
+	exporter string,
+) (*batchv1.Job, *corev1.PersistentVolumeClaim, error) {
+	if expected.Purpose != SnapshotJobUpload {
+		return nil, nil, fmt.Errorf("snapshot job %q has purpose %q, expected %q", expected.Name, expected.Purpose, SnapshotJobUpload)
+	}
+	if expected.UID == "" {
+		return nil, nil, fmt.Errorf("snapshot upload job %q is missing its listed UID", expected.Name)
+	}
+
+	namespace := owner.GetNamespace()
+	jobName := fmt.Sprintf("%s-upload", expected.Name)
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, nil, fmt.Errorf("get orphan upload job %s/%s: %w", namespace, jobName, err)
+		}
+		job = nil
+	} else {
+		if job.UID != expected.UID {
+			return nil, nil, fmt.Errorf("orphan upload job %s/%s has UID %s, expected listed UID %s",
+				job.Namespace, job.Name, job.UID, expected.UID)
+		}
+		if !metav1.IsControlledBy(job, owner) {
+			return nil, nil, fmt.Errorf("orphan upload job %s/%s is not controlled by snapshot owner %s",
+				job.Namespace, job.Name, owner.GetName())
+		}
+		for _, expectedLabel := range []struct {
+			name  string
+			value string
+		}{
+			{name: labelExporter, value: exporter},
+			{name: labelOwner, value: owner.GetName()},
+			{name: labelType, value: typeUpload},
+		} {
+			if job.Labels[expectedLabel.name] != expectedLabel.value {
+				return nil, nil, fmt.Errorf("orphan upload job %s/%s has %s label %q, expected %q",
+					job.Namespace, job.Name, expectedLabel.name, job.Labels[expectedLabel.name], expectedLabel.value)
+			}
+		}
+	}
+
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return job, nil, nil
+		}
+		return nil, nil, fmt.Errorf("get orphan upload PVC %s/%s: %w", namespace, jobName, err)
+	}
+	controller := metav1.GetControllerOfNoCopy(pvc)
+	if controller == nil || controller.APIVersion != batchv1.SchemeGroupVersion.String() || controller.Kind != "Job" ||
+		controller.Name != jobName || controller.UID != expected.UID {
+		return nil, nil, fmt.Errorf("orphan upload PVC %s/%s is not controlled by upload job UID %s",
+			pvc.Namespace, pvc.Name, expected.UID)
+	}
+	return job, pvc, nil
+}
+
+func cleanupSnapshotUploadResources(
+	ctx context.Context,
+	client kubernetes.Interface,
+	job *batchv1.Job,
+	pvc *corev1.PersistentVolumeClaim,
+) error {
+	if pvc != nil {
+		err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &pvc.UID},
+		})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete orphan upload PVC %s/%s: %w", pvc.Namespace, pvc.Name, err)
+		}
+	}
+	if job == nil || job.DeletionTimestamp != nil {
+		return nil
+	}
+	if err := deleteSnapshotJob(ctx, client, job); err != nil {
+		return fmt.Errorf("delete orphan upload job %s/%s: %w", job.Namespace, job.Name, err)
+	}
+	return nil
+}
+
+func getSnapshotDeletionJobForCleanup(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	expected SnapshotJob,
+	exporter string,
+) (*batchv1.Job, error) {
+	if expected.Purpose != SnapshotJobDelete {
+		return nil, fmt.Errorf("snapshot job %q has purpose %q, expected %q", expected.Name, expected.Purpose, SnapshotJobDelete)
+	}
+
+	namespace := owner.GetNamespace()
+	jobName := fmt.Sprintf("%s-delete", expected.Name)
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get snapshot deletion job %s/%s: %w", namespace, jobName, err)
+	}
+	if job.UID != expected.UID {
+		return nil, fmt.Errorf("snapshot deletion job %s/%s has UID %s, expected listed UID %s",
+			job.Namespace, job.Name, job.UID, expected.UID)
+	}
+	if !metav1.IsControlledBy(job, owner) {
+		return nil, fmt.Errorf("snapshot deletion job %s/%s is not controlled by snapshot owner %s",
+			job.Namespace, job.Name, owner.GetName())
+	}
+	if job.DeletionTimestamp != nil {
+		return nil, fmt.Errorf("snapshot deletion job %s/%s is terminating: %w",
+			job.Namespace, job.Name, ErrStaleJobTerminating)
+	}
+	for _, expectedLabel := range []struct {
+		name  string
+		value string
+	}{
+		{name: labelExporter, value: exporter},
+		{name: labelType, value: typeDelete},
+	} {
+		if job.Labels[expectedLabel.name] != expectedLabel.value {
+			return nil, fmt.Errorf("snapshot deletion job %s/%s has %s label %q, expected %q",
+				job.Namespace, job.Name, expectedLabel.name, job.Labels[expectedLabel.name], expectedLabel.value)
+		}
+	}
+	return job, nil
+}
+
+func cleanupSnapshotDeletionResources(
+	ctx context.Context,
+	client kubernetes.Interface,
+	owner metav1.Object,
+	expected SnapshotJob,
+	exporter string,
+) error {
+	if expected.Upload == nil {
+		return cleanupSnapshotDeletionJob(ctx, client, owner, expected, exporter)
+	}
+
+	deletionJob, err := getSnapshotDeletionJobForCleanup(ctx, client, owner, expected, exporter)
+	if err != nil {
+		return err
+	}
+	upload := SnapshotJob{
+		Name:        expected.Name,
+		UID:         expected.Upload.UID,
+		Purpose:     SnapshotJobUpload,
+		Terminating: expected.Upload.Terminating,
+	}
+	job, pvc, err := getSnapshotUploadResources(ctx, client, owner, upload, exporter)
+	if err != nil {
+		return err
+	}
+	if err = cleanupSnapshotUploadResources(ctx, client, job, pvc); err != nil {
+		return err
+	}
+	if deletionJob == nil {
+		return nil
+	}
+	if err = deleteSnapshotJob(ctx, client, deletionJob); err != nil {
+		return fmt.Errorf("delete snapshot deletion job %s/%s: %w", deletionJob.Namespace, deletionJob.Name, err)
+	}
+	return nil
 }
 
 func ensureUploadPVC(

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -533,6 +533,14 @@ func deletionJobFromUpload(
 		return mount.Name == "data"
 	})
 	template := *upload.Spec.Template.DeepCopy()
+	for _, label := range []string{
+		"controller-uid",
+		"job-name",
+		"batch.kubernetes.io/controller-uid",
+		"batch.kubernetes.io/job-name",
+	} {
+		delete(template.Labels, label)
+	}
 	template.Spec.Containers = []corev1.Container{container}
 	template.Spec.Volumes = slices.DeleteFunc(template.Spec.Volumes, func(volume corev1.Volume) bool {
 		return volume.Name == "data"
@@ -860,9 +868,9 @@ func cleanupSnapshotDeletionResources(
 	exporter string,
 ) error {
 	if expected.Upload == nil {
-		if err := cleanupDanglingUploadPVC(ctx, client, owner.GetNamespace(), expected.Name); err != nil {
-			return err
-		}
+		// Legacy deletion Jobs did not persist an upload UID. A same-name PVC
+		// controlled by an already-absent Job cannot be tied to this ChainNode, so
+		// retain it rather than risk deleting another node's colliding upload PVC.
 		return cleanupSnapshotDeletionJob(ctx, client, owner, expected, exporter)
 	}
 
@@ -898,34 +906,6 @@ func cleanupSnapshotDeletionResources(
 	}
 	if err = deleteSnapshotJob(ctx, client, deletionJob); err != nil {
 		return fmt.Errorf("delete snapshot deletion job %s/%s: %w", deletionJob.Namespace, deletionJob.Name, err)
-	}
-	return nil
-}
-
-func cleanupDanglingUploadPVC(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
-	jobName := name + "-upload"
-	if _, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{}); err == nil {
-		return nil
-	} else if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("get legacy upload job %s/%s: %w", namespace, jobName, err)
-	}
-	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, jobName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("get dangling upload PVC %s/%s: %w", namespace, jobName, err)
-	}
-	controller := metav1.GetControllerOfNoCopy(pvc)
-	if controller == nil || controller.APIVersion != batchv1.SchemeGroupVersion.String() ||
-		controller.Kind != "Job" || controller.Name != jobName || controller.UID == "" {
-		return fmt.Errorf("dangling upload PVC %s/%s lacks a verified upload Job controller", namespace, jobName)
-	}
-	err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, jobName, metav1.DeleteOptions{
-		Preconditions: &metav1.Preconditions{UID: &pvc.UID},
-	})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete dangling upload PVC %s/%s: %w", namespace, jobName, err)
 	}
 	return nil
 }

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -780,9 +780,39 @@ func getSnapshotDeletionJob(
 	}
 	if upload == nil && expected.Upload != nil {
 		// Legacy deletion Jobs did not persist the paired upload identity. They
-		// cannot safely finish while an active co-listed upload may still write the
-		// archive, so replace them with a suspended paired workflow.
-		if !expected.Upload.Terminating {
+		// cannot safely finish while a co-listed upload may still write the
+		// archive. Upgrade an active legacy Job in place so the suspended cleanup
+		// workflow is durable before upload teardown starts. This also covers an
+		// upload that is already terminating: its pods may still be writing until
+		// foreground deletion completes.
+		if snapshotJobStatus(job) == SnapshotActive {
+			identity := *expected.Upload
+			_, pvc, resourceErr := getSnapshotUploadResources(ctx, client, owner, expected.Name, identity, exporter)
+			if resourceErr != nil {
+				return nil, nil, resourceErr
+			}
+			if pvc != nil {
+				identity.PVCUID = pvc.UID
+			}
+			updated := job.DeepCopy()
+			setSnapshotDeletionUploadIdentity(updated, owner, exporter, identity)
+			updated, err = client.BatchV1().Jobs(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+			if err != nil {
+				return nil, nil, fmt.Errorf("pair legacy snapshot deletion job %s/%s with upload UID %s: %w",
+					job.Namespace, job.Name, expected.Upload.UID, err)
+			}
+			if updated.UID != job.UID {
+				return nil, nil, fmt.Errorf("paired snapshot deletion job %s/%s has UID %s, expected %s",
+					updated.Namespace, updated.Name, updated.UID, job.UID)
+			}
+			job = updated
+			upload = &identity
+		} else if expected.Upload.Terminating {
+			// The legacy deletion already reached a terminal state, so there is no
+			// running deletion to suspend. Keep its durable marker until the
+			// foreground-terminating upload disappears; the orphan-upload path will
+			// then decide whether another external deletion is required.
+		} else {
 			if err = deleteSnapshotJob(ctx, client, job); err != nil {
 				return nil, nil, fmt.Errorf("replace unpaired snapshot deletion job %s/%s: %w", job.Namespace, job.Name, err)
 			}

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -433,6 +433,13 @@ func TestDeleteSnapshotForPreviousExporterUploadDerivesDeletionJob(t *testing.T)
 		VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/home/app/data"}},
 	}}
 	upload.Spec.Template.Spec.Volumes = []corev1.Volume{{Name: "data"}}
+	upload.Spec.Template.Labels = map[string]string{
+		"application":                        "dataexporter",
+		"controller-uid":                     "upload-uid",
+		"job-name":                           upload.Name,
+		"batch.kubernetes.io/controller-uid": "upload-uid",
+		"batch.kubernetes.io/job-name":       upload.Name,
+	}
 	client := fake.NewSimpleClientset(upload, pvc)
 
 	deletion, status, err := DeleteSnapshotForUpload(context.Background(), client, owner, SnapshotJob{
@@ -450,6 +457,11 @@ func TestDeleteSnapshotForPreviousExporterUploadDerivesDeletionJob(t *testing.T)
 	assert.Equal(t, "/app", job.Spec.Template.Spec.Containers[0].WorkingDir)
 	assert.Empty(t, job.Spec.Template.Spec.Containers[0].VolumeMounts)
 	assert.Empty(t, job.Spec.Template.Spec.Volumes)
+	assert.Equal(t, "dataexporter", job.Spec.Template.Labels["application"])
+	assert.NotContains(t, job.Spec.Template.Labels, "controller-uid")
+	assert.NotContains(t, job.Spec.Template.Labels, "job-name")
+	assert.NotContains(t, job.Spec.Template.Labels, "batch.kubernetes.io/controller-uid")
+	assert.NotContains(t, job.Spec.Template.Labels, "batch.kubernetes.io/job-name")
 	require.NotNil(t, job.Spec.Suspend)
 	assert.False(t, *job.Spec.Suspend)
 }
@@ -468,7 +480,7 @@ func TestReconcileLegacyDeletionReplacesActiveUnpairedUploadWorkflow(t *testing.
 	assert.True(t, apierrors.IsNotFound(getErr))
 }
 
-func TestCleanupLegacyDeletionRemovesDanglingUploadPVC(t *testing.T) {
+func TestCleanupLegacyDeletionRetainsUnattributedDanglingUploadPVC(t *testing.T) {
 	owner := testJobOwner()
 	deleteJob := desiredDeleteJob(owner, gcsExporter)
 	deleteJob.UID = "delete-uid"
@@ -483,8 +495,9 @@ func TestCleanupLegacyDeletionRemovesDanglingUploadPVC(t *testing.T) {
 	require.NoError(t, cleanupSnapshotDeletionResources(context.Background(), client, owner, SnapshotJob{
 		Name: "snapshot", UID: deleteJob.UID, Purpose: SnapshotJobDelete,
 	}, gcsExporter))
-	_, err := client.CoreV1().PersistentVolumeClaims(owner.Namespace).Get(context.Background(), pvc.Name, metav1.GetOptions{})
-	assert.True(t, apierrors.IsNotFound(err))
+	storedPVC, err := client.CoreV1().PersistentVolumeClaims(owner.Namespace).Get(context.Background(), pvc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, pvc.UID, storedPVC.UID)
 }
 
 func TestListSnapshotJobsIgnoresSameNamePreviousOwner(t *testing.T) {

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -298,6 +298,226 @@ func TestUploadJobStatusReportsMissingJob(t *testing.T) {
 	assert.Equal(t, SnapshotNotFound, status)
 }
 
+func TestDeletionJobStatusReportsMissingJobWithoutCreatingIt(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	status, err := deletionJobStatus(context.Background(), client, testJobOwner(), "default", "snapshot-delete", gcsExporter)
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotNotFound, status)
+	for _, action := range client.Actions() {
+		assert.False(t, action.GetVerb() == "create" && action.GetResource().Resource == "jobs")
+	}
+}
+
+func TestSnapshotJobsFromJobsRetainsUploadIdentityAlongsidePreferredDeletionJob(t *testing.T) {
+	deletionTimestamp := metav1.Now()
+	jobs := []batchv1.Job{
+		{ObjectMeta: metav1.ObjectMeta{Name: "snapshot-delete", UID: "delete-uid", Labels: map[string]string{labelType: typeDelete}}},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name:              "snapshot-upload",
+			UID:               "upload-uid",
+			DeletionTimestamp: &deletionTimestamp,
+			Labels:            map[string]string{labelType: typeUpload},
+		}},
+	}
+
+	assert.Equal(t, []SnapshotJob{{
+		Name:    "snapshot",
+		UID:     "delete-uid",
+		Purpose: SnapshotJobDelete,
+		Upload:  &SnapshotJobIdentity{UID: "upload-uid", Terminating: true},
+	}}, snapshotJobsFromJobs(jobs))
+}
+
+func TestSnapshotJobsFromJobsCarriesTerminatingUploadIdentity(t *testing.T) {
+	deletionTimestamp := metav1.Now()
+	jobs := []batchv1.Job{{ObjectMeta: metav1.ObjectMeta{
+		Name:              "snapshot-upload",
+		UID:               "upload-uid",
+		DeletionTimestamp: &deletionTimestamp,
+		Labels:            map[string]string{labelType: typeUpload},
+	}}}
+
+	assert.Equal(t, []SnapshotJob{{
+		Name:        "snapshot",
+		UID:         "upload-uid",
+		Purpose:     SnapshotJobUpload,
+		Terminating: true,
+	}}, snapshotJobsFromJobs(jobs))
+}
+
+func TestGetSnapshotUploadResourcesRejectsChangedIdentityOrOwnership(t *testing.T) {
+	owner := testJobOwner()
+	foreignOwner := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: "default", UID: "foreign-owner-uid"},
+	}
+	tests := []struct {
+		name      string
+		mutateJob func(*batchv1.Job)
+		mutatePVC func(*corev1.PersistentVolumeClaim)
+		wantError string
+	}{
+		{
+			name: "same-name replacement Job",
+			mutateJob: func(job *batchv1.Job) {
+				job.UID = "replacement-job-uid"
+			},
+			wantError: "UID",
+		},
+		{
+			name: "foreign controller",
+			mutateJob: func(job *batchv1.Job) {
+				job.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(foreignOwner)}
+			},
+			wantError: "not controlled by snapshot owner",
+		},
+		{
+			name: "changed provider",
+			mutateJob: func(job *batchv1.Job) {
+				job.Labels[labelExporter] = s3Exporter
+			},
+			wantError: "exporter label",
+		},
+		{
+			name: "changed type",
+			mutateJob: func(job *batchv1.Job) {
+				job.Labels[labelType] = typeDelete
+			},
+			wantError: "type label",
+		},
+		{
+			name: "same-name replacement PVC",
+			mutatePVC: func(pvc *corev1.PersistentVolumeClaim) {
+				pvc.UID = "replacement-pvc-uid"
+				pvc.OwnerReferences[0].UID = "replacement-job-uid"
+			},
+			wantError: "not controlled by upload job",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-upload",
+				Namespace: "default",
+				UID:       "listed-job-uid",
+				Labels: map[string]string{
+					labelExporter: gcsExporter,
+					labelOwner:    owner.Name,
+					labelType:     typeUpload,
+				},
+				OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+			}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Name:      job.Name,
+				Namespace: job.Namespace,
+				UID:       "listed-pvc-uid",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: batchv1.SchemeGroupVersion.String(),
+					Kind:       "Job",
+					Name:       job.Name,
+					UID:        job.UID,
+					Controller: ptr.To(true),
+				}},
+			}}
+			if tt.mutateJob != nil {
+				tt.mutateJob(job)
+			}
+			if tt.mutatePVC != nil {
+				tt.mutatePVC(pvc)
+			}
+			client := fake.NewSimpleClientset(job, pvc)
+
+			_, _, err := getSnapshotUploadResources(context.Background(), client, owner, SnapshotJob{
+				Name:    "snapshot",
+				UID:     "listed-job-uid",
+				Purpose: SnapshotJobUpload,
+			}, gcsExporter)
+			require.ErrorContains(t, err, tt.wantError)
+			for _, action := range client.Actions() {
+				assert.NotEqual(t, "delete", action.GetVerb())
+			}
+		})
+	}
+}
+
+func TestCleanupSnapshotDeletionResourcesRejectsChangedDeletionIdentityBeforeUploadCleanup(t *testing.T) {
+	owner := testJobOwner()
+	foreignOwner := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: "default", UID: "foreign-owner-uid"},
+	}
+	tests := []struct {
+		name      string
+		mutate    func(*batchv1.Job)
+		wantError string
+	}{
+		{
+			name: "same-name replacement",
+			mutate: func(job *batchv1.Job) {
+				job.UID = "replacement-delete-uid"
+			},
+			wantError: "UID",
+		},
+		{
+			name: "foreign replacement",
+			mutate: func(job *batchv1.Job) {
+				job.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(foreignOwner)}
+			},
+			wantError: "not controlled by snapshot owner",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uploadJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-upload",
+				Namespace: "default",
+				UID:       "upload-job-uid",
+				Labels: map[string]string{
+					labelExporter: gcsExporter,
+					labelOwner:    owner.Name,
+					labelType:     typeUpload,
+				},
+				OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+			}}
+			uploadPVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Name:      uploadJob.Name,
+				Namespace: uploadJob.Namespace,
+				UID:       "upload-pvc-uid",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: batchv1.SchemeGroupVersion.String(),
+					Kind:       "Job",
+					Name:       uploadJob.Name,
+					UID:        uploadJob.UID,
+					Controller: ptr.To(true),
+				}},
+			}}
+			deleteJob := desiredDeleteJob(owner, gcsExporter)
+			deleteJob.UID = "listed-delete-uid"
+			deleteJob.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(owner)}
+			tt.mutate(deleteJob)
+			client := fake.NewSimpleClientset(uploadJob, uploadPVC, deleteJob)
+
+			err := cleanupSnapshotDeletionResources(context.Background(), client, owner, SnapshotJob{
+				Name:    "snapshot",
+				UID:     "listed-delete-uid",
+				Purpose: SnapshotJobDelete,
+				Upload:  &SnapshotJobIdentity{UID: uploadJob.UID},
+			}, gcsExporter)
+			require.ErrorContains(t, err, tt.wantError)
+			for _, action := range client.Actions() {
+				assert.NotEqual(t, "delete", action.GetVerb(), "upload resources must survive an unverified deletion Job")
+			}
+			_, err = client.BatchV1().Jobs("default").Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			_, err = client.CoreV1().PersistentVolumeClaims("default").Get(context.Background(), uploadPVC.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestEnsureSnapshotJobKeepsJobWithMatchingLabels(t *testing.T) {
 	owner := testJobOwner()
 	existing := desiredDeleteJob(owner, "s3-exporter")
@@ -361,7 +581,7 @@ func TestCleanupSnapshotDeletionJobTreatsNotFoundAsSuccess(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	owner := testJobOwner()
 
-	require.NoError(t, cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter))
+	require.NoError(t, cleanupSnapshotDeletionJob(context.Background(), client, owner, testDeletionSnapshotJob("snapshot"), gcsExporter))
 	for _, action := range client.Actions() {
 		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "jobs")
 	}
@@ -374,7 +594,7 @@ func TestCleanupSnapshotDeletionJobWaitsForTerminatingJob(t *testing.T) {
 	job.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 	client := fake.NewSimpleClientset(job)
 
-	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, testDeletionSnapshotJob("snapshot"), gcsExporter)
 	require.ErrorIs(t, err, ErrStaleJobTerminating)
 
 	for _, action := range client.Actions() {
@@ -393,7 +613,7 @@ func TestCleanupSnapshotDeletionJobRejectsForeignJob(t *testing.T) {
 	job.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(foreignOwner)}
 	client := fake.NewSimpleClientset(job)
 
-	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, testDeletionSnapshotJob("snapshot"), gcsExporter)
 	require.ErrorContains(t, err, "not controlled by snapshot owner")
 
 	_, err = client.BatchV1().Jobs("default").Get(context.Background(), job.Name, metav1.GetOptions{})
@@ -439,7 +659,7 @@ func TestCleanupSnapshotDeletionJobReplacesMislabeledOwnedJob(t *testing.T) {
 			tt.mutate(job)
 			client := fake.NewSimpleClientset(job)
 
-			err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+			err := cleanupSnapshotDeletionJob(context.Background(), client, owner, testDeletionSnapshotJob("snapshot"), gcsExporter)
 			require.ErrorIs(t, err, ErrStaleJobReplaced)
 			var replacement *StaleJobReplacedError
 			require.ErrorAs(t, err, &replacement)
@@ -460,7 +680,7 @@ func TestCleanupSnapshotDeletionJobReportsGetFailure(t *testing.T) {
 		return true, nil, errors.New("get refused")
 	})
 
-	err := cleanupSnapshotDeletionJob(context.Background(), client, testJobOwner(), "snapshot", gcsExporter)
+	err := cleanupSnapshotDeletionJob(context.Background(), client, testJobOwner(), testDeletionSnapshotJob("snapshot"), gcsExporter)
 	require.ErrorContains(t, err, "get snapshot deletion job default/snapshot-delete")
 	require.ErrorContains(t, err, "get refused")
 }
@@ -478,7 +698,7 @@ func TestCleanupSnapshotDeletionJobReportsUIDPreconditionConflict(t *testing.T) 
 		)
 	})
 
-	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, "snapshot", gcsExporter)
+	err := cleanupSnapshotDeletionJob(context.Background(), client, owner, testDeletionSnapshotJob("snapshot"), gcsExporter)
 	require.True(t, apierrors.IsConflict(err))
 	require.ErrorContains(t, err, "delete snapshot deletion job default/snapshot-delete")
 	require.ErrorContains(t, err, "UID precondition did not match")
@@ -492,6 +712,10 @@ func testJobOwner() *corev1.ConfigMap {
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"},
 	}
+}
+
+func testDeletionSnapshotJob(name string) SnapshotJob {
+	return SnapshotJob{Name: name, Purpose: SnapshotJobDelete}
 }
 
 func ownerReferenceTo(owner *corev1.ConfigMap) metav1.OwnerReference {

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -367,6 +367,77 @@ func TestSnapshotJobsFromJobsCarriesTerminatingUploadIdentity(t *testing.T) {
 	}}, snapshotJobsFromJobs(jobs))
 }
 
+func TestListSnapshotJobsIncludesPreviousExporterDeletionWorkflow(t *testing.T) {
+	owner := testJobOwner()
+	client := fake.NewSimpleClientset(
+		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Name:      "previous-delete",
+			Namespace: owner.Namespace,
+			UID:       "previous-delete-uid",
+			Labels: map[string]string{
+				labelExporter:         s3Exporter,
+				labelOwner:            owner.Name,
+				labelType:             typeDelete,
+				labelCleanupExporter:  s3Exporter,
+				labelCleanupOwner:     owner.Name,
+				labelCleanupType:      typeUpload,
+				labelCleanupUploadUID: "previous-upload-uid",
+				labelCleanupPVCUID:    "previous-pvc-uid",
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		}},
+		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Name:      "current-upload",
+			Namespace: owner.Namespace,
+			UID:       "current-upload-uid",
+			Labels: map[string]string{
+				labelExporter: gcsExporter,
+				labelOwner:    owner.Name,
+				labelType:     typeUpload,
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		}},
+		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Name:      "previous-upload",
+			Namespace: owner.Namespace,
+			UID:       "old-upload-only-uid",
+			Labels: map[string]string{
+				labelExporter: s3Exporter,
+				labelOwner:    owner.Name,
+				labelType:     typeUpload,
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
+		}},
+	)
+
+	jobs, err := listSnapshotJobs(context.Background(), client, owner, gcsExporter)
+	require.NoError(t, err)
+	assert.Equal(t, []SnapshotJob{
+		{Name: "current", UID: "current-upload-uid", Purpose: SnapshotJobUpload},
+		{
+			Name: "previous", UID: "previous-delete-uid", Purpose: SnapshotJobDelete, Exporter: s3Exporter,
+			Upload: &SnapshotJobIdentity{UID: "previous-upload-uid", PVCUID: "previous-pvc-uid"},
+		},
+	}, jobs)
+}
+
+func TestSnapshotJobsFromJobsDoesNotPairDifferentExporterUpload(t *testing.T) {
+	jobs := []batchv1.Job{
+		{ObjectMeta: metav1.ObjectMeta{
+			Name: "snapshot-delete", UID: "delete-uid",
+			Labels: map[string]string{labelExporter: s3Exporter, labelType: typeDelete},
+		}},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name: "snapshot-upload", UID: "upload-uid",
+			Labels: map[string]string{labelExporter: gcsExporter, labelType: typeUpload},
+		}},
+	}
+
+	assert.Equal(t, []SnapshotJob{{
+		Name: "snapshot", UID: "delete-uid", Purpose: SnapshotJobDelete, Exporter: s3Exporter,
+	}}, snapshotJobsFromJobs(jobs, gcsExporter))
+}
+
 func TestGetSnapshotUploadResourcesRejectsChangedIdentityOrOwnership(t *testing.T) {
 	owner := testJobOwner()
 	foreignOwner := &corev1.ConfigMap{

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -298,10 +298,12 @@ func TestUploadJobStatusReportsMissingJob(t *testing.T) {
 	assert.Equal(t, SnapshotNotFound, status)
 }
 
-func TestDeletionJobStatusReportsMissingJobWithoutCreatingIt(t *testing.T) {
+func TestReconcileSnapshotDeletionJobReportsMissingJobWithoutCreatingIt(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
-	status, err := deletionJobStatus(context.Background(), client, testJobOwner(), "default", "snapshot-delete", gcsExporter)
+	status, err := reconcileSnapshotDeletionJob(context.Background(), client, testJobOwner(), SnapshotJob{
+		Name: "snapshot", Purpose: SnapshotJobDelete,
+	}, gcsExporter)
 	require.NoError(t, err)
 	assert.Equal(t, SnapshotNotFound, status)
 	for _, action := range client.Actions() {
@@ -327,6 +329,25 @@ func TestSnapshotJobsFromJobsRetainsUploadIdentityAlongsidePreferredDeletionJob(
 		Purpose: SnapshotJobDelete,
 		Upload:  &SnapshotJobIdentity{UID: "upload-uid", Terminating: true},
 	}}, snapshotJobsFromJobs(jobs))
+}
+
+func TestSnapshotJobsFromJobsRetainsRecordedUploadIdentityAfterUploadJobIsGone(t *testing.T) {
+	job := batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "snapshot-delete",
+		UID:  "delete-uid",
+		Labels: map[string]string{
+			labelType:             typeDelete,
+			labelCleanupUploadUID: "upload-uid",
+			labelCleanupPVCUID:    "pvc-uid",
+		},
+	}}
+
+	assert.Equal(t, []SnapshotJob{{
+		Name:    "snapshot",
+		UID:     "delete-uid",
+		Purpose: SnapshotJobDelete,
+		Upload:  &SnapshotJobIdentity{UID: "upload-uid", PVCUID: "pvc-uid"},
+	}}, snapshotJobsFromJobs([]batchv1.Job{job}))
 }
 
 func TestSnapshotJobsFromJobsCarriesTerminatingUploadIdentity(t *testing.T) {
@@ -429,17 +450,166 @@ func TestGetSnapshotUploadResourcesRejectsChangedIdentityOrOwnership(t *testing.
 			}
 			client := fake.NewSimpleClientset(job, pvc)
 
-			_, _, err := getSnapshotUploadResources(context.Background(), client, owner, SnapshotJob{
-				Name:    "snapshot",
-				UID:     "listed-job-uid",
-				Purpose: SnapshotJobUpload,
-			}, gcsExporter)
+			_, _, err := getSnapshotUploadResources(
+				context.Background(),
+				client,
+				owner,
+				"snapshot",
+				SnapshotJobIdentity{UID: "listed-job-uid", PVCUID: "listed-pvc-uid"},
+				gcsExporter,
+			)
 			require.ErrorContains(t, err, tt.wantError)
 			for _, action := range client.Actions() {
 				assert.NotEqual(t, "delete", action.GetVerb())
 			}
 		})
 	}
+}
+
+func TestReconcileSnapshotDeletionJobRejectsChangedDeletionOrCleanupIdentity(t *testing.T) {
+	owner := testJobOwner()
+	foreignOwner := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: "default", UID: "foreign-owner-uid"},
+	}
+	tests := []struct {
+		name      string
+		mutate    func(*batchv1.Job)
+		wantError string
+	}{
+		{name: "delete UID", mutate: func(job *batchv1.Job) { job.UID = "replacement-delete-uid" }, wantError: "UID"},
+		{name: "delete owner", mutate: func(job *batchv1.Job) {
+			job.OwnerReferences = []metav1.OwnerReference{ownerReferenceTo(foreignOwner)}
+		}, wantError: "not controlled by snapshot owner"},
+		{name: "delete provider", mutate: func(job *batchv1.Job) { job.Labels[labelExporter] = s3Exporter }, wantError: labelExporter},
+		{name: "delete owner label", mutate: func(job *batchv1.Job) { job.Labels[labelOwner] = foreignOwner.Name }, wantError: labelOwner},
+		{name: "delete type", mutate: func(job *batchv1.Job) { job.Labels[labelType] = typeUpload }, wantError: labelType},
+		{name: "cleanup provider", mutate: func(job *batchv1.Job) { job.Labels[labelCleanupExporter] = s3Exporter }, wantError: labelCleanupExporter},
+		{name: "cleanup owner", mutate: func(job *batchv1.Job) { job.Labels[labelCleanupOwner] = foreignOwner.Name }, wantError: labelCleanupOwner},
+		{name: "cleanup type", mutate: func(job *batchv1.Job) { job.Labels[labelCleanupType] = typeDelete }, wantError: labelCleanupType},
+		{name: "upload UID", mutate: func(job *batchv1.Job) { job.Labels[labelCleanupUploadUID] = "replacement-upload-uid" }, wantError: "records upload UID"},
+		{name: "PVC UID", mutate: func(job *batchv1.Job) { job.Labels[labelCleanupPVCUID] = "replacement-pvc-uid" }, wantError: "records upload PVC UID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := desiredDeleteJob(owner, gcsExporter)
+			job.UID = "listed-delete-uid"
+			setSnapshotDeletionUploadIdentity(job, owner, gcsExporter, SnapshotJobIdentity{
+				UID: "listed-upload-uid", PVCUID: "listed-pvc-uid",
+			})
+			expected := snapshotJobFromJob(job)
+			tt.mutate(job)
+			client := fake.NewSimpleClientset(job)
+
+			_, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+			require.ErrorContains(t, err, tt.wantError)
+			for _, action := range client.Actions() {
+				assert.NotContains(t, []string{"delete", "update"}, action.GetVerb())
+			}
+		})
+	}
+}
+
+func TestReconcileSnapshotDeletionJobKeepsSuspendedMarkerForSameNameUploadReplacement(t *testing.T) {
+	owner := testJobOwner()
+	deletionJob := desiredDeleteJob(owner, gcsExporter)
+	deletionJob.UID = "delete-uid"
+	setSnapshotDeletionUploadIdentity(deletionJob, owner, gcsExporter, SnapshotJobIdentity{
+		UID: "original-upload-uid", PVCUID: "original-pvc-uid",
+	})
+	replacementJob, replacementPVC := testOrphanUploadResources(owner, gcsExporter)
+	replacementJob.UID = "replacement-upload-uid"
+	replacementPVC.UID = "replacement-pvc-uid"
+	replacementPVC.OwnerReferences[0].UID = replacementJob.UID
+	client := fake.NewSimpleClientset(deletionJob, replacementJob, replacementPVC)
+
+	_, err := reconcileSnapshotDeletionJob(
+		context.Background(), client, owner, snapshotJobFromJob(deletionJob), gcsExporter,
+	)
+	require.ErrorContains(t, err, "UID")
+
+	storedDeletion, err := client.BatchV1().Jobs("default").Get(context.Background(), deletionJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, storedDeletion.Spec.Suspend)
+	assert.True(t, *storedDeletion.Spec.Suspend)
+	storedReplacement, err := client.BatchV1().Jobs("default").Get(context.Background(), replacementJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, replacementJob.UID, storedReplacement.UID)
+	for _, action := range client.Actions() {
+		assert.NotContains(t, []string{"delete", "update"}, action.GetVerb())
+	}
+}
+
+func TestReconcileSnapshotDeletionJobRetriesActivationAfterCrash(t *testing.T) {
+	owner := testJobOwner()
+	deletionJob := desiredDeleteJob(owner, gcsExporter)
+	deletionJob.UID = "delete-uid"
+	setSnapshotDeletionUploadIdentity(deletionJob, owner, gcsExporter, SnapshotJobIdentity{UID: "upload-uid"})
+	client := fake.NewSimpleClientset(deletionJob)
+	crashErr := errors.New("controller crashed before activation was persisted")
+	updateCalls := 0
+	client.PrependReactor("update", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls == 1 {
+			return true, nil, crashErr
+		}
+		return false, nil, nil
+	})
+	expected := snapshotJobFromJob(deletionJob)
+
+	_, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+	require.ErrorIs(t, err, crashErr)
+	stored, err := client.BatchV1().Jobs("default").Get(context.Background(), deletionJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Spec.Suspend)
+	assert.True(t, *stored.Spec.Suspend)
+
+	status, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	stored, err = client.BatchV1().Jobs("default").Get(context.Background(), deletionJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Spec.Suspend)
+	assert.False(t, *stored.Spec.Suspend)
+	assert.Equal(t, 2, updateCalls)
+}
+
+func TestReconcileSnapshotDeletionJobRecoversWhenActivationResponseIsLost(t *testing.T) {
+	owner := testJobOwner()
+	deletionJob := desiredDeleteJob(owner, gcsExporter)
+	deletionJob.UID = "delete-uid"
+	setSnapshotDeletionUploadIdentity(deletionJob, owner, gcsExporter, SnapshotJobIdentity{UID: "upload-uid"})
+	client := fake.NewSimpleClientset(deletionJob)
+	crashErr := errors.New("controller crashed after activation was persisted")
+	updateCalls := 0
+	client.PrependReactor("update", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls != 1 {
+			return false, nil, nil
+		}
+		updateAction, ok := action.(k8stesting.UpdateAction)
+		require.True(t, ok)
+		updated, ok := updateAction.GetObject().(*batchv1.Job)
+		require.True(t, ok)
+		require.NoError(t, client.Tracker().Update(
+			batchv1.SchemeGroupVersion.WithResource("jobs"), updated.DeepCopy(), updated.Namespace,
+		))
+		return true, nil, crashErr
+	})
+	expected := snapshotJobFromJob(deletionJob)
+
+	_, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+	require.ErrorIs(t, err, crashErr)
+	stored, err := client.BatchV1().Jobs("default").Get(context.Background(), deletionJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Spec.Suspend)
+	assert.False(t, *stored.Spec.Suspend)
+
+	status, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	assert.Equal(t, 1, updateCalls, "the activated deletion Job must not be started again")
 }
 
 func TestCleanupSnapshotDeletionResourcesRejectsChangedDeletionIdentityBeforeUploadCleanup(t *testing.T) {
@@ -732,6 +902,33 @@ func ownerReferenceToObject(owner metav1.Object) metav1.OwnerReference {
 		UID:        owner.GetUID(),
 		Controller: ptr.To(true),
 	}
+}
+
+func testOrphanUploadResources(owner metav1.Object, exporter string) (*batchv1.Job, *corev1.PersistentVolumeClaim) {
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "snapshot-upload",
+		Namespace: owner.GetNamespace(),
+		UID:       "upload-uid",
+		Labels: map[string]string{
+			labelExporter: exporter,
+			labelOwner:    owner.GetName(),
+			labelType:     typeUpload,
+		},
+		OwnerReferences: []metav1.OwnerReference{ownerReferenceToObject(owner)},
+	}}
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:      job.Name,
+		Namespace: job.Namespace,
+		UID:       "pvc-uid",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       "Job",
+			Name:       job.Name,
+			UID:        job.UID,
+			Controller: ptr.To(true),
+		}},
+	}}
+	return job, pvc
 }
 
 func desiredDeleteJob(owner *corev1.ConfigMap, exporter string) *batchv1.Job {

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -412,6 +412,8 @@ func TestListSnapshotJobsIncludesPreviousExporterDeletionWorkflow(t *testing.T) 
 
 	jobs, err := listSnapshotJobs(context.Background(), client, owner, gcsExporter)
 	require.NoError(t, err)
+	require.NotNil(t, jobs[1].Source)
+	jobs[1].Source = nil
 	assert.Equal(t, []SnapshotJob{
 		{Name: "current", UID: "current-upload-uid", Purpose: SnapshotJobUpload},
 		{Name: "old-upload-only", UID: "old-upload-only-uid", Purpose: SnapshotJobUpload, Exporter: s3Exporter},
@@ -464,6 +466,26 @@ func TestDeleteSnapshotForPreviousExporterUploadDerivesDeletionJob(t *testing.T)
 	assert.NotContains(t, job.Spec.Template.Labels, "batch.kubernetes.io/job-name")
 	require.NotNil(t, job.Spec.Suspend)
 	assert.False(t, *job.Spec.Suspend)
+}
+
+func TestDeleteSnapshotForPreviousExporterUploadUsesListedSourceAfterJobVanishes(t *testing.T) {
+	owner := testJobOwner()
+	upload, pvc := testOrphanUploadResources(owner, s3Exporter)
+	upload.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "dataexporter", Args: []string{"s3", "upload", "data", "snapshots", "snapshot"},
+	}}
+	client := fake.NewSimpleClientset(pvc)
+
+	deletion, status, err := DeleteSnapshotForUpload(context.Background(), client, owner, SnapshotJob{
+		Name: "snapshot", UID: upload.UID, Purpose: SnapshotJobUpload, Exporter: s3Exporter, Source: upload.DeepCopy(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	assert.Equal(t, s3Exporter, deletion.Exporter)
+	job, err := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), "snapshot-delete", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(upload.UID), job.Labels[labelCleanupUploadUID])
+	assert.Equal(t, string(pvc.UID), job.Labels[labelCleanupPVCUID])
 }
 
 func TestReconcileLegacyDeletionReplacesActiveUnpairedUploadWorkflow(t *testing.T) {

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -533,6 +533,98 @@ func TestReconcileLegacyDeletionWaitsForTerminatingUnpairedUpload(t *testing.T) 
 	assert.Equal(t, uploadJob.UID, storedUpload.UID)
 }
 
+func TestReconcileLegacyTerminalDeletionRunsAfterTerminatingUploadDisappears(t *testing.T) {
+	tests := []struct {
+		name   string
+		status batchv1.JobStatus
+	}{
+		{
+			name: "succeeded",
+			status: batchv1.JobStatus{
+				Succeeded: 1,
+				Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+		{
+			name: "failed",
+			status: batchv1.JobStatus{
+				Failed: 1,
+				Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner := testJobOwner()
+			deleteJob := desiredDeleteJob(owner, gcsExporter)
+			deleteJob.UID = "delete-uid"
+			deleteJob.Status = tt.status
+			uploadJob, uploadPVC := testOrphanUploadResources(owner, gcsExporter)
+			deletionTimestamp := metav1.Now()
+			uploadJob.DeletionTimestamp = &deletionTimestamp
+			client := fake.NewSimpleClientset(deleteJob, uploadJob, uploadPVC)
+			expected := snapshotJobsFromJobs([]batchv1.Job{*deleteJob, *uploadJob})[0]
+
+			status, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+			require.NoError(t, err)
+			require.Equal(t, SnapshotActive, status)
+
+			marker, err := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, string(uploadJob.UID), marker.Labels[labelCleanupUploadUID])
+			assert.Equal(t, string(uploadPVC.UID), marker.Labels[labelCleanupPVCUID])
+			assert.Equal(t, "true", marker.Labels[labelCleanupAfterUpload])
+			assert.Nil(t, marker.Spec.TTLSecondsAfterFinished)
+
+			worker, err := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), "snapshot-purge", metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, worker.Spec.Suspend)
+			assert.True(t, *worker.Spec.Suspend)
+			assert.True(t, metav1.IsControlledBy(worker, marker))
+
+			require.NoError(t, client.Tracker().Delete(
+				batchv1.SchemeGroupVersion.WithResource("jobs"), uploadJob.Namespace, uploadJob.Name,
+			))
+			status, err = reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+			require.NoError(t, err)
+			require.Equal(t, SnapshotActive, status)
+			worker, err = client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), worker.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, worker.Spec.Suspend)
+			assert.False(t, *worker.Spec.Suspend)
+
+			worker.Status = batchv1.JobStatus{
+				Succeeded: 1,
+				Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+				}},
+			}
+			require.NoError(t, client.Tracker().Update(
+				batchv1.SchemeGroupVersion.WithResource("jobs"), worker, worker.Namespace,
+			))
+			status, err = reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+			require.NoError(t, err)
+			assert.Equal(t, SnapshotSucceeded, status)
+
+			actionCount := len(client.Actions())
+			require.NoError(t, cleanupSnapshotDeletionResources(
+				context.Background(), client, owner, expected, gcsExporter,
+			))
+			deleteAction := requireJobDeleteAction(t, client.Actions()[actionCount:])
+			assert.Equal(t, marker.Name, deleteAction.GetName())
+			options := deleteAction.GetDeleteOptions()
+			require.NotNil(t, options.Preconditions)
+			require.NotNil(t, options.Preconditions.UID)
+			assert.Equal(t, marker.UID, *options.Preconditions.UID)
+		})
+	}
+}
+
 func TestCleanupLegacyDeletionRetainsUnattributedDanglingUploadPVC(t *testing.T) {
 	owner := testJobOwner()
 	deleteJob := desiredDeleteJob(owner, gcsExporter)

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -488,18 +488,49 @@ func TestDeleteSnapshotForPreviousExporterUploadUsesListedSourceAfterJobVanishes
 	assert.Equal(t, string(pvc.UID), job.Labels[labelCleanupPVCUID])
 }
 
-func TestReconcileLegacyDeletionReplacesActiveUnpairedUploadWorkflow(t *testing.T) {
+func TestReconcileLegacyDeletionPairsActiveUnpairedUploadWorkflowBeforeCleanup(t *testing.T) {
 	owner := testJobOwner()
 	deleteJob := desiredDeleteJob(owner, gcsExporter)
 	deleteJob.UID = "delete-uid"
-	uploadJob, _ := testOrphanUploadResources(owner, gcsExporter)
-	client := fake.NewSimpleClientset(deleteJob, uploadJob)
+	uploadJob, uploadPVC := testOrphanUploadResources(owner, gcsExporter)
+	client := fake.NewSimpleClientset(deleteJob, uploadJob, uploadPVC)
 	expected := snapshotJobsFromJobs([]batchv1.Job{*deleteJob, *uploadJob})[0]
 
-	_, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
-	require.ErrorIs(t, err, ErrStaleJobReplaced)
-	_, getErr := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
-	assert.True(t, apierrors.IsNotFound(getErr))
+	status, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	stored, err := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Spec.Suspend)
+	assert.False(t, *stored.Spec.Suspend)
+	assert.Equal(t, string(uploadJob.UID), stored.Labels[labelCleanupUploadUID])
+	assert.Equal(t, string(uploadPVC.UID), stored.Labels[labelCleanupPVCUID])
+	_, err = client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestReconcileLegacyDeletionWaitsForTerminatingUnpairedUpload(t *testing.T) {
+	owner := testJobOwner()
+	deleteJob := desiredDeleteJob(owner, gcsExporter)
+	deleteJob.UID = "delete-uid"
+	uploadJob, uploadPVC := testOrphanUploadResources(owner, gcsExporter)
+	deletionTimestamp := metav1.Now()
+	uploadJob.DeletionTimestamp = &deletionTimestamp
+	client := fake.NewSimpleClientset(deleteJob, uploadJob, uploadPVC)
+	expected := snapshotJobsFromJobs([]batchv1.Job{*deleteJob, *uploadJob})[0]
+
+	status, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	stored, err := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Spec.Suspend)
+	assert.True(t, *stored.Spec.Suspend)
+	assert.Equal(t, string(uploadJob.UID), stored.Labels[labelCleanupUploadUID])
+	assert.Equal(t, string(uploadPVC.UID), stored.Labels[labelCleanupPVCUID])
+	storedUpload, err := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), uploadJob.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, uploadJob.UID, storedUpload.UID)
 }
 
 func TestCleanupLegacyDeletionRetainsUnattributedDanglingUploadPVC(t *testing.T) {

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -421,6 +421,27 @@ func TestListSnapshotJobsIncludesPreviousExporterDeletionWorkflow(t *testing.T) 
 	}, jobs)
 }
 
+func TestListSnapshotJobsIgnoresSameNamePreviousOwner(t *testing.T) {
+	owner := testJobOwner()
+	previousOwner := owner.DeepCopy()
+	previousOwner.UID = "previous-owner-uid"
+	client := fake.NewSimpleClientset(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "previous-delete",
+		Namespace: owner.Namespace,
+		UID:       "previous-delete-uid",
+		Labels: map[string]string{
+			labelExporter: s3Exporter,
+			labelOwner:    owner.Name,
+			labelType:     typeDelete,
+		},
+		OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(previousOwner)},
+	}})
+
+	jobs, err := listSnapshotJobs(context.Background(), client, owner, gcsExporter)
+	require.NoError(t, err)
+	assert.Empty(t, jobs)
+}
+
 func TestSnapshotJobsFromJobsDoesNotPairDifferentExporterUpload(t *testing.T) {
 	jobs := []batchv1.Job{
 		{ObjectMeta: metav1.ObjectMeta{

--- a/internal/datasnapshot/snapshot_test.go
+++ b/internal/datasnapshot/snapshot_test.go
@@ -398,7 +398,7 @@ func TestListSnapshotJobsIncludesPreviousExporterDeletionWorkflow(t *testing.T) 
 			OwnerReferences: []metav1.OwnerReference{ownerReferenceTo(owner)},
 		}},
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
-			Name:      "previous-upload",
+			Name:      "old-upload-only-upload",
 			Namespace: owner.Namespace,
 			UID:       "old-upload-only-uid",
 			Labels: map[string]string{
@@ -414,11 +414,77 @@ func TestListSnapshotJobsIncludesPreviousExporterDeletionWorkflow(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, []SnapshotJob{
 		{Name: "current", UID: "current-upload-uid", Purpose: SnapshotJobUpload},
+		{Name: "old-upload-only", UID: "old-upload-only-uid", Purpose: SnapshotJobUpload, Exporter: s3Exporter},
 		{
 			Name: "previous", UID: "previous-delete-uid", Purpose: SnapshotJobDelete, Exporter: s3Exporter,
 			Upload: &SnapshotJobIdentity{UID: "previous-upload-uid", PVCUID: "previous-pvc-uid"},
 		},
 	}, jobs)
+}
+
+func TestDeleteSnapshotForPreviousExporterUploadDerivesDeletionJob(t *testing.T) {
+	owner := testJobOwner()
+	upload, pvc := testOrphanUploadResources(owner, s3Exporter)
+	upload.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name:         "dataexporter",
+		Image:        "dataexporter:test",
+		Args:         []string{"s3", "upload", "data", "snapshots", "snapshot"},
+		WorkingDir:   "/home/app",
+		VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/home/app/data"}},
+	}}
+	upload.Spec.Template.Spec.Volumes = []corev1.Volume{{Name: "data"}}
+	client := fake.NewSimpleClientset(upload, pvc)
+
+	deletion, status, err := DeleteSnapshotForUpload(context.Background(), client, owner, SnapshotJob{
+		Name: "snapshot", UID: upload.UID, Purpose: SnapshotJobUpload, Exporter: s3Exporter,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, SnapshotActive, status)
+	assert.Equal(t, s3Exporter, deletion.Exporter)
+
+	job, err := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), "snapshot-delete", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, s3Exporter, job.Labels[labelExporter])
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+	assert.Equal(t, []string{"s3", "delete", "snapshots", "snapshot"}, job.Spec.Template.Spec.Containers[0].Args)
+	assert.Equal(t, "/app", job.Spec.Template.Spec.Containers[0].WorkingDir)
+	assert.Empty(t, job.Spec.Template.Spec.Containers[0].VolumeMounts)
+	assert.Empty(t, job.Spec.Template.Spec.Volumes)
+	require.NotNil(t, job.Spec.Suspend)
+	assert.False(t, *job.Spec.Suspend)
+}
+
+func TestReconcileLegacyDeletionReplacesActiveUnpairedUploadWorkflow(t *testing.T) {
+	owner := testJobOwner()
+	deleteJob := desiredDeleteJob(owner, gcsExporter)
+	deleteJob.UID = "delete-uid"
+	uploadJob, _ := testOrphanUploadResources(owner, gcsExporter)
+	client := fake.NewSimpleClientset(deleteJob, uploadJob)
+	expected := snapshotJobsFromJobs([]batchv1.Job{*deleteJob, *uploadJob})[0]
+
+	_, err := reconcileSnapshotDeletionJob(context.Background(), client, owner, expected, gcsExporter)
+	require.ErrorIs(t, err, ErrStaleJobReplaced)
+	_, getErr := client.BatchV1().Jobs(owner.Namespace).Get(context.Background(), deleteJob.Name, metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(getErr))
+}
+
+func TestCleanupLegacyDeletionRemovesDanglingUploadPVC(t *testing.T) {
+	owner := testJobOwner()
+	deleteJob := desiredDeleteJob(owner, gcsExporter)
+	deleteJob.UID = "delete-uid"
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name: "snapshot-upload", Namespace: owner.Namespace, UID: "pvc-uid",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job", Name: "snapshot-upload", UID: "upload-uid", Controller: ptr.To(true),
+		}},
+	}}
+	client := fake.NewSimpleClientset(deleteJob, pvc)
+
+	require.NoError(t, cleanupSnapshotDeletionResources(context.Background(), client, owner, SnapshotJob{
+		Name: "snapshot", UID: deleteJob.UID, Purpose: SnapshotJobDelete,
+	}, gcsExporter))
+	_, err := client.CoreV1().PersistentVolumeClaims(owner.Namespace).Get(context.Background(), pvc.Name, metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestListSnapshotJobsIgnoresSameNamePreviousOwner(t *testing.T) {


### PR DESCRIPTION
## Summary
- persist tarball deletion success before removing the VolumeSnapshot or cleanup Job
- track upload/delete Job identity so orphan recovery cannot schedule duplicate deletion workflows
- use ownership and UID preconditions for VolumeSnapshot, Job, and PVC cleanup across crash/replacement races
- keep GCS and S3 deletion behavior symmetric

## Test plan
- `make test.unit`
- focused controller and datasnapshot package tests
- regression coverage for time/count retention, delete-Job disappearance, foreground cleanup, controller restart, and same-name replacements

Closes #83

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates tarball deletion and hardens orphan/legacy cleanup to stop duplicate delete Jobs and races. Persists terminal cleanup so we don’t recreate delete jobs after completion or while terminating, and resumes cleanup across restarts, exporter switches, or when snapshots/export are disabled.

- **Bug Fixes**
  - Persist deletion success via `cosmopilot.voluzi.com/tarball-deletion-complete` and track the delete job via `cosmopilot.voluzi.com/tarball-deletion-name`; persist terminal workflow state to avoid re-scheduling.
  - Reconcile deletion status without creating jobs; dedupe by Job UID/PVC UID/terminating; prefer the deletion job while retaining upload identity; recover orphan and legacy delete jobs.
  - Label delete jobs with owner; preserve exporter/owner scoping during recovery; ignore jobs from replaced nodes; scope actions to the current exporter.
  - Enforce UID preconditions and foreground deletes for `VolumeSnapshot`, `Job`, and `PVC`.
  - Skip retention while a tarball deletion is pending; do not restart deletion for terminating orphan uploads; resume cleanup across crashes or config changes.
  - Keep `GCS` and `S3` symmetric for deletion status, listings, and guarded cleanup.

<sup>Written for commit 6c5ade8fc2fc574da32a46e03ec84a6b7af79b6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

