### PR TITLE
fix: isolate cosmosigner discovery command

### DIFF
--- a/cmd/nodeutils/dns.go
+++ b/cmd/nodeutils/dns.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -38,6 +37,11 @@ func runWaitForDNSCommand(ctx context.Context, resolver dnsResolver, client http
 	if len(args) != 3 {
 		return fmt.Errorf("usage: node-utils wait-for-dns <hostname> <ip-address> <timeout>")
 	}
+	if net.ParseIP(args[1]) == nil {
+		// Fail immediately rather than after the whole timeout: an unset downward-API address is a
+		// pod-spec problem, not a publication delay.
+		return fmt.Errorf("invalid IP address %q", args[1])
+	}
 	timeout, err := time.ParseDuration(args[2])
 	if err != nil || timeout <= 0 {
 		return fmt.Errorf("invalid DNS wait timeout %q", args[2])
@@ -46,28 +50,42 @@ func runWaitForDNSCommand(ctx context.Context, resolver dnsResolver, client http
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// An inbound signer connection is definitive evidence that the signer has
-	// discovered this Pod. Keep the Pod-local DNS lookup running for diagnostics,
-	// but do not make it a prerequisite: the target and signer may use different
-	// DNS caches, and either cache can observe publication first.
-	dnsCtx, stopDNS := context.WithCancel(ctx)
-	defer stopDNS()
-	dnsResult := make(chan error, 1)
+	// Only an inbound signer connection releases this gate: it is the one observation that could only
+	// follow the signer resolving this Pod and authenticating against it. This Pod resolving its own
+	// published address proves nothing about the signer, which reads a different DNS cache, so the
+	// lookup runs alongside purely as a diagnostic for a gate that times out.
+	diagnosticCtx, stopDiagnostic := context.WithCancel(ctx)
+	defer stopDiagnostic()
+	dnsObservations := make(chan error, 1)
 	go func() {
-		dnsResult <- waitForDNSAddress(dnsCtx, resolver, args[0], args[1], interval)
+		dnsObservations <- waitForDNSAddress(diagnosticCtx, resolver, args[0], args[1], interval)
 	}()
 
-	if err := waitForSignerDiscovery(ctx, client, signerDiscoveryURL, interval); err != nil {
-		select {
-		case dnsErr := <-dnsResult:
-			if dnsErr != nil && !errors.Is(dnsErr, context.Canceled) {
-				return fmt.Errorf("%w; pod-local DNS observation: %v", err, dnsErr)
-			}
-		default:
-		}
-		return err
+	signerErr := waitForSignerDiscovery(ctx, client, signerDiscoveryURL, interval)
+	// Stop the diagnostic lookup and wait for it, so no lookup outlives this call.
+	stopDiagnostic()
+	dnsErr := <-dnsObservations
+
+	if signerErr == nil {
+		log.WithFields(log.Fields{
+			"hostname":       args[0],
+			"target_address": args[1],
+		}).Info("remote signer discovery confirmed")
+		return nil
 	}
-	return nil
+
+	dnsStatus := "address published"
+	if dnsErr != nil {
+		dnsStatus = dnsErr.Error()
+	}
+	failures := strings.Join([]string{
+		fmt.Sprintf("signer connection: %v", signerErr),
+		fmt.Sprintf("pod-local DNS: %s", dnsStatus),
+	}, "; ")
+	if cause := ctx.Err(); cause != nil {
+		return fmt.Errorf("remote signer discovery was not confirmed (%s): %w", failures, cause)
+	}
+	return fmt.Errorf("remote signer discovery was not confirmed (%s)", failures)
 }
 
 func waitForDNSAddress(ctx context.Context, resolver dnsResolver, hostname, address string, interval time.Duration) error {

--- a/cmd/nodeutils/dns_test.go
+++ b/cmd/nodeutils/dns_test.go
@@ -92,6 +92,42 @@ func TestWaitForDNSCommandAcceptsSignerConfirmationWhileLocalDNSIsStale(t *testi
 	}
 }
 
+// TestWaitForDNSCommandRequiresSignerConfirmationDespiteLocalDNSPublication is the converse of the
+// stale-DNS case: this Pod resolving its own published address only proves its own DNS cache caught
+// up. The signer reads a different cache, so local publication is diagnostic and an authenticated
+// signer connection stays mandatory.
+func TestWaitForDNSCommandRequiresSignerConfirmationDespiteLocalDNSPublication(t *testing.T) {
+	resolver := &sequenceDNSResolver{
+		responses: [][]net.IPAddr{{{IP: net.ParseIP("10.0.0.2")}}},
+	}
+	client := &sequenceHTTPDoer{errors: []error{errors.New("node-utils connection refused")}}
+
+	err := runWaitForDNSCommand(context.Background(), resolver, client,
+		[]string{"signer-privval.default.svc", "10.0.0.2", "20ms"}, time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runWaitForDNSCommand() error = %v, want deadline exceeded", err)
+	}
+	for _, want := range []string{"signer connection", "pod-local DNS: address published"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("runWaitForDNSCommand() error = %v, want it to report %q", err, want)
+		}
+	}
+}
+
+func TestWaitForDNSCommandRejectsInvalidPodAddress(t *testing.T) {
+	// An unexpanded or unset downward-API address is a pod-spec problem: report it now instead of
+	// spending the whole discovery timeout on it.
+	for _, address := range []string{"", "$(POD_IP)", "not-an-ip"} {
+		t.Run(address, func(t *testing.T) {
+			err := runWaitForDNSCommand(context.Background(), &sequenceDNSResolver{}, &sequenceHTTPDoer{},
+				[]string{"signer-privval.default.svc", address, "25s"}, time.Millisecond)
+			if err == nil || !strings.Contains(err.Error(), "invalid IP address") {
+				t.Fatalf("runWaitForDNSCommand() error = %v, want invalid-address error", err)
+			}
+		})
+	}
+}
+
 func TestWaitForDNSCommandRejectsWrongArgumentCount(t *testing.T) {
 	tests := []struct {
 		name string
@@ -124,13 +160,14 @@ func TestWaitForDNSCommandRejectsInvalidTimeout(t *testing.T) {
 	}
 }
 
-func TestWaitForDNSCommandTimesOutWithSignerDiscoveryDiagnostics(t *testing.T) {
+func TestWaitForDNSCommandTimesOutWithDiscoveryDiagnostics(t *testing.T) {
 	client := &sequenceHTTPDoer{
 		statuses: []int{0, http.StatusNotAcceptable},
 		errors:   []error{errors.New("node-utils connection refused")},
 	}
+	resolver := &sequenceDNSResolver{responses: [][]net.IPAddr{{{IP: net.ParseIP("10.0.0.1")}}}}
 	started := time.Now()
-	err := runWaitForDNSCommand(context.Background(), &sequenceDNSResolver{}, client,
+	err := runWaitForDNSCommand(context.Background(), resolver, client,
 		[]string{"signer-privval.default.svc", "10.0.0.2", "20ms"}, time.Millisecond)
 
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -139,11 +176,19 @@ func TestWaitForDNSCommandTimesOutWithSignerDiscoveryDiagnostics(t *testing.T) {
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("runWaitForDNSCommand() took %s, want bounded timeout", elapsed)
 	}
-	if !strings.Contains(err.Error(), "last status: Not Acceptable") {
-		t.Fatalf("runWaitForDNSCommand() error = %v, want last HTTP status", err)
-	}
-	if !strings.Contains(err.Error(), "last error: node-utils connection refused") {
-		t.Fatalf("runWaitForDNSCommand() error = %v, want last client error", err)
+	// The signer never confirmed, so the diagnostic lookup must be reported alongside it: whether
+	// the address was published locally is exactly what separates a signer that never dialed from a
+	// Service that never published this Pod.
+	for _, want := range []string{
+		"signer connection",
+		"last status: Not Acceptable",
+		"last error: node-utils connection refused",
+		"pod-local DNS",
+		"observed addresses: 10.0.0.1",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("runWaitForDNSCommand() error = %v, want it to report %q", err, want)
+		}
 	}
 }
 

--- a/cmd/nodeutils/dns_test.go
+++ b/cmd/nodeutils/dns_test.go
@@ -120,7 +120,7 @@ func TestWaitForDNSCommandRejectsInvalidPodAddress(t *testing.T) {
 	for _, address := range []string{"", "$(POD_IP)", "not-an-ip"} {
 		t.Run(address, func(t *testing.T) {
 			err := runWaitForDNSCommand(context.Background(), &sequenceDNSResolver{}, &sequenceHTTPDoer{},
-				[]string{"signer-privval.default.svc", address, "25s"}, time.Millisecond)
+				[]string{"signer-privval.default.svc", address, "20ms"}, time.Millisecond)
 			if err == nil || !strings.Contains(err.Error(), "invalid IP address") {
 				t.Fatalf("runWaitForDNSCommand() error = %v, want invalid-address error", err)
 			}

--- a/cmd/nodeutils/main.go
+++ b/cmd/nodeutils/main.go
@@ -75,6 +75,9 @@ func run(args []string, cmds commands) error {
 			printHelp()
 			return nil
 		case "mock":
+			if err := validateMockArgs(args[1:]); err != nil {
+				return err
+			}
 			cmds.mock(args[1:])
 			return nil
 		case "wait-for-dns":
@@ -100,6 +103,20 @@ func rejectPositionalArgs(args []string) error {
 		return nil
 	}
 	return fmt.Errorf("unexpected argument %q after flags: run `node-utils help`", args[0])
+}
+
+func validateMockArgs(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: node-utils mock <set-cpu <millicores>|set-memory <mib>|get>")
+	}
+	want := 1
+	if args[0] == "set-cpu" || args[0] == "set-memory" {
+		want = 2
+	}
+	if len(args) != want {
+		return fmt.Errorf("invalid arguments for node-utils mock %s", args[0])
+	}
+	return nil
 }
 
 func startServer() error {

--- a/cmd/nodeutils/main.go
+++ b/cmd/nodeutils/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -33,25 +34,79 @@ var (
 	haltHeight       int64
 )
 
+// subcommands are the standalone entry points this binary implements. They run in containers that
+// mount none of the server's runtime configuration, so they must never reach startServer.
+var subcommands = []string{"help", "mock", "wait-for-dns"}
+
+// commands are the entry points run dispatches to. Tests replace them to assert which one a given
+// argument list selects.
+type commands struct {
+	waitForDNS func([]string) error
+	mock       func([]string)
+	serve      func() error
+}
+
+func defaultCommands() commands {
+	return commands{
+		waitForDNS: handleWaitForDNSCommand,
+		mock:       handleMockCommand,
+		serve:      startServer,
+	}
+}
+
 func main() {
-	// Check for CLI subcommands before parsing flags
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "mock":
-			handleMockCommand(os.Args[2:])
-			return
-		case "wait-for-dns":
-			if err := handleWaitForDNSCommand(os.Args[2:]); err != nil {
-				log.Fatal(err)
-			}
-			return
-		case "help", "--help", "-h":
+	if err := run(os.Args[1:], defaultCommands()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// run selects a standalone subcommand before any server configuration is touched, and rejects a
+// leading argument that is neither a flag nor a subcommand this binary implements.
+//
+// The rejection is the point: flag.Parse stops at the first non-flag argument and reports nothing,
+// so an argument list this build does not recognise — a typo, or a subcommand emitted by a newer
+// cosmopilot than the node-utils image it deployed — used to fall through to startServer. The
+// containers that run subcommands mount no /config volume, so that fall-through surfaced as a
+// missing default /config/upgrades.json instead of the argument that was never understood.
+func run(args []string, cmds commands) error {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		switch args[0] {
+		case "help":
 			printHelp()
-			return
+			return nil
+		case "mock":
+			cmds.mock(args[1:])
+			return nil
+		case "wait-for-dns":
+			return cmds.waitForDNS(args[1:])
+		default:
+			return fmt.Errorf("unknown subcommand %q: this node-utils build implements %s",
+				args[0], strings.Join(subcommands, ", "))
 		}
 	}
 
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		printHelp()
+		return nil
+	}
+
+	return cmds.serve()
+}
+
+// rejectPositionalArgs turns the arguments flag.Parse stopped at into an error, so a stray
+// positional after the flags cannot be silently dropped either.
+func rejectPositionalArgs(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return fmt.Errorf("unexpected argument %q after flags: run `node-utils help`", args[0])
+}
+
+func startServer() error {
 	flag.Parse()
+	if err := rejectPositionalArgs(flag.Args()); err != nil {
+		return err
+	}
 
 	if level, err := log.ParseLevel(logLevel); err == nil {
 		log.SetLevel(level)
@@ -75,7 +130,7 @@ func main() {
 		nodeutils.WithMockMode(mockMode),
 	)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	go func() {
@@ -86,9 +141,7 @@ func main() {
 		}
 	}()
 
-	if err := nodeUtilsServer.Start(); err != nil {
-		log.Fatal(err)
-	}
+	return nodeUtilsServer.Start()
 }
 
 func printHelp() {

--- a/cmd/nodeutils/main.go
+++ b/cmd/nodeutils/main.go
@@ -38,6 +38,14 @@ var (
 // mount none of the server's runtime configuration, so they must never reach startServer.
 var subcommands = []string{"help", "mock", "wait-for-dns"}
 
+// mockCommandArity is the single command contract used before mock dispatch. Keeping command
+// recognition and exact arity together prevents validation from drifting from execution.
+var mockCommandArity = map[string]int{
+	"get":        1,
+	"set-cpu":    2,
+	"set-memory": 2,
+}
+
 // commands are the entry points run dispatches to. Tests replace them to assert which one a given
 // argument list selects.
 type commands struct {
@@ -109,9 +117,9 @@ func validateMockArgs(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("usage: node-utils mock <set-cpu <millicores>|set-memory <mib>|get>")
 	}
-	want := 1
-	if args[0] == "set-cpu" || args[0] == "set-memory" {
-		want = 2
+	want, ok := mockCommandArity[args[0]]
+	if !ok {
+		return fmt.Errorf("unknown node-utils mock command %q", args[0])
 	}
 	if len(args) != want {
 		return fmt.Errorf("invalid arguments for node-utils mock %s", args[0])
@@ -197,10 +205,6 @@ func handleMockCommand(args []string) {
 
 	switch args[0] {
 	case "set-cpu":
-		if len(args) < 2 {
-			fmt.Println("Usage: node-utils mock set-cpu <millicores>")
-			os.Exit(1)
-		}
 		url := fmt.Sprintf("%s/mock/cpu?millicores=%s", baseURL, args[1])
 		resp, err := http.Post(url, "text/plain", bytes.NewBuffer(nil))
 		if err != nil {
@@ -216,10 +220,6 @@ func handleMockCommand(args []string) {
 		fmt.Printf("CPU set to %s millicores\n", args[1])
 
 	case "set-memory":
-		if len(args) < 2 {
-			fmt.Println("Usage: node-utils mock set-memory <mib>")
-			os.Exit(1)
-		}
 		url := fmt.Sprintf("%s/mock/memory?mib=%s", baseURL, args[1])
 		fmt.Printf("DEBUG: POST %s\n", url)
 		resp, err := http.Post(url, "text/plain", bytes.NewBuffer(nil))

--- a/cmd/nodeutils/main_test.go
+++ b/cmd/nodeutils/main_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+)
+
+// testCommands fails the test if the node-utils server is ever started. Standalone subcommands run
+// in containers that mount none of the server's runtime configuration, so any argument list that
+// reaches startServer fails on that missing configuration rather than on the arguments themselves.
+func testCommands(t *testing.T) commands {
+	t.Helper()
+	return commands{
+		waitForDNS: func([]string) error {
+			t.Fatal("run() dispatched wait-for-dns unexpectedly")
+			return nil
+		},
+		mock: func([]string) { t.Fatal("run() dispatched the mock command unexpectedly") },
+		serve: func() error {
+			t.Fatalf("run() reached node-utils server startup, which requires %s", nodeutils.DefaultUpgradesConfig)
+			return nil
+		},
+	}
+}
+
+// requireNoServerConfiguration asserts the premise the wait-for-dns tests rely on: the default
+// upgrades config the server would load is genuinely absent, exactly as it is in the generated
+// discovery gate container.
+func requireNoServerConfiguration(t *testing.T) {
+	t.Helper()
+	if _, err := os.Stat(nodeutils.DefaultUpgradesConfig); err == nil {
+		t.Skipf("%s exists in this environment; cannot assert the no-config guarantee", nodeutils.DefaultUpgradesConfig)
+	}
+}
+
+func TestRunWaitForDNSRunsWithoutServerConfiguration(t *testing.T) {
+	requireNoServerConfiguration(t)
+
+	var forwarded []string
+	cmds := testCommands(t)
+	cmds.waitForDNS = func(args []string) error {
+		forwarded = append([]string(nil), args...)
+		// The signer has dialed this Pod and the node-utils sidecar recorded the authenticated
+		// The command is dispatched directly without touching server configuration. Simulate the
+		// authenticated signer confirmation that releases the gate.
+		return runWaitForDNSCommand(
+			context.Background(),
+			&sequenceDNSResolver{responses: [][]net.IPAddr{{{IP: net.ParseIP("10.0.0.2")}}}},
+			&sequenceHTTPDoer{statuses: []int{http.StatusOK}},
+			args,
+			time.Millisecond,
+		)
+	}
+
+	if err := run([]string{"wait-for-dns", "signer-privval.default.svc", "10.0.0.2", "25s"}, cmds); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"signer-privval.default.svc", "10.0.0.2", "25s"}
+	if !reflect.DeepEqual(forwarded, want) {
+		t.Fatalf("wait-for-dns arguments = %q, want %q", forwarded, want)
+	}
+}
+
+// TestRunRejectsUnknownSubcommand covers the failure this binary used to report as a missing
+// /config/upgrades.json: flag.Parse stops at the first non-flag argument without reporting it, so an
+// unrecognized subcommand fell through to server startup. It must name the argument instead.
+func TestRunRejectsUnknownSubcommand(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "subcommand from a newer operator", args: []string{"wait-for-signer", "signer-privval.default.svc", "10.0.0.2", "25s"}},
+		{name: "misspelled subcommand", args: []string{"wait-for-dnss", "signer-privval.default.svc", "10.0.0.2", "25s"}},
+		{name: "bare argument", args: []string{"serve"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := run(tt.args, testCommands(t))
+			if err == nil {
+				t.Fatal("run() accepted an unknown subcommand")
+			}
+			if !strings.Contains(err.Error(), "unknown subcommand") || !strings.Contains(err.Error(), tt.args[0]) {
+				t.Fatalf("run() error = %v, want it to name the unknown subcommand", err)
+			}
+			for _, name := range subcommands {
+				if !strings.Contains(err.Error(), name) {
+					t.Fatalf("run() error = %v, want it to list the supported subcommand %q", err, name)
+				}
+			}
+		})
+	}
+}
+
+func TestRunDispatchesStandaloneSubcommands(t *testing.T) {
+	t.Run("mock", func(t *testing.T) {
+		var forwarded []string
+		cmds := testCommands(t)
+		cmds.mock = func(args []string) { forwarded = append([]string(nil), args...) }
+
+		if err := run([]string{"mock", "set-cpu", "500"}, cmds); err != nil {
+			t.Fatal(err)
+		}
+		if want := []string{"set-cpu", "500"}; !reflect.DeepEqual(forwarded, want) {
+			t.Fatalf("mock arguments = %q, want %q", forwarded, want)
+		}
+	})
+
+	for _, args := range [][]string{{"help"}, {"--help"}, {"-h"}} {
+		t.Run(args[0], func(t *testing.T) {
+			if err := run(args, testCommands(t)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestRunStartsServerWithoutSubcommand(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+	}{
+		{name: "no arguments"},
+		{name: "flags only", args: []string{"-log-level", "debug"}},
+		{name: "long flags only", args: []string{"--tmkms-proxy=true"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			started := false
+			cmds := testCommands(t)
+			cmds.serve = func() error {
+				started = true
+				return nil
+			}
+
+			if err := run(tt.args, cmds); err != nil {
+				t.Fatal(err)
+			}
+			if !started {
+				t.Fatal("run() did not start the node-utils server")
+			}
+		})
+	}
+}
+
+func TestRejectPositionalArgs(t *testing.T) {
+	if err := rejectPositionalArgs(nil); err != nil {
+		t.Fatalf("rejectPositionalArgs(nil) = %v, want nil", err)
+	}
+	err := rejectPositionalArgs([]string{"wait-for-dns", "signer-privval.default.svc"})
+	if err == nil || !strings.Contains(err.Error(), "wait-for-dns") {
+		t.Fatalf("rejectPositionalArgs() error = %v, want it to name the leftover argument", err)
+	}
+}

--- a/cmd/nodeutils/main_test.go
+++ b/cmd/nodeutils/main_test.go
@@ -103,6 +103,8 @@ func TestRunRejectsMalformedMockArguments(t *testing.T) {
 	for _, args := range [][]string{
 		{"mock"},
 		{"mock", "get", "extra"},
+		{"mock", "bogus"},
+		{"mock", "bogus", "extra"},
 		{"mock", "set-cpu"},
 		{"mock", "set-cpu", "500", "extra"},
 		{"mock", "set-memory"},

--- a/cmd/nodeutils/main_test.go
+++ b/cmd/nodeutils/main_test.go
@@ -48,7 +48,6 @@ func TestRunWaitForDNSRunsWithoutServerConfiguration(t *testing.T) {
 	cmds := testCommands(t)
 	cmds.waitForDNS = func(args []string) error {
 		forwarded = append([]string(nil), args...)
-		// The signer has dialed this Pod and the node-utils sidecar recorded the authenticated
 		// The command is dispatched directly without touching server configuration. Simulate the
 		// authenticated signer confirmation that releases the gate.
 		return runWaitForDNSCommand(
@@ -95,6 +94,24 @@ func TestRunRejectsUnknownSubcommand(t *testing.T) {
 				if !strings.Contains(err.Error(), name) {
 					t.Fatalf("run() error = %v, want it to list the supported subcommand %q", err, name)
 				}
+			}
+		})
+	}
+}
+
+func TestRunRejectsMalformedMockArguments(t *testing.T) {
+	for _, args := range [][]string{
+		{"mock"},
+		{"mock", "get", "extra"},
+		{"mock", "set-cpu"},
+		{"mock", "set-cpu", "500", "extra"},
+		{"mock", "set-memory"},
+		{"mock", "set-memory", "512", "extra"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			err := run(args, testCommands(t))
+			if err == nil || !strings.Contains(err.Error(), "node-utils mock") {
+				t.Fatalf("run(%q) error = %v, want mock usage error", args, err)
 			}
 		})
 	}

--- a/internal/controllers/chainnode/cosmosigner_test.go
+++ b/internal/controllers/chainnode/cosmosigner_test.go
@@ -1580,6 +1580,27 @@ func TestRemoteSignerTargetPodWaitsForDiscoveryPublication(t *testing.T) {
 			require.NotNil(t, gate.Env[0].ValueFrom)
 			require.NotNil(t, gate.Env[0].ValueFrom.FieldRef)
 			assert.Equal(t, "status.podIP", gate.Env[0].ValueFrom.FieldRef.FieldPath)
+
+			// The gate is a narrow probe: `node-utils wait-for-dns` reads no server configuration, so
+			// it must keep mounting nothing. Mounting the config volume here would be the wrong fix
+			// for the missing /config/upgrades.json this container used to fail on.
+			assert.Empty(t, gate.VolumeMounts, "the discovery gate must not mount runtime configuration")
+			assert.Nil(t, gate.RestartPolicy, "the discovery gate must run to completion, not linger as a sidecar")
+
+			nodeUtilsIndex, gateIndex := -1, -1
+			for i := range pod.Spec.InitContainers {
+				switch pod.Spec.InitContainers[i].Name {
+				case nodeUtilsContainerName:
+					nodeUtilsIndex = i
+				case CosmosignerDiscoveryWaitContainerName:
+					gateIndex = i
+				}
+			}
+			require.NotEqual(t, -1, nodeUtilsIndex, "the node-utils sidecar must be present")
+			assert.Greater(t, gateIndex, nodeUtilsIndex,
+				"the gate must start after the node-utils sidecar, which is the only thing that can confirm an inbound signer connection")
+			assert.Equal(t, len(pod.Spec.InitContainers)-1, gateIndex,
+				"the gate must be the last init container, so the app starts only once discovery is published")
 		})
 	}
 }

--- a/test/e2e/chainnodeset_cosmosigner_test.go
+++ b/test/e2e/chainnodeset_cosmosigner_test.go
@@ -495,21 +495,22 @@ func waitForCosmosignerRetargetCompletion(cns *appsv1.ChainNodeSet, logicalName,
 		pollTimeout  = 8 * time.Minute
 	)
 	deadline := time.Now().Add(pollTimeout)
-	sawMigration := false
 	for {
 		current := &appsv1.ChainNodeSet{}
-		Expect(Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current)).To(Succeed())
+		if err := Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current); err != nil {
+			Expect(time.Now()).To(BeTemporally("<", deadline),
+				"timed out reading the ChainNodeSet while waiting for the retarget to %s: %v", targetPodName, err)
+			time.Sleep(pollInterval)
+			continue
+		}
 		status := current.GetCosmosignerStatus(logicalName)
 		Expect(status).NotTo(BeNil(), "signer %q lost its status entry during the retarget", logicalName)
 		switch {
 		case status.Migration != nil:
-			sawMigration = true
 		case status.AppliedDigest != "" && status.AppliedDigest != previousDigest:
 			Expect(cosmosignerTargetPodServed(
 				cns.GetNamespace(), targetPodName, appsv1.CosmosignerStatusResourceName(status),
 			)).To(BeTrue(), "the retarget completed before %s was running, ready and past its discovery gate", targetPodName)
-			Expect(sawMigration).To(BeTrue(),
-				"the retarget must run through the migration state machine, not swap targets in place")
 			return status.DeepCopy()
 		}
 		Expect(time.Now()).To(BeTemporally("<", deadline),

--- a/test/e2e/chainnodeset_cosmosigner_test.go
+++ b/test/e2e/chainnodeset_cosmosigner_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
 	"github.com/voluzi/cosmopilot/v2/internal/controllers"
 	chainnodecontroller "github.com/voluzi/cosmopilot/v2/internal/controllers/chainnode"
 	managedcosmosigner "github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
@@ -49,6 +50,8 @@ var _ = Describe("ChainNodeSet Cosmosigner", func() {
 				// happens if the validator node's remote signer is actually signing.
 				WaitForChainNodeSetHeight(cns, 3)
 				signerName := fmt.Sprintf("%s-signer", cns.GetName())
+				signerStatus := waitForCosmosignerApplied(cns, signerName)
+				reservation := waitForConsensusKeyReservation(cns, signerStatus.PublicKey)
 				validatorPodName := fmt.Sprintf("%s-validator", cns.GetName())
 				validatorPod := waitForReadyCosmosignerTargetPod(
 					ns.Name, validatorPodName, signerName, cns.Spec.App.App,
@@ -57,6 +60,7 @@ var _ = Describe("ChainNodeSet Cosmosigner", func() {
 					validatorPod = replaceCosmosignerTargetPodOnce(
 						cns, validatorPod, signerName, cns.Spec.App.App, cycle,
 					)
+					assertConsensusKeyReservationUnchanged(reservation)
 				}
 
 				sts := &appsv1k8s.StatefulSet{}
@@ -245,6 +249,88 @@ var _ = Describe("ChainNodeSet Cosmosigner", func() {
 			setPodTestFinalizer(ns.Name, heldNames[1], false)
 			waitForReadySignerPods(ns.Name, resourceName, 3)
 		})
+
+		It("should keep a two-sentry retarget migrating until the new target is served, then settle without pod churn", func() {
+			requireCosmosignerE2E()
+			app := apps.Nibiru()
+			ns := CreateTestNamespace()
+			cns := buildSentryRetargetCosmosignerSet(app, ns.Name, createCosmosignerSentryKeySecret(ns.Name))
+			Expect(Framework().Client().Create(Framework().Context(), cns)).To(Succeed())
+
+			// Fresh rollout: the signer dials sentry A, whose app only starts once the discovery
+			// Service publishes that pod to the signer.
+			WaitForChainNodeSetHeight(cns, 3)
+			signerName := fmt.Sprintf("%s-signer", cns.Name)
+			sentryA := fmt.Sprintf("%s-%s-0", cns.Name, cosmosignerSentryGroupA)
+			sentryB := fmt.Sprintf("%s-%s-0", cns.Name, cosmosignerSentryGroupB)
+			appliedOnA := waitForCosmosignerApplied(cns, signerName)
+			Expect(appsv1.CosmosignerStatusResourceName(appliedOnA)).To(Equal(signerName))
+			Expect(appliedOnA.TargetGroups).To(ConsistOf(cosmosignerSentryGroupA))
+			reservation := waitForConsensusKeyReservation(cns, appliedOnA.PublicKey)
+			waitForReadyCosmosignerTargetPod(ns.Name, sentryA, signerName, cns.Spec.App.App)
+			waitForReadySignerPods(ns.Name, signerName, 1)
+
+			retargetTopLevelCosmosigner(cns, cosmosignerSentryGroupB)
+			appliedOnB := waitForCosmosignerRetargetCompletion(cns, signerName, sentryB, appliedOnA.AppliedDigest)
+
+			// The retarget only changes which pods the signer dials, so it keeps the same key and the
+			// same resource identity: a new public key here would mean the sentry stopped signing as
+			// itself, and a new resource name would mean its raft state was abandoned.
+			Expect(appliedOnB.PublicKey).To(Equal(appliedOnA.PublicKey))
+			Expect(appsv1.CosmosignerStatusResourceName(appliedOnB)).To(Equal(signerName))
+			Expect(appliedOnB.TargetGroups).To(ConsistOf(cosmosignerSentryGroupB))
+			assertConsensusKeyReservationUnchanged(reservation)
+
+			targetPod := waitForReadyCosmosignerTargetPod(ns.Name, sentryB, signerName, cns.Spec.App.App)
+			assertNoCosmosignerDiscoveryPubKeyFailure(ns.Name, sentryB, cns.Spec.App.App, 1)
+			signerPods := waitForReadySignerPods(ns.Name, signerName, 1)
+			settledSignerUID := signerPods[0].UID
+
+			// Sentry A must be released back to local signing, not left selected by the discovery
+			// Service alongside B.
+			Eventually(func(g Gomega) {
+				pod := &corev1.Pod{}
+				g.Expect(Framework().Client().Get(
+					Framework().Context(), client.ObjectKey{Namespace: ns.Name, Name: sentryA}, pod,
+				)).To(Succeed())
+				g.Expect(pod.DeletionTimestamp).To(BeNil())
+				g.Expect(pod.Labels).NotTo(HaveKey(controllers.LabelCosmosignerTarget))
+				g.Expect(podReady(pod)).To(BeTrue())
+			}, 3*time.Minute, time.Second).Should(Succeed())
+
+			// A settled retarget stays settled: re-opening the migration, or replacing either the
+			// signer pod or the freshly targeted pod again, is the recurring churn this guards.
+			heightAfterRetarget, err := observedChainNodeSetHeight(cns)
+			Expect(err).NotTo(HaveOccurred())
+			Consistently(func(g Gomega) {
+				current := &appsv1.ChainNodeSet{}
+				g.Expect(Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current)).To(Succeed())
+				status := current.GetCosmosignerStatus(signerName)
+				g.Expect(status).NotTo(BeNil())
+				g.Expect(status.Migration).To(BeNil(), "the settled retarget must not re-open a migration")
+
+				pods, err := listSignerPods(ns.Name, signerName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods).To(HaveLen(1))
+				g.Expect(pods[0].UID).To(Equal(settledSignerUID), "the signer pod must not churn after the retarget")
+
+				pod := &corev1.Pod{}
+				g.Expect(Framework().Client().Get(
+					Framework().Context(), client.ObjectKey{Namespace: ns.Name, Name: sentryB}, pod,
+				)).To(Succeed())
+				g.Expect(pod.UID).To(Equal(targetPod.UID), "the new target pod must not be replaced again")
+				g.Expect(podReady(pod)).To(BeTrue())
+				g.Expect(cosmosignerDiscoveryGateSucceeded(pod)).To(BeTrue())
+				restartCount, previousLogs, found := appContainerRestartDetails(ns.Name, pod, cns.Spec.App.App)
+				g.Expect(found).To(BeTrue(), "app container %q status is missing", cns.Spec.App.App)
+				g.Expect(restartCount).To(BeZero(), "the new target's app container restarted; previous logs:\n%s", previousLogs)
+			}, 35*time.Second, 500*time.Millisecond).Should(Succeed())
+
+			Eventually(func() (int64, error) {
+				return observedChainNodeSetHeight(cns)
+			}, time.Minute, time.Second).Should(BeNumerically(">", heightAfterRetarget),
+				"the chain must keep advancing after the retarget settles")
+		})
 	})
 })
 
@@ -252,6 +338,39 @@ func requireCosmosignerE2E() {
 	if !Framework().Config().InstallVault {
 		Skip("cosmosigner e2e is opt-in (enable with the Vault install flag)")
 	}
+}
+
+func waitForConsensusKeyReservation(cns *appsv1.ChainNodeSet, publicKey string) *appsv1.ConsensusKeyReservation {
+	var result *appsv1.ConsensusKeyReservation
+	Eventually(func(g Gomega) {
+		current := &appsv1.ChainNodeSet{}
+		g.Expect(Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current)).To(Succeed())
+		g.Expect(current.Status.ChainID).NotTo(BeEmpty())
+		g.Expect(publicKey).NotTo(BeEmpty())
+
+		reservation := &appsv1.ConsensusKeyReservation{}
+		g.Expect(Framework().Client().Get(Framework().Context(), client.ObjectKey{
+			Name: managedcosmosigner.ConsensusKeyReservationName(current.Status.ChainID, publicKey),
+		}, reservation)).To(Succeed())
+		g.Expect(reservation.Spec.ChainID).To(Equal(current.Status.ChainID))
+		g.Expect(reservation.Spec.PublicKey).To(Equal(publicKey))
+		g.Expect(reservation.Spec.OwnerUID).To(Equal(current.UID))
+		g.Expect(reservation.Spec.OwnerKind).To(Equal("ChainNodeSet"))
+		g.Expect(reservation.Spec.Namespace).To(Equal(current.Namespace))
+		g.Expect(reservation.Spec.OwnerName).To(Equal(current.Name))
+		g.Expect(reservation.Spec.Claim).NotTo(BeEmpty())
+		result = reservation.DeepCopy()
+	}).Should(Succeed())
+	return result
+}
+
+func assertConsensusKeyReservationUnchanged(want *appsv1.ConsensusKeyReservation) {
+	Consistently(func(g Gomega) {
+		current := &appsv1.ConsensusKeyReservation{}
+		g.Expect(Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(want), current)).To(Succeed())
+		g.Expect(current.UID).To(Equal(want.UID), "the consensus-key reservation must not be released and recreated")
+		g.Expect(current.Spec).To(Equal(want.Spec), "the consensus-key reservation owner, claim and public key must remain unchanged")
+	}, 5*time.Second, 500*time.Millisecond).Should(Succeed())
 }
 
 func buildNamedValidatorCosmosignerSet(app apps.TestApp, namespace string, replicas int32) *appsv1.ChainNodeSet {
@@ -300,6 +419,120 @@ func moveTopLevelCosmosignerIntoGroup(cns *appsv1.ChainNodeSet, groupName string
 		}
 		return fmt.Errorf("node group %q not found", groupName)
 	}).Should(Succeed())
+}
+
+const (
+	cosmosignerSentryGroupA = "sentry-a"
+	cosmosignerSentryGroupB = "sentry-b"
+)
+
+// buildSentryRetargetCosmosignerSet builds a ChainNodeSet with a self-signing validator and two
+// interchangeable sentry groups, plus a sentry-mode signer dialing the first of them. The validator
+// signs locally and keeps producing blocks throughout, so the chain height stays an independent
+// witness of the retarget rather than a restatement of it.
+func buildSentryRetargetCosmosignerSet(app apps.TestApp, namespace, keySecretName string) *appsv1.ChainNodeSet {
+	cns := app.BuildChainNodeSet(namespace, 0)
+	cns.Name = fmt.Sprintf("e2e-nibiru-retarget-%s", RandString(6))
+	cns.GenerateName = ""
+
+	// Both sentries reuse the generated fullnode group's config, so the targeted group is the only
+	// difference between A and B.
+	template := cns.Spec.Nodes[0]
+	groups := make([]appsv1.NodeGroupSpec, 0, 2)
+	for _, name := range []string{cosmosignerSentryGroupA, cosmosignerSentryGroupB} {
+		group := template.DeepCopy()
+		group.Name = name
+		group.Instances = ptr.To(1)
+		groups = append(groups, *group)
+	}
+	cns.Spec.Nodes = groups
+
+	cns.Spec.Cosmosigner = &appsv1.Cosmosigner{
+		NodeGroups: []string{cosmosignerSentryGroupA},
+		Replicas:   ptr.To[int32](1),
+		Backend: appsv1.CosmosignerBackend{
+			Software: &appsv1.CosmosignerSoftwareBackend{PrivateKeySecret: ptr.To(keySecretName)},
+		},
+	}
+	return cns
+}
+
+// createCosmosignerSentryKeySecret creates the out-of-band consensus key a sentry-mode signer must
+// carry: targeting no validator, it has no controller-registered key to reuse.
+func createCosmosignerSentryKeySecret(namespace string) string {
+	key, err := cometbft.GeneratePrivKey()
+	Expect(err).NotTo(HaveOccurred())
+	const name = "e2e-cosmosigner-sentry-priv-key"
+	Expect(Framework().Client().Create(Framework().Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       map[string][]byte{chainnodecontroller.PrivKeyFilename: key},
+	})).To(Succeed())
+	return name
+}
+
+func retargetTopLevelCosmosigner(cns *appsv1.ChainNodeSet, groups ...string) {
+	Eventually(func() error {
+		current := &appsv1.ChainNodeSet{}
+		if err := Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current); err != nil {
+			return err
+		}
+		if current.Spec.Cosmosigner == nil {
+			return fmt.Errorf("top-level cosmosigner is absent")
+		}
+		current.Spec.Cosmosigner.NodeGroups = append([]string(nil), groups...)
+		return Framework().Client().Update(Framework().Context(), current)
+	}).Should(Succeed())
+}
+
+// waitForCosmosignerRetargetCompletion drives a target-group retarget to completion while asserting
+// its ordering guarantee: the migration must stay open until the newly targeted pod is running,
+// ready and past its discovery gate. It samples directly rather than through Eventually because a
+// premature completion has to fail at the sample that observes it — a retry would let the new target
+// turn healthy in the meantime and hide it.
+func waitForCosmosignerRetargetCompletion(cns *appsv1.ChainNodeSet, logicalName, targetPodName, previousDigest string) *appsv1.CosmosignerStatus {
+	const (
+		pollInterval = 500 * time.Millisecond
+		pollTimeout  = 8 * time.Minute
+	)
+	deadline := time.Now().Add(pollTimeout)
+	sawMigration := false
+	for {
+		current := &appsv1.ChainNodeSet{}
+		Expect(Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current)).To(Succeed())
+		status := current.GetCosmosignerStatus(logicalName)
+		Expect(status).NotTo(BeNil(), "signer %q lost its status entry during the retarget", logicalName)
+		switch {
+		case status.Migration != nil:
+			sawMigration = true
+		case status.AppliedDigest != "" && status.AppliedDigest != previousDigest:
+			Expect(cosmosignerTargetPodServed(
+				cns.GetNamespace(), targetPodName, appsv1.CosmosignerStatusResourceName(status),
+			)).To(BeTrue(), "the retarget completed before %s was running, ready and past its discovery gate", targetPodName)
+			Expect(sawMigration).To(BeTrue(),
+				"the retarget must run through the migration state machine, not swap targets in place")
+			return status.DeepCopy()
+		}
+		Expect(time.Now()).To(BeTemporally("<", deadline),
+			"timed out waiting for the retarget to %s to complete", targetPodName)
+		time.Sleep(pollInterval)
+	}
+}
+
+// cosmosignerTargetPodServed reports whether a pod is a live endpoint of the given signer: labelled
+// for it, running, ready, and past the discovery gate that exits only once the discovery Service
+// publishes this pod to the signer.
+func cosmosignerTargetPodServed(namespace, name, signerName string) bool {
+	pod := &corev1.Pod{}
+	if err := Framework().Client().Get(
+		Framework().Context(), client.ObjectKey{Namespace: namespace, Name: name}, pod,
+	); err != nil {
+		return false
+	}
+	return pod.DeletionTimestamp == nil &&
+		pod.Labels[controllers.LabelCosmosignerTarget] == signerName &&
+		pod.Status.Phase == corev1.PodRunning &&
+		podReady(pod) &&
+		cosmosignerDiscoveryGateSucceeded(pod)
 }
 
 func waitForCosmosignerApplied(cns *appsv1.ChainNodeSet, logicalName string) *appsv1.CosmosignerStatus {


### PR DESCRIPTION
## Summary
- dispatches standalone `node-utils` commands before any server configuration is initialized and rejects unknown/leftover positional arguments explicitly
- keeps Cosmosigner discovery gated on authenticated signer confirmation while retaining pod-local DNS diagnostics
- adds unit coverage for no-config command execution and generated discovery-gate Pod semantics
- extends Cosmosigner E2E coverage for target Pod replacement, two-sentry retarget migration, post-migration stability, and consensus-key reservation continuity

## Verification
- `make test.unit`
- `make test.integration`
- `go test -race ./cmd/nodeutils/...`
- `go test ./internal/controllers/chainnode/... ./internal/controllers/chainnodeset/... ./test/e2e/...`
- `make test.e2e FOCUS='software backend.*Nibiru' PROCS=1`
- full `make test.e2e FOCUS='Cosmosigner'`: 7/8 passed; the Nibiru replacement spec observed two replacement UIDs under the parallel run, then passed cleanly in the isolated rerun above with both replacement cycles

Closes VLZ-794

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated `node-utils` subcommands from server startup and kept Cosmosigner discovery gated on authenticated signer confirmation with clearer diagnostics and centralized `mock` command validation. Addresses VLZ-794.

- **Bug Fixes**
  - Reject unknown subcommands and leftover positional args; no fall-through to server startup without config; `help` handled.
  - Centralized `mock` command validation with strict arity before dispatch.
  - `wait-for-dns` validates the target IP up-front and only releases on authenticated signer; local DNS is diagnostic; timeouts report signer connection status and pod-local DNS observations.

- **Refactors**
  - Added `run()` to dispatch subcommands before any server configuration; `startServer()` returns errors; unit tests cover dispatch, unknown subcommands, positional args, and `mock` validation.
  - Hardened Cosmosigner tests: discovery gate container stays isolated (no config mount, not a sidecar), starts after the `node-utils` sidecar, and E2E retargets assert ordering, stability (no post-retarget churn), and consensus-key reservation continuity.

<sup>Written for commit 43f3d7c01adcfa56d6c57046a68f57d2cc5e9784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

