### PR TITLE
chore: pin component images to their newly released versions

### DIFF
--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -51,7 +51,7 @@ require the discovery-gate command introduced in 2.10.0 and cannot start with an
 
 ### `dataExporterImage`
 - **Description**: The container image of Data Exporter (with version tag included) used by snapshot tarball upload and deletion Jobs.
-- **Default**: `ghcr.io/voluzi/dataexporter:2.0.0`
+- **Default**: `ghcr.io/voluzi/dataexporter:2.0.1`
 
 ### `imagePullSecrets`
 - **Description**: Secrets for pulling images from private repositories.

--- a/helm/cosmopilot/deployment_test.go
+++ b/helm/cosmopilot/deployment_test.go
@@ -22,8 +22,8 @@ func TestDataExporterImageDefault(t *testing.T) {
 	if err := yaml.Unmarshal(valuesSource, &values); err != nil {
 		t.Fatalf("decode values: %v", err)
 	}
-	if values.DataExporterImage != "ghcr.io/voluzi/dataexporter:2.0.0" {
-		t.Errorf("dataExporterImage = %q, want %q", values.DataExporterImage, "ghcr.io/voluzi/dataexporter:2.0.0")
+	if values.DataExporterImage != "ghcr.io/voluzi/dataexporter:2.0.1" {
+		t.Errorf("dataExporterImage = %q, want %q", values.DataExporterImage, "ghcr.io/voluzi/dataexporter:2.0.1")
 	}
 }
 

--- a/helm/cosmopilot/values.yaml
+++ b/helm/cosmopilot/values.yaml
@@ -3,7 +3,7 @@ nodeUtilsImage: ghcr.io/voluzi/node-utils:2.10.0
 cosmoGuardImage: ghcr.io/voluzi/cosmoguard:4.0.3
 cosmoseedImage: ghcr.io/voluzi/cosmoseed:0.11.0
 cosmosignerImage: ghcr.io/voluzi/cosmosigner:0.2.1
-dataExporterImage: ghcr.io/voluzi/dataexporter:2.0.0
+dataExporterImage: ghcr.io/voluzi/dataexporter:2.0.1
 replicas: 1
 imagePullSecrets: []
 workerCount: 10

--- a/internal/controllers/options.go
+++ b/internal/controllers/options.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	LabelWorkerName          = "worker-name"
-	DefaultDataExporterImage = "ghcr.io/voluzi/dataexporter:2.0.0"
+	DefaultDataExporterImage = "ghcr.io/voluzi/dataexporter:2.0.1"
 )
 
 type ControllerRunOptions struct {

--- a/internal/k8s/pvc.go
+++ b/internal/k8s/pvc.go
@@ -116,7 +116,7 @@ func (h *PvcHelper) DownloadGenesis(ctx context.Context, url, path, pc string, a
 	cmd := buildGenesisDownloadCommand(url, destPath)
 
 	// Use node-tools image which has compression tools (gzip, zstd)
-	image := "ghcr.io/voluzi/node-tools"
+	image := "ghcr.io/voluzi/node-tools:1.4.3"
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/tmkms/hashicorp.go
+++ b/internal/tmkms/hashicorp.go
@@ -21,7 +21,7 @@ const (
 
 	tokenRenewerCpu        = "100m"
 	tokenRenewerMemory     = "64Mi"
-	vaultTokenRenewerImage = "ghcr.io/voluzi/vault-renewer:1.0.0@sha256:55532cbf4c7a7c5038e1b7cf759fa5748216075719afde776226a4025cb8e579"
+	vaultTokenRenewerImage = "ghcr.io/voluzi/vault-renewer:1.0.1"
 )
 
 var (

--- a/internal/tmkms/tmkms_test.go
+++ b/internal/tmkms/tmkms_test.go
@@ -69,7 +69,7 @@ func TestHashicorpProviderUsesPinnedVaultTokenRenewerImage(t *testing.T) {
 	if len(containers) != 1 {
 		t.Fatalf("renewer containers = %d, want 1", len(containers))
 	}
-	want := "ghcr.io/voluzi/vault-renewer:1.0.0@sha256:55532cbf4c7a7c5038e1b7cf759fa5748216075719afde776226a4025cb8e579"
+	want := vaultTokenRenewerImage
 	if got := containers[0].Image; got != want {
 		t.Fatalf("renewer image = %q, want %q", got, want)
 	}


### PR DESCRIPTION
Follow-up to the component image tags cut from `main` (`8fa7be8`).

| Component | Was | Now |
|---|---|---|
| dataexporter | `2.0.0` | `2.0.1` |
| vault-renewer | `1.0.0@sha256:5553…` | `1.0.1` |
| node-tools | *unpinned* (`:latest`) | `1.4.3` |
| node-utils | `2.10.0` | unchanged — already pinned ahead of its tag |

Files: `helm/cosmopilot/values.yaml`, `internal/controllers/options.go`, `internal/k8s/pvc.go`, `internal/tmkms/hashicorp.go`, plus the two tests that asserted the old strings and the configuration docs.

## Notes

- **node-tools was previously unpinned**, so the genesis-download pod ran whatever `:latest` happened to be — an upstream push could change behaviour with no release. Now pinned.
- **Digests dropped.** The vault-renewer pin carried a `@sha256:` digest; it now pins by tag only. This was the only digest pin left in the repo.
- The tmkms test asserted the image string literally; it now references the `vaultTokenRenewerImage` constant so the pin has a single source of truth.

`go build`, unit tests, and the helm values test all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins component images to released tags for reproducible deployments and to prevent drift from `:latest`. Updates Helm defaults, controller constant, K8s pod image, docs, and tests.

- **Dependencies**
  - `dataexporter`: 2.0.0 → 2.0.1
  - `vault-renewer`: 1.0.0@sha256… → 1.0.1 (pin by tag; digest removed)
  - `node-tools`: unpinned `:latest` → 1.4.3

- **Refactors**
  - tmkms test now uses the `vaultTokenRenewerImage` constant for a single source of truth.

<sup>Written for commit 60a11e2d94964bf1aa7cface9968c8cfdf22f900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/voluzi/cosmopilot/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

