### PR TITLE
fix: allow same-root cosmosigner reservation aliases

### DIFF
--- a/api/v1/chainnodeset_helper.go
+++ b/api/v1/chainnodeset_helper.go
@@ -105,6 +105,18 @@ func (nodeSet *ChainNodeSet) RecordedChildIdentity(child *ChainNode) (nameRecord
 	return match != RecordedChildNone, match == RecordedChildExact
 }
 
+// GeneratedValidatorNodeName returns the name of the child ChainNode this ChainNodeSet generates for
+// one instance of a validator group. ReservedValidatorGroupName is the legacy singleton
+// .spec.validator (rejected as a real group name by the webhook), which is a single node with no
+// ordinal suffix. Callers outside the controller use it to resolve a recorded validator group back to
+// the child that carries its consensus identity.
+func (nodeSet *ChainNodeSet) GeneratedValidatorNodeName(group string, index int) string {
+	if group == ReservedValidatorGroupName {
+		return fmt.Sprintf("%s-validator", nodeSet.GetName())
+	}
+	return fmt.Sprintf("%s-%s-%d", nodeSet.GetName(), group, index)
+}
+
 func (nodeSet *ChainNodeSet) HasValidator() bool {
 	if nodeSet.Spec.Validator != nil {
 		return true

--- a/internal/controllers/chainnode/signing_test.go
+++ b/internal/controllers/chainnode/signing_test.go
@@ -139,6 +139,87 @@ func TestEnsureValidatorConsensusKeyReservationUsesChainNodeSetRoot(t *testing.T
 	}
 }
 
+func TestEnsureValidatorConsensusKeyReservationAllowsGeneratedChildDuringCosmosignerMigration(t *testing.T) {
+	const (
+		namespace = "default"
+		name      = "nodes-validator"
+		publicKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	)
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	chainNode := &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: namespace, UID: "child-uid",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNodeSet", Name: "nodes",
+				UID: "nodeset-uid", Controller: ptr.To(true),
+			}},
+		},
+		Spec: appsv1.ChainNodeSpec{Validator: &appsv1.ValidatorConfig{TmKMS: &appsv1.TmKMS{Provider: appsv1.TmKmsProvider{
+			Hashicorp: &appsv1.TmKmsHashicorpProvider{
+				Address: "https://vault:8200",
+				Key:     "validator",
+				TokenSecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "vault-token"},
+					Key:                  "token",
+				},
+			},
+		}}}},
+		Status: appsv1.ChainNodeStatus{ChainID: "chain-1", PubKey: `{"key":"` + publicKey + `"}`},
+	}
+	chainNode.Status.TmKMSReservationIdentity = chainNode.EffectiveSigningIdentity()
+
+	// The top-level Cosmosigner has rolled out over the same Vault key, so the root records it, but the
+	// child is not yet stamped as its target: this is the break-before-make window the migration deadlocked in.
+	nodeSet := &appsv1.ChainNodeSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodes", Namespace: namespace, UID: "nodeset-uid"},
+		Status: appsv1.ChainNodeSetStatus{
+			ChainID: "chain-1",
+			PubKey:  `{"key":"` + publicKey + `"}`,
+			Validators: []appsv1.ChainNodeSetValidatorStatus{
+				{Name: name, UID: chainNode.UID, Group: appsv1.ReservedValidatorGroupName, PubKey: `{"key":"` + publicKey + `"}`},
+			},
+			Cosmosigners: []appsv1.CosmosignerStatus{{
+				Name: "cosmosigner", PublicKey: publicKey, ServingGroup: appsv1.ReservedValidatorGroupName,
+			}},
+		},
+	}
+	token := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-token", Namespace: namespace},
+		Data:       map[string][]byte{"token": []byte("token")},
+	}
+	reservation := &appsv1.ConsensusKeyReservation{
+		ObjectMeta: metav1.ObjectMeta{Name: cosmosigner.ConsensusKeyReservationName("chain-1", publicKey)},
+		Spec: appsv1.ConsensusKeyReservationSpec{
+			ChainID: "chain-1", PublicKey: publicKey, OwnerUID: "nodeset-uid",
+			OwnerKind: "ChainNodeSet", Namespace: namespace, OwnerName: "nodes", Claim: name,
+		},
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: namespace,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNode", Name: name,
+			UID: chainNode.UID, Controller: ptr.To(true),
+		}},
+	}}
+	r := &Reconciler{Client: fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(chainNode, nodeSet, token, reservation, pod).Build()}
+
+	if _, err := r.ensureValidatorConsensusKeyReservation(context.Background(), chainNode); err != nil {
+		t.Fatalf("a generated validator child must not conflict with its own root's signer status: %v", err)
+	}
+	remaining := &corev1.Pod{}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, remaining); err != nil {
+		t.Fatalf("the validator pod must survive the migration window, got %v", err)
+	}
+}
+
 func TestEnsureValidatorConsensusKeyReservationSkipsRemoteSignerTarget(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := appsv1.AddToScheme(scheme); err != nil {

--- a/internal/controllers/chainnodeset/cosmosigner_test.go
+++ b/internal/controllers/chainnodeset/cosmosigner_test.go
@@ -1733,6 +1733,35 @@ func TestInitCosmosignerLocksRecordsPreRolloutTargetKind(t *testing.T) {
 		assert.True(t, *fresh.Status.Cosmosigners[0].LocalKeyEverServed)
 	})
 
+	// The top-level .spec.cosmosigner over the legacy singleton .spec.validator records the RESERVED
+	// group name, and that name must resolve back to the generated validator child — which is the claim
+	// that child holds on the shared consensus-key reservation. legacyCosmosignerStatusMatchesClaim
+	// relies on exactly this to tell a same-root status entry apart from a foreign owner, and it fails
+	// closed on an unrecorded group, so a regression here would silently re-deadlock the
+	// tmKMS-to-cosmosigner migration rather than misfire.
+	t.Run("top-level validator target", func(t *testing.T) {
+		nodeSet := &appsv1.ChainNodeSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-nodeset", Namespace: "default"},
+			Spec: appsv1.ChainNodeSetSpec{
+				Validator:   &appsv1.NodeSetValidatorConfig{PrivateKeySecret: ptr.To("val-priv-key")},
+				Cosmosigner: &appsv1.Cosmosigner{Backend: cosmosignerVaultBackend()},
+			},
+			Status: appsv1.ChainNodeSetStatus{ChainID: "test-1"},
+		}
+		r := newValidatorTestReconciler(t, nodeSet)
+		changed, err := r.initCosmosignerLocks(context.Background(), nodeSet)
+		require.NoError(t, err)
+		assert.True(t, changed)
+
+		fresh := &appsv1.ChainNodeSet{}
+		require.NoError(t, r.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-nodeset"}, fresh))
+		require.Len(t, fresh.Status.Cosmosigners, 1)
+		servingGroup := fresh.Status.Cosmosigners[0].ServingGroup
+		assert.Equal(t, appsv1.ReservedValidatorGroupName, servingGroup)
+		assert.Equal(t, "test-nodeset-validator", fresh.GeneratedValidatorNodeName(servingGroup, 0),
+			"the recorded group must resolve to the generated child whose name is the reservation claim")
+	})
+
 	t.Run("migration to a local key records monotonic history before rollout", func(t *testing.T) {
 		nodeSet := cosmosignerValidatorNodeSet(cosmosignerVaultBackend())
 		require.NotNil(t, nodeSet.Status.Cosmosigners[0].LocalKeyEverServed)

--- a/internal/controllers/chainnodeset/validator.go
+++ b/internal/controllers/chainnodeset/validator.go
@@ -306,12 +306,9 @@ func updateValidatorStatus(
 }
 
 func validatorNodeName(nodeSet *appsv1.ChainNodeSet, group string, index int) string {
-	// validatorGroupName is reserved for the legacy singleton .spec.validator (rejected as a
-	// real group name by the webhook), so it is the only caller that reaches this branch.
-	if group == validatorGroupName {
-		return fmt.Sprintf("%s-validator", nodeSet.GetName())
-	}
-	return fmt.Sprintf("%s-%s-%d", nodeSet.GetName(), group, index)
+	// Shared with the consensus-key reservation scan, which resolves a recorded ServingGroup back to
+	// the child holding that validator identity and must derive the exact same name.
+	return nodeSet.GeneratedValidatorNodeName(group, index)
 }
 
 func (r *Reconciler) getValidatorSpec(nodeSet *appsv1.ChainNodeSet, group string, index int, cfg *appsv1.NodeSetValidatorConfig) (*appsv1.ChainNode, error) {

--- a/internal/cosmosigner/reservation.go
+++ b/internal/cosmosigner/reservation.go
@@ -170,7 +170,8 @@ func ensureNoLegacyConsensusKeyOwner(ctx context.Context, reader client.Reader, 
 		}
 		for _, signer := range set.Status.Cosmosigners {
 			if signer.PublicKey == publicKey {
-				if set.UID == holder.UID && holder.matchesLegacyStatus(signer.Name) {
+				if set.UID == holder.UID &&
+					(holder.matchesLegacyStatus(signer.Name) || legacyCosmosignerStatusMatchesClaim(set, signer.ServingGroup, holder.Claim)) {
 					continue
 				}
 				return fmt.Errorf("%w: consensus key on chain %q is already recorded by ChainNodeSet %s/%s",
@@ -219,6 +220,21 @@ func legacyChainNodeMatchesClaim(node *appsv1.ChainNode, holder ReservationHolde
 	}
 	return belongsToRoot(node, holder.UID) &&
 		(node.GetName() == holder.Claim || holder.matchesLegacyNode(node.GetName()))
+}
+
+// legacyCosmosignerStatusMatchesClaim reports whether a managed signer recorded in a ChainNodeSet's
+// status protects exactly the consensus identity the holder is claiming. It is only consulted for a
+// same-root status entry (the caller compares owner UIDs), so it never relaxes cross-root conflicts.
+//
+// A ChainNodeSet-generated validator child acquires its reservation under the root's UID with its own
+// node name as the claim, while the root records the signer serving it under the signer's own name —
+// which the child cannot enumerate in LegacyStatusNames. The recorded ServingGroup resolves back to
+// the same generated instance-0 child name the root's signer preflight uses as its claim, so exact
+// equality with the holder's claim proves both name one logical validator. An entry with no recorded
+// ServingGroup (a sentry signer, or one whose served group predates the field) proves nothing and
+// fails closed.
+func legacyCosmosignerStatusMatchesClaim(set *appsv1.ChainNodeSet, servingGroup, claim string) bool {
+	return servingGroup != "" && set.GeneratedValidatorNodeName(servingGroup, 0) == claim
 }
 
 func legacyChainNodeSetAliasMatchesClaim(set *appsv1.ChainNodeSet, holder ReservationHolder, publicKey string) bool {

--- a/internal/cosmosigner/reservation_test.go
+++ b/internal/cosmosigner/reservation_test.go
@@ -148,6 +148,114 @@ func TestEnsureConsensusKeyReservationAllowsExactPlacementReplacementStatuses(t 
 	}
 }
 
+func TestEnsureConsensusKeyReservationAllowsGeneratedValidatorChildAfterSignerRollout(t *testing.T) {
+	scheme := reservationScheme(t)
+	set := generatedValidatorChildNodeSet("nodes", "default", "nodeset-uid", appsv1.ReservedValidatorGroupName, "nodes-validator")
+	child := generatedValidatorChildNode("nodes-validator", "default", "nodeset-uid")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&appsv1.ChainNodeSet{}).WithObjects(set, child).Build()
+	holder := ReservationHolder{
+		UID: "nodeset-uid", Kind: "ChainNodeSet", Namespace: "default", Name: "nodes", Claim: "nodes-validator",
+	}
+
+	// TmKMS era: the generated child claims its key under the root it is controlled by.
+	requireReservation(t, c, c, "chain-1", reservationTestPublicKey, holder)
+
+	// The top-level Cosmosigner rolls out over the same Vault key and the root records it against the
+	// signer serving that validator group.
+	recordCosmosignerStatus(t, c, set, appsv1.CosmosignerStatus{
+		Name: "cosmosigner", PublicKey: reservationTestPublicKey, ServingGroup: appsv1.ReservedValidatorGroupName,
+	})
+
+	// The child reconciles again inside the break-before-make window, before it is stamped as a remote
+	// signer target. Its holder cannot name the signer's status entry, so only the claim proves the two
+	// describe one validator.
+	requireReservation(t, c, c, "chain-1", reservationTestPublicKey, holder)
+
+	reservation := &appsv1.ConsensusKeyReservation{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: ConsensusKeyReservationName("chain-1", reservationTestPublicKey)}, reservation); err != nil {
+		t.Fatal(err)
+	}
+	if reservation.Spec.OwnerUID != holder.UID || reservation.Spec.Claim != holder.Claim {
+		t.Fatalf("the generated child must keep its root-owned claim: %#v", reservation.Spec)
+	}
+}
+
+func TestEnsureConsensusKeyReservationAllowsGeneratedValidatorChildInNamedGroup(t *testing.T) {
+	scheme := reservationScheme(t)
+	set := generatedValidatorChildNodeSet("nodes", "default", "nodeset-uid", "vals", "nodes-vals-0")
+	set.Status.Cosmosigners = []appsv1.CosmosignerStatus{
+		{Name: "vals-signer", PublicKey: reservationTestPublicKey, ServingGroup: "vals"},
+	}
+	child := generatedValidatorChildNode("nodes-vals-0", "default", "nodeset-uid")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(set, child).Build()
+	holder := ReservationHolder{
+		UID: "nodeset-uid", Kind: "ChainNodeSet", Namespace: "default", Name: "nodes", Claim: "nodes-vals-0",
+	}
+
+	requireReservation(t, c, c, "chain-1", reservationTestPublicKey, holder)
+}
+
+func TestEnsureConsensusKeyReservationBlocksSiblingGroupCosmosignerStatus(t *testing.T) {
+	scheme := reservationScheme(t)
+	set := &appsv1.ChainNodeSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodes", Namespace: "default", UID: "nodeset-uid"},
+		Status: appsv1.ChainNodeSetStatus{
+			ChainID: "chain-1",
+			Cosmosigners: []appsv1.CosmosignerStatus{
+				{Name: "other-signer", PublicKey: reservationTestPublicKey, ServingGroup: "other"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(set).Build()
+	holder := ReservationHolder{
+		UID: "nodeset-uid", Kind: "ChainNodeSet", Namespace: "default", Name: "nodes", Claim: "nodes-validator",
+	}
+
+	err := EnsureConsensusKeyReservation(context.Background(), c, c, "chain-1", reservationTestPublicKey, holder)
+	if !errors.Is(err, ErrConsensusKeyReservationConflict) {
+		t.Fatalf("a signer serving a sibling validator group must not share another claim's key, got %v", err)
+	}
+}
+
+func TestEnsureConsensusKeyReservationBlocksCosmosignerStatusWithoutServedGroup(t *testing.T) {
+	scheme := reservationScheme(t)
+	set := &appsv1.ChainNodeSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodes", Namespace: "default", UID: "nodeset-uid"},
+		Status: appsv1.ChainNodeSetStatus{
+			ChainID:      "chain-1",
+			Cosmosigners: []appsv1.CosmosignerStatus{{Name: "sentry-signer", PublicKey: reservationTestPublicKey}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(set).Build()
+	holder := ReservationHolder{
+		UID: "nodeset-uid", Kind: "ChainNodeSet", Namespace: "default", Name: "nodes", Claim: "nodes-validator",
+	}
+
+	err := EnsureConsensusKeyReservation(context.Background(), c, c, "chain-1", reservationTestPublicKey, holder)
+	if !errors.Is(err, ErrConsensusKeyReservationConflict) {
+		t.Fatalf("a signer status with no recorded served group proves no claim and must fail closed, got %v", err)
+	}
+}
+
+func TestEnsureConsensusKeyReservationBlocksForeignRootCosmosignerStatusAlias(t *testing.T) {
+	scheme := reservationScheme(t)
+	// Same object name in another namespace, so the alias derived from the served group collides with
+	// the holder's claim and only the owner UID separates the two roots.
+	set := generatedValidatorChildNodeSet("nodes", "other", "other-uid", appsv1.ReservedValidatorGroupName, "nodes-validator")
+	set.Status.Cosmosigners = []appsv1.CosmosignerStatus{
+		{Name: "cosmosigner", PublicKey: reservationTestPublicKey, ServingGroup: appsv1.ReservedValidatorGroupName},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(set).Build()
+	holder := ReservationHolder{
+		UID: "nodeset-uid", Kind: "ChainNodeSet", Namespace: "default", Name: "nodes", Claim: "nodes-validator",
+	}
+
+	err := EnsureConsensusKeyReservation(context.Background(), c, c, "chain-1", reservationTestPublicKey, holder)
+	if !errors.Is(err, ErrConsensusKeyReservationConflict) {
+		t.Fatalf("a matching generated-child name in a foreign root must not alias its signer status, got %v", err)
+	}
+}
+
 func TestEnsureConsensusKeyReservationBlocksLegacySingletonAlias(t *testing.T) {
 	scheme := reservationScheme(t)
 	legacy := &appsv1.ChainNodeSet{
@@ -262,6 +370,49 @@ func reservationScheme(t *testing.T) *runtime.Scheme {
 func requireReservation(t *testing.T, reader client.Reader, writer client.Writer, chainID, publicKey string, holder ReservationHolder) {
 	t.Helper()
 	if err := EnsureConsensusKeyReservation(context.Background(), reader, writer, chainID, publicKey, holder); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// generatedValidatorChildNodeSet builds a ChainNodeSet whose recorded validator is the child
+// ChainNode it generates for one validator group, as the set looks once that validator is live.
+func generatedValidatorChildNodeSet(name, namespace string, uid types.UID, group, childName string) *appsv1.ChainNodeSet {
+	set := &appsv1.ChainNodeSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: uid},
+		Status: appsv1.ChainNodeSetStatus{
+			ChainID: "chain-1",
+			Validators: []appsv1.ChainNodeSetValidatorStatus{
+				{Name: childName, Group: group, PubKey: `{"key":"` + reservationTestPublicKey + `"}`},
+			},
+		},
+	}
+	if group == appsv1.ReservedValidatorGroupName {
+		set.Status.PubKey = `{"key":"` + reservationTestPublicKey + `"}`
+	}
+	return set
+}
+
+func generatedValidatorChildNode(name, namespace string, root types.UID) *appsv1.ChainNode {
+	return &appsv1.ChainNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: namespace, UID: types.UID(name + "-uid"),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: appsv1.GroupVersion.String(), Kind: "ChainNodeSet", Name: "nodes",
+				UID: root, Controller: reservationBoolPtr(true),
+			}},
+		},
+		Status: appsv1.ChainNodeStatus{ChainID: "chain-1", PubKey: `{"key":"` + reservationTestPublicKey + `"}`},
+	}
+}
+
+func recordCosmosignerStatus(t *testing.T, c client.Client, set *appsv1.ChainNodeSet, status appsv1.CosmosignerStatus) {
+	t.Helper()
+	live := &appsv1.ChainNodeSet{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(set), live); err != nil {
+		t.Fatal(err)
+	}
+	live.Status.Cosmosigners = append(live.Status.Cosmosigners, status)
+	if err := c.Status().Update(context.Background(), live); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/cosmosigner/reservation_test.go
+++ b/internal/cosmosigner/reservation_test.go
@@ -242,6 +242,9 @@ func TestEnsureConsensusKeyReservationBlocksForeignRootCosmosignerStatusAlias(t 
 	// Same object name in another namespace, so the alias derived from the served group collides with
 	// the holder's claim and only the owner UID separates the two roots.
 	set := generatedValidatorChildNodeSet("nodes", "other", "other-uid", appsv1.ReservedValidatorGroupName, "nodes-validator")
+	// Isolate the serving-group alias path: no validator status may claim the key first.
+	set.Status.Validators = nil
+	set.Status.PubKey = ""
 	set.Status.Cosmosigners = []appsv1.CosmosignerStatus{
 		{Name: "cosmosigner", PublicKey: reservationTestPublicKey, ServingGroup: appsv1.ReservedValidatorGroupName},
 	}

--- a/test/e2e/apps/types.go
+++ b/test/e2e/apps/types.go
@@ -425,9 +425,23 @@ func (t TestApp) BuildChainNodeSetWithCosmosigner(namespace string, cfg Cosmosig
 // BuildChainNodeWithTmKMS creates a ChainNode resource with TMKMS Vault configuration
 func (t TestApp) BuildChainNodeWithTmKMS(namespace string, tmkmsConfig TmKMSConfig) *appsv1.ChainNode {
 	chainNode := t.BuildChainNode(namespace)
+	chainNode.Spec.Validator.TmKMS = t.tmKMS(tmkmsConfig)
+	return chainNode
+}
 
-	// Configure TMKMS with Vault provider
-	chainNode.Spec.Validator.TmKMS = &appsv1.TmKMS{
+// BuildChainNodeSetWithTmKMS creates a genesis-initializing ChainNodeSet whose legacy singleton
+// validator signs through a TMKMS Vault sidecar. This is the pre-migration shape of a set that later
+// moves onto a Cosmopilot-managed cosmosigner over the same Vault key.
+func (t TestApp) BuildChainNodeSetWithTmKMS(namespace string, tmkmsConfig TmKMSConfig) *appsv1.ChainNodeSet {
+	cns := t.BuildChainNodeSet(namespace, 0)
+	cns.Spec.Validator.TmKMS = t.tmKMS(tmkmsConfig)
+	return cns
+}
+
+// tmKMS builds the Vault-provider TMKMS configuration shared by the ChainNode and ChainNodeSet
+// builders, so both describe the same signing sidecar.
+func (t TestApp) tmKMS(tmkmsConfig TmKMSConfig) *appsv1.TmKMS {
+	return &appsv1.TmKMS{
 		Provider: appsv1.TmKmsProvider{
 			Hashicorp: &appsv1.TmKmsHashicorpProvider{
 				Address: tmkmsConfig.VaultAddress,
@@ -453,6 +467,4 @@ func (t TestApp) BuildChainNodeWithTmKMS(namespace string, tmkmsConfig TmKMSConf
 			ConsensusKeyPrefix: t.ValidatorConfig.ValPrefix + "conspub",
 		},
 	}
-
-	return chainNode
 }

--- a/test/e2e/chainnodeset_cosmosigner_test.go
+++ b/test/e2e/chainnodeset_cosmosigner_test.go
@@ -331,6 +331,106 @@ var _ = Describe("ChainNodeSet Cosmosigner", func() {
 			}, time.Minute, time.Second).Should(BeNumerically(">", heightAfterRetarget),
 				"the chain must keep advancing after the retarget settles")
 		})
+
+		// Serial: this spec restarts the shared Cosmopilot deployment, which every other spec depends
+		// on, so it must not run alongside them.
+		It("should migrate a ChainNodeSet validator from tmKMS Vault to a top-level cosmosigner across a controller restart", Serial, func() {
+			requireCosmosignerE2E()
+			app := apps.Nibiru()
+			ns := CreateTestNamespace()
+			tokenSecretName, caSecretName := CopyVaultSecretsToNamespace(ns.Name)
+			keyName := fmt.Sprintf("%s-nodeset-cosmosigner-%s", app.ValidatorConfig.ChainID, RandString(6))
+			cns := app.BuildChainNodeSetWithTmKMS(ns.Name, apps.TmKMSConfig{
+				VaultAddress:    GetVaultAddress(),
+				KeyName:         keyName,
+				TokenSecretName: tokenSecretName,
+				CASecretName:    caSecretName,
+			})
+			Expect(Framework().Client().Create(Framework().Context(), cns)).To(Succeed())
+
+			// The legacy singleton validator is a generated child ChainNode, so the tmKMS-era waits
+			// apply to it directly.
+			validatorName := fmt.Sprintf("%s-validator", cns.Name)
+			signerName := fmt.Sprintf("%s-signer", cns.Name)
+			WaitForChainNodeSetHeight(cns, 3)
+			WaitForTmkmsContainerRunning(&appsv1.ChainNode{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: validatorName},
+			})
+			Eventually(func() string {
+				child := &appsv1.ChainNode{}
+				if err := Framework().Client().Get(Framework().Context(),
+					client.ObjectKey{Namespace: ns.Name, Name: validatorName}, child); err != nil {
+					return ""
+				}
+				return child.Annotations[controllers.AnnotationVaultKeyUploaded]
+			}).Should(Equal(controllers.StringValueTrue), "the cosmosigner can only adopt a key tmKMS already uploaded")
+
+			var publicKey string
+			var heightBeforeMigration int64
+			Eventually(func(g Gomega) {
+				current := &appsv1.ChainNodeSet{}
+				g.Expect(Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current)).To(Succeed())
+				publicKey = managedcosmosigner.CanonicalSDKPublicKey(current.Status.PubKey)
+				g.Expect(publicKey).NotTo(BeEmpty())
+				heightBeforeMigration = current.Status.LatestHeight
+			}).Should(Succeed())
+			reservation := waitForConsensusKeyReservation(cns, publicKey)
+			Expect(reservation.Spec.Claim).To(Equal(validatorName),
+				"the tmKMS-era validator child claims its key under the root ChainNodeSet")
+
+			// Hold the old pod in Terminating so the migration parks in its break-before-make window:
+			// the tmKMS signer is gone and the replacement cannot be created yet.
+			tmkmsPod := &corev1.Pod{}
+			Expect(Framework().Client().Get(Framework().Context(),
+				client.ObjectKey{Namespace: ns.Name, Name: validatorName}, tmkmsPod)).To(Succeed())
+			tmkmsPodUID := string(tmkmsPod.UID)
+			setPodTestFinalizer(ns.Name, validatorName, true)
+			DeferCleanup(func() { setPodTestFinalizer(ns.Name, validatorName, false) })
+
+			migrateNodeSetValidatorToCosmosigner(cns, keyName, tokenSecretName, caSecretName)
+			waitForBrokenTmKMSValidatorPod(ns.Name, validatorName, signerName, tmkmsPodUID)
+
+			// A restart drops every cached decision, so the controller must re-derive the migration
+			// from live state alone — including the reservation its own root already recorded against
+			// the managed signer, which VLZ-799 read back as a conflicting legacy owner and deadlocked
+			// on, leaving the validator quiesced with no replacement.
+			restartCosmopilotController()
+			setPodTestFinalizer(ns.Name, validatorName, false)
+
+			replacement := waitForCosmosignerTargetedValidatorPod(ns.Name, validatorName, signerName, tmkmsPodUID, cns.Spec.App.App)
+			Expect(replacement.Labels[controllers.LabelCosmosignerTarget]).To(Equal(signerName))
+			assertNoCosmosignerDiscoveryPubKeyFailure(ns.Name, validatorName, cns.Spec.App.App, 1)
+
+			signerStatus := waitForCosmosignerApplied(cns, signerName)
+			Expect(signerStatus.PublicKey).To(Equal(publicKey),
+				"the managed signer must adopt the tmKMS consensus key, not mint a new one")
+			// Same-root alias matching keys on the recorded served group and fails closed without it, so
+			// assert it directly: otherwise a regression that stopped recording it would surface only as
+			// the replacement-pod wait timing out, with nothing pointing at the cause.
+			Expect(signerStatus.ServingGroup).To(Equal(appsv1.ReservedValidatorGroupName),
+				"the signer must record the validator group it serves for the child's reservation to be recognised as same-root")
+			waitForReadySignerPods(ns.Name, signerName, 1)
+
+			Eventually(func(g Gomega) {
+				current := &appsv1.ChainNodeSet{}
+				g.Expect(Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current)).To(Succeed())
+				g.Expect(managedcosmosigner.CanonicalSDKPublicKey(current.Status.PubKey)).To(Equal(publicKey))
+				g.Expect(current.Status.LatestHeight).To(BeNumerically(">", heightBeforeMigration),
+					"the migrated validator must resume signing")
+			}).Should(Succeed())
+
+			// The sidecar's configuration must be removed, not merely left unused.
+			Eventually(func() bool {
+				configMap := &corev1.ConfigMap{}
+				err := Framework().Client().Get(Framework().Context(),
+					client.ObjectKey{Namespace: ns.Name, Name: validatorName + "-tmkms"}, configMap)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+
+			// One consensus key, one reservation, held continuously across the whole migration: a
+			// released-and-recreated reservation would mean the key went unguarded in between.
+			assertConsensusKeyReservationUnchanged(reservation)
+		})
 	})
 })
 
@@ -419,6 +519,138 @@ func moveTopLevelCosmosignerIntoGroup(cns *appsv1.ChainNodeSet, groupName string
 		}
 		return fmt.Errorf("node group %q not found", groupName)
 	}).Should(Succeed())
+}
+
+// migrateNodeSetValidatorToCosmosigner switches the legacy singleton validator from its tmKMS
+// sidecar to a top-level cosmosigner over the same Vault key. Both must move in a single update: the
+// webhook rejects a spec carrying .spec.validator.tmKMS and .spec.cosmosigner at once, which is also
+// what makes the switch a break-before-make rather than an overlap.
+func migrateNodeSetValidatorToCosmosigner(cns *appsv1.ChainNodeSet, keyName, tokenSecretName, caSecretName string) {
+	Eventually(func() error {
+		current := &appsv1.ChainNodeSet{}
+		if err := Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cns), current); err != nil {
+			return err
+		}
+		if current.Spec.Validator == nil {
+			return fmt.Errorf("the legacy singleton validator is absent")
+		}
+		current.Spec.Validator.TmKMS = nil
+		current.Spec.Cosmosigner = &appsv1.Cosmosigner{
+			Replicas: ptr.To[int32](1),
+			Backend: appsv1.CosmosignerBackend{Vault: &appsv1.CosmosignerVaultBackend{
+				Address: GetVaultAddress(),
+				KeyName: keyName,
+				TokenSecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: tokenSecretName},
+					Key:                  "token",
+				},
+				CertificateSecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: caSecretName},
+					Key:                  "ca.crt",
+				},
+			}},
+		}
+		return Framework().Client().Update(Framework().Context(), current)
+	}).Should(Succeed())
+}
+
+// waitForBrokenTmKMSValidatorPod waits until the tmKMS validator pod is being torn down, which is
+// where a break-before-make migration is at its most exposed: the old signing path is gone and the
+// replacement does not exist yet.
+func waitForBrokenTmKMSValidatorPod(namespace, name, signerName, uid string) {
+	Eventually(func(g Gomega) {
+		pod := &corev1.Pod{}
+		g.Expect(Framework().Client().Get(
+			Framework().Context(), client.ObjectKey{Namespace: namespace, Name: name}, pod,
+		)).To(Succeed())
+		assertNoTmKMSSigningOverlap(pod, signerName)
+		g.Expect(string(pod.UID)).To(Equal(uid), "the tmKMS pod was replaced before the test observed the break")
+		g.Expect(pod.DeletionTimestamp).NotTo(BeNil())
+	}, 8*time.Minute, time.Second).Should(Succeed())
+}
+
+// waitForCosmosignerTargetedValidatorPod waits for the replacement validator pod that closes a
+// tmKMS-to-cosmosigner migration: a new pod, without the sidecar, serving the managed signer.
+func waitForCosmosignerTargetedValidatorPod(namespace, name, signerName, previousUID, appContainer string) *corev1.Pod {
+	var result *corev1.Pod
+	Eventually(func(g Gomega) {
+		pod := &corev1.Pod{}
+		g.Expect(Framework().Client().Get(
+			Framework().Context(), client.ObjectKey{Namespace: namespace, Name: name}, pod,
+		)).To(Succeed())
+		assertNoTmKMSSigningOverlap(pod, signerName)
+		g.Expect(string(pod.UID)).NotTo(Equal(previousUID), "the tmKMS pod must be replaced, not adopted")
+		g.Expect(pod.DeletionTimestamp).To(BeNil())
+		g.Expect(podHasTmKMSContainer(pod)).To(BeFalse())
+		g.Expect(pod.Labels[controllers.LabelCosmosignerTarget]).To(Equal(signerName))
+		g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+		g.Expect(podReady(pod)).To(BeTrue())
+		g.Expect(cosmosignerDiscoveryGateSucceeded(pod)).To(BeTrue())
+		restartCount, previousLogs, found := appContainerRestartDetails(namespace, pod, appContainer)
+		g.Expect(found).To(BeTrue(), "app container %q status is missing", appContainer)
+		g.Expect(restartCount).To(BeZero(), "the replacement app container restarted; previous logs:\n%s", previousLogs)
+		result = pod.DeepCopy()
+	}, 8*time.Minute, time.Second).Should(Succeed())
+	return result
+}
+
+// assertNoTmKMSSigningOverlap fails at the sample that observes a pod running its tmKMS sidecar while
+// also selected as a cosmosigner target. Two signing paths holding one consensus key at the same
+// instant is the double-sign the break-before-make migration exists to prevent, so it must fail where
+// it is seen rather than be retried past.
+func assertNoTmKMSSigningOverlap(pod *corev1.Pod, signerName string) {
+	Expect(podHasTmKMSContainer(pod) && pod.Labels[controllers.LabelCosmosignerTarget] == signerName).To(BeFalse(),
+		"pod %q carries the tmKMS sidecar and the cosmosigner target label at the same time", pod.Name)
+}
+
+func podHasTmKMSContainer(pod *corev1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "tmkms" {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	cosmopilotNamespace      = "cosmopilot-system"
+	cosmopilotDeploymentName = "cosmopilot"
+)
+
+// restartCosmopilotController deletes the controller pods and waits for their replacements to become
+// ready, leaving the operator with no cached state about work already in flight.
+func restartCosmopilotController() {
+	By("restarting the Cosmopilot controller")
+	deployment := &appsv1k8s.Deployment{}
+	Expect(Framework().Client().Get(Framework().Context(), client.ObjectKey{
+		Namespace: cosmopilotNamespace, Name: cosmopilotDeploymentName,
+	}, deployment)).To(Succeed())
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	Expect(err).NotTo(HaveOccurred())
+	listOptions := []client.ListOption{
+		client.InNamespace(cosmopilotNamespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	}
+
+	running := &corev1.PodList{}
+	Expect(Framework().Client().List(Framework().Context(), running, listOptions...)).To(Succeed())
+	Expect(running.Items).NotTo(BeEmpty(), "the Cosmopilot controller has no pods to restart")
+	previousUIDs := make(map[string]struct{}, len(running.Items))
+	for i := range running.Items {
+		previousUIDs[string(running.Items[i].UID)] = struct{}{}
+		Expect(Framework().Client().Delete(Framework().Context(), &running.Items[i])).To(Succeed())
+	}
+
+	Eventually(func(g Gomega) {
+		pods := &corev1.PodList{}
+		g.Expect(Framework().Client().List(Framework().Context(), pods, listOptions...)).To(Succeed())
+		g.Expect(pods.Items).To(HaveLen(len(previousUIDs)))
+		for i := range pods.Items {
+			g.Expect(previousUIDs).NotTo(HaveKey(string(pods.Items[i].UID)))
+			g.Expect(pods.Items[i].DeletionTimestamp).To(BeNil())
+			g.Expect(podReady(&pods.Items[i])).To(BeTrue())
+		}
+	}, 3*time.Minute, time.Second).Should(Succeed())
 }
 
 const (


### PR DESCRIPTION
## Summary
- recognize a ChainNodeSet's own populated Cosmosigner status as the same consensus-key claim when its recorded validator serving group resolves to the generated child
- preserve exact root UID and generated-child claim matching, while continuing to fail closed for foreign roots, sibling claims, sentry/legacy entries without a serving group, and stale owners
- add controller/reservation regressions and an opt-in serial E2E for TmKMS Vault → top-level Cosmosigner Vault across a controller restart in the break-before-make window

## Verification
- `make test.unit`
- `make test.integration` — 91/91 specs passed
- `go test ./internal/cosmosigner ./internal/controllers/chainnode ./internal/controllers/chainnodeset ./api/v1`
- `go test ./test/e2e/...` — E2E package compile/helper-test check; Kind suite intentionally left to CI

## Risk
- the alias exemption is limited to the same ChainNodeSet UID and an exact generated instance-0 validator claim derived from the persisted `status.cosmosigners[].servingGroup`; missing or mismatched evidence remains a conflict

Linear: VLZ-799

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows a ChainNodeSet to keep its consensus-key reservation when migrating from tmKMS Vault to a top‑level cosmosigner by treating the root’s own cosmosigner status as the same claim when it resolves to the generated validator child. Fixes the tmKMS→cosmosigner break‑before‑make deadlock (Linear: VLZ-799) and prevents unnecessary validator downtime.

- **Bug Fixes**
  - Treat same‑root cosmosigner status as the same reservation claim when `ServingGroup` resolves to the generated validator child; no conflict during migration.
  - Fail closed for foreign roots (including cross‑namespace same‑name alias collisions), sibling groups, entries without `ServingGroup`, and stale owners.

- **Refactors**
  - Added `GeneratedValidatorNodeName` and used it in both the validator controller and the reservation scan for consistent child naming.
  - Expanded regressions and added an opt‑in serial E2E covering tmKMS Vault → top‑level cosmosigner across a controller restart, asserting no tmKMS/cosmosigner overlap and continuous reservation ownership.

<sup>Written for commit 0353979b437c16639801aecc9fc07a94057ea6fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

