### PR TITLE
test: keep required nodes in deletion fixture

### DIFF
--- a/test/e2e/deletion_policy_test.go
+++ b/test/e2e/deletion_policy_test.go
@@ -152,9 +152,10 @@ var _ = Describe("Deletion policy", func() {
 	It("releases a ChainNodeSet reservation only after its validator signing workload is gone", WithNs(func(ns *corev1.Namespace) {
 		app := apps.Nibiru()
 		cns := app.BuildChainNodeSet(ns.Name, 0)
-		// This spec exercises the legacy validator owner path only. Drop the zero-instance fullnode
-		// group because its inherited snapshotNodeIndex is invalid when there are no instances.
-		cns.Spec.Nodes = nil
+		// This spec exercises the legacy validator owner path only. Keep the required nodes field,
+		// but drop the zero-instance fullnode group because its inherited snapshotNodeIndex is invalid
+		// when there are no instances.
+		cns.Spec.Nodes = []appsv1.NodeGroupSpec{}
 		Expect(Framework().Client().Create(Framework().Context(), cns)).To(Succeed())
 		WaitForChainNodeSetHeight(cns, 1)
 		RefreshChainNodeSet(cns)


### PR DESCRIPTION
## Summary

- Keep `spec.nodes` as an explicit empty list in the ChainNodeSet deletion-policy E2E fixture
- Preserve the intended legacy-validator-only topology without violating the required CRD field
- Fix the deterministic HTTP 422 failure from E2E run `31120351886`

## Root cause

The fixture assigned `cns.Spec.Nodes = nil`. Because `spec.nodes` is required by the ChainNodeSet CRD, the API server rejected the object before the deletion/CKR lifecycle assertions ran.

## Verification

- `go test ./test/e2e/... -count=1`
- `go vet ./test/e2e/...`
- `make test.unit`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deletion-policy E2E fixture by keeping the required `spec.nodes` field as an empty list, preventing API server 422s and allowing the validator-only topology test to run.

- **Bug Fixes**
  - Set `cns.Spec.Nodes = []appsv1.NodeGroupSpec{}` (instead of `nil`) to satisfy the ChainNodeSet CRD.
  - Drops the zero-instance fullnode group while preserving the legacy validator path.

<sup>Written for commit 5929e3876c7bfff4671535c20367380acb2ce1aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

