### PR TITLE
fix(cosmoguard): separate startup from readiness

### DIFF
--- a/internal/cosmoguard/cosmoguard.go
+++ b/internal/cosmoguard/cosmoguard.go
@@ -380,7 +380,7 @@ func (p Params) StatefulSet() *appsv1.StatefulSet {
 		},
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: metricsPort, Scheme: corev1.URISchemeHTTP},
+				HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: metricsPort, Scheme: corev1.URISchemeHTTP},
 			},
 			PeriodSeconds:    2,
 			FailureThreshold: 30,

--- a/internal/cosmoguard/cosmoguard_test.go
+++ b/internal/cosmoguard/cosmoguard_test.go
@@ -74,6 +74,25 @@ func TestStatefulSet_StaticUpstream(t *testing.T) {
 	assert.Equal(t, int32(2), *dep.Spec.Replicas)
 }
 
+func TestStatefulSet_ProbeSemantics(t *testing.T) {
+	p := baseParams()
+	p.UpstreamHost = "host"
+
+	container := p.StatefulSet().Spec.Template.Spec.Containers[0]
+
+	require.NotNil(t, container.StartupProbe)
+	require.NotNil(t, container.StartupProbe.HTTPGet)
+	assert.Equal(t, "/healthz", container.StartupProbe.HTTPGet.Path)
+
+	require.NotNil(t, container.ReadinessProbe)
+	require.NotNil(t, container.ReadinessProbe.HTTPGet)
+	assert.Equal(t, "/readyz", container.ReadinessProbe.HTTPGet.Path)
+
+	require.NotNil(t, container.LivenessProbe)
+	require.NotNil(t, container.LivenessProbe.HTTPGet)
+	assert.Equal(t, "/healthz", container.LivenessProbe.HTTPGet.Path)
+}
+
 func TestStatefulSet_DiscoveryUpstream(t *testing.T) {
 	p := baseParams()
 	p.DiscoveryHost = "chain-group-cg-upstream.ns.svc.cluster.local"


### PR DESCRIPTION
## Summary
- use CosmoGuard `/healthz` for the Kubernetes startup probe
- keep `/readyz` for readiness because it intentionally reflects upstream availability
- add a regression test pinning startup, readiness, and liveness probe semantics

## Root cause
The generated StatefulSet used `/readyz` as its startup probe. CosmoGuard returns 503 from `/readyz` while no discovered upstream is healthy. During node replacement, ChainNodes and their EndpointSlices can take more than the 60-second startup budget to recover, so kubelet repeatedly terminated healthy CosmoGuard processes even though `/healthz` was already serving.

The observed containers exited cleanly with code 0 after SIGTERM; this was not an OOM or application crash.

## Verification
- `go test ./internal/cosmoguard/...`
- `go test ./internal/controllers/chainnodeset/... ./internal/controllers/chainnode/...`
- live RCA correlated pod last state, previous logs, probe events, DNS/EndpointSlice recovery, and restart timestamps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `/healthz` for the startup probe and keep `/readyz` for readiness to prevent premature restarts during upstream recovery. Adds a regression test to pin probe semantics (startup, readiness, liveness).

- **Bug Fixes**
  - Change startup probe from `/readyz` to `/healthz` in `internal/cosmoguard/cosmoguard.go`.
  - Prevent kubelet from terminating healthy `CosmoGuard` when upstream recovery exceeds the startup budget.

<sup>Written for commit 522d4d9c3fc84b5e28fed9093e040b165d45f7ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

