### PR TITLE
test: keep fullnode in VLZ-799 fixture

### DIFF
--- a/test/e2e/apps/types.go
+++ b/test/e2e/apps/types.go
@@ -433,7 +433,7 @@ func (t TestApp) BuildChainNodeWithTmKMS(namespace string, tmkmsConfig TmKMSConf
 // validator signs through a TMKMS Vault sidecar. This is the pre-migration shape of a set that later
 // moves onto a Cosmopilot-managed cosmosigner over the same Vault key.
 func (t TestApp) BuildChainNodeSetWithTmKMS(namespace string, tmkmsConfig TmKMSConfig) *appsv1.ChainNodeSet {
-	cns := t.BuildChainNodeSet(namespace, 0)
+	cns := t.BuildChainNodeSet(namespace, 1)
 	cns.Spec.Validator.TmKMS = t.tmKMS(tmkmsConfig)
 	return cns
 }


### PR DESCRIPTION
## Summary
- keep one fullnode in the VLZ-799 TmKMS → Cosmosigner E2E fixture
- avoid the invalid zero-instance group whose snapshot index was rejected by admission

## Verification
- `go test ./test/e2e/...` (E2E package compile/helper-test check)

Follow-up to #105.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep one fullnode in the VLZ-799 TmKMS → Cosmosigner E2E fixture to prevent zero-instance groups that fail admission due to an invalid snapshot index. Updates BuildChainNodeSetWithTmKMS to create the set with 1 node instead of 0.

<sup>Written for commit cea80dd538bf99c4d57464cf6f51a35a289e37ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

