### PR TITLE
fix: allow tmKMS-to-cosmosigner migration on ChainNodeSet validators

### DIFF
--- a/api/v1/chainnode_webhook.go
+++ b/api/v1/chainnode_webhook.go
@@ -368,10 +368,13 @@ func (chainNode *ChainNode) Validate(old *ChainNode) (admission.Warnings, error)
 			case oldHasInit && newHasInit:
 				// A managed signer migration may intentionally change signing keys. When cosmosigner is
 				// involved, keep the non-signing genesis configuration immutable while leaving the
-				// on-chain key choice to the user.
+				// on-chain key choice to the user. A ChainNodeSet-generated child never carries
+				// .spec.cosmosigner — the signer belongs to its parent and the child is marked with
+				// .spec.remoteSignerTarget — so both shapes must be recognised here, otherwise a
+				// nodeset validator can never migrate off tmKMS once genesis exists.
 				oldFP := old.Spec.Validator.GenesisSigningFingerprint(defaultPrivKeySecret)
 				newFP := chainNode.Spec.Validator.GenesisSigningFingerprint(defaultPrivKeySecret)
-				if old.Spec.Cosmosigner != nil || chainNode.Spec.Cosmosigner != nil {
+				if old.IsSignerTarget() || chainNode.IsSignerTarget() {
 					oldFP = genesisConfigurationFingerprint(old.Spec.Validator.Init, old.Spec.Validator.Info, old.Spec.Validator.GetAccountPrefix(), old.Spec.Validator.GetValPrefix(), old.Spec.Validator.GetAccountHDPath())
 					newFP = genesisConfigurationFingerprint(chainNode.Spec.Validator.Init, chainNode.Spec.Validator.Info, chainNode.Spec.Validator.GetAccountPrefix(), chainNode.Spec.Validator.GetValPrefix(), chainNode.Spec.Validator.GetAccountHDPath())
 				}

--- a/api/v1/chainnode_webhook_test.go
+++ b/api/v1/chainnode_webhook_test.go
@@ -233,6 +233,60 @@ func TestChainNodeValidateRejectsInitChangeAfterCreation(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestChainNodeValidateAllowsSignerMigrationOnGeneratedValidator covers the ChainNodeSet-generated
+// validator child: it never carries .spec.cosmosigner (the signer belongs to its parent) and is marked
+// with .spec.remoteSignerTarget instead. Dropping its tmKMS sidecar for that managed signer changes the
+// signing key choice, which must be admitted for the same reason it is on a standalone ChainNode — while
+// the non-signing genesis configuration stays immutable.
+func TestChainNodeValidateAllowsSignerMigrationOnGeneratedValidator(t *testing.T) {
+	init := func() *GenesisInitConfig {
+		return &GenesisInitConfig{ChainID: "test-localnet", Assets: []string{"1unibi"}, StakeAmount: "1unibi"}
+	}
+	// .spec.remoteSignerTarget is only accepted on a generated child, so the fixture carries the
+	// controller owner reference the ChainNodeSet controller sets.
+	ownedByNodeSet := []metav1.OwnerReference{{
+		APIVersion: GroupVersion.String(), Kind: "ChainNodeSet", Name: "cns",
+		UID: "11111111-1111-1111-1111-111111111111", Controller: ptr.To(true),
+	}}
+	tmkmsChild := func() *ChainNode {
+		return &ChainNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "cns-validator", OwnerReferences: ownedByNodeSet},
+			Spec: ChainNodeSpec{Validator: &ValidatorConfig{
+				Init: init(),
+				TmKMS: &TmKMS{Provider: TmKmsProvider{Hashicorp: &TmKmsHashicorpProvider{
+					Address:     "https://vault:8200",
+					Key:         "myval",
+					TokenSecret: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "vault-token"}, Key: "token"},
+				}}},
+			}},
+			Status: ChainNodeStatus{ChainID: "test-localnet"},
+		}
+	}
+
+	// tmKMS sidecar -> parent-owned cosmosigner: the child drops TmKMS and gains the target marker.
+	migrated := tmkmsChild()
+	migrated.Status = ChainNodeStatus{}
+	migrated.Spec.Validator.TmKMS = nil
+	migrated.Spec.RemoteSignerTarget = true
+	_, err := migrated.Validate(tmkmsChild())
+	assert.NoError(t, err)
+
+	// The relaxation is scoped to the signing key: genesis configuration stays immutable.
+	changedStake := migrated.DeepCopy()
+	changedStake.Spec.Validator.Init.StakeAmount = "2unibi"
+	_, err = changedStake.Validate(tmkmsChild())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "immutable after genesis")
+
+	// Without either signer marker the signing key stays immutable: dropping tmKMS for a local key is
+	// still rejected, so this does not become a blanket escape hatch.
+	local := migrated.DeepCopy()
+	local.Spec.RemoteSignerTarget = false
+	_, err = local.Validate(tmkmsChild())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "immutable after genesis")
+}
+
 // TestChainNodeValidateRejectsInitChangeNoWebhook verifies the no-webhook reconcile path (Validate with
 // old == nil): a post-genesis .validator.init change is rejected by diffing the current spec against the
 // genesis fingerprint recorded in the object's own status. Without a recorded digest (legacy/upgrade)

--- a/test/integration/cosmosigner_webhook_test.go
+++ b/test/integration/cosmosigner_webhook_test.go
@@ -534,11 +534,19 @@ var _ = Describe("Cosmosigner Webhook Validation", func() {
 		}
 		Expect(Framework().Client().Create(Framework().Context(), cn)).To(Succeed())
 
-		// Mark the chain as established and record the applied signer identity/public key.
-		cn.Status.ChainID = "test-chain-1"
-		cn.Status.CosmosignerAppliedDigest = cn.CosmosignerSigningDigest()
-		cn.Status.CosmosignerPublicKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-		Expect(Framework().Client().Status().Update(Framework().Context(), cn)).To(Succeed())
+		// Mark the chain as established and record the applied signer identity/public key. The
+		// controller adds its cleanup finalizer right after creation, so re-fetch and retry on the
+		// resulting stale-write conflict.
+		Eventually(func() error {
+			fresh := &appsv1.ChainNode{}
+			if err := Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cn), fresh); err != nil {
+				return err
+			}
+			fresh.Status.ChainID = "test-chain-1"
+			fresh.Status.CosmosignerAppliedDigest = fresh.CosmosignerSigningDigest()
+			fresh.Status.CosmosignerPublicKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+			return Framework().Client().Status().Update(Framework().Context(), fresh)
+		}).Should(Succeed())
 
 		// Changing the Vault key is admitted for break-before-make migration.
 		Eventually(func() error {
@@ -582,8 +590,14 @@ var _ = Describe("Cosmosigner Webhook Validation", func() {
 			},
 		}
 		Expect(Framework().Client().Create(Framework().Context(), cn)).To(Succeed())
-		cn.Status.ChainID = "test-chain-1"
-		Expect(Framework().Client().Status().Update(Framework().Context(), cn)).To(Succeed())
+		Eventually(func() error {
+			fresh := &appsv1.ChainNode{}
+			if err := Framework().Client().Get(Framework().Context(), client.ObjectKeyFromObject(cn), fresh); err != nil {
+				return err
+			}
+			fresh.Status.ChainID = "test-chain-1"
+			return Framework().Client().Status().Update(Framework().Context(), fresh)
+		}).Should(Succeed())
 
 		// Switch to cosmosigner pointing at the same Vault transit key (default mount, no namespace).
 		Eventually(func() error {


### PR DESCRIPTION
Fixes two independent CI failures on `main`: a product bug breaking the E2E suite, and a stale-write race breaking the integration suite.

## 1. Webhook blocks signer migration on ChainNodeSet validators (E2E)

`api/v1/chainnode_webhook.go` relaxes the post-genesis `.spec.validator.init` immutability check when a managed signer is involved, so a migration can intentionally change the signing key while the genesis configuration stays immutable. That escape hatch only recognised the **standalone ChainNode** shape:

```go
if old.Spec.Cosmosigner != nil || chainNode.Spec.Cosmosigner != nil {
```

A ChainNodeSet-generated validator child never carries `.spec.cosmosigner` — the signer is owned by its parent, and the child is marked `.spec.remoteSignerTarget` instead (`validator.go:469`). So the relaxation never fired, the strict `GenesisSigningFingerprint` (which includes `TmKMS`) applied, and dropping the sidecar was rejected:

```
failed to ensure validator node ...: admission webhook "vchainnode.kb.io" denied the request:
.spec.validator.init is immutable after genesis has been created
```

`ensureValidator` then failed on every reconcile, so the child was never updated and its pod never torn down — leaving the migration permanently stuck. **A ChainNodeSet validator could not migrate off tmKMS once genesis existed.**

Fixed by using the existing `IsSignerTarget()` helper, which covers both shapes.

This is what `should migrate a ChainNodeSet validator from tmKMS Vault to a top-level cosmosigner across a controller restart` has been catching. That spec was added in #105, whose own E2E run was cancelled, so it merged unvalidated and has failed every completed E2E run since (#106, #107) at the same assertion.

## 2. Stale status write in the cosmosigner webhook integration specs (Test)

`Cosmosigner Webhook Validation → allows a recorded cosmosigner key migration and rejects validator removal` called `Status().Update()` on the object returned by `Create`. The controller concurrently writes its cleanup finalizer (`internal/controllers/chainnode/controller.go:224-229`), bumping `resourceVersion` and leaving the test's copy stale:

```
Operation cannot be fulfilled on chainnodes.cosmopilot.voluzi.com "...":
the object has been modified; please apply your changes to the latest version and try again
```

Switched to the refetch-and-retry pattern already used throughout that file. Also applied to the identical pattern in the adjacent `allows a same-key migration from tmKMS to cosmosigner` spec, which was passing only by luck. These were the only two occurrences in the integration suite.

## Verification

- New unit test fails without the webhook fix with the exact E2E error, and passes with it. It also pins the relaxation's scope: changing `init.stakeAmount` is still rejected, and dropping tmKMS with neither signer marker is still rejected, so this is not a blanket escape hatch.
- The integration race was reproduced deterministically with a temporary scratch spec that injected the conflicting update (old pattern failed with the exact CI error, new pattern passed), then removed.
- `go build`, `go vet`, full unit suite, and full integration suite green; integration ran clean on three consecutive invocations.
- The E2E spec is being re-run locally against a kind cluster to confirm end-to-end; result to follow.