### PR TITLE
chore: update module path to v3 for major version release

### DIFF
--- a/api/v1/chainnodeset_helper.go
+++ b/api/v1/chainnodeset_helper.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 const (

--- a/api/v1/common_helper.go
+++ b/api/v1/common_helper.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/utils/ptr"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/voluzi/cosmopilot/v2/internal/tmkms"
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/internal/tmkms"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
 )
 
 const (

--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/voluzi/cosmopilot/v2/internal/tmkms"
+	"github.com/voluzi/cosmopilot/v3/internal/tmkms"
 )
 
 // Reasons for events.

--- a/api/v1/cosmosigner_helper.go
+++ b/api/v1/cosmosigner_helper.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // GetReplicas returns the configured number of signer replicas, defaulting to

--- a/api/v1/cosmosigner_resolve.go
+++ b/api/v1/cosmosigner_resolve.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // HasLegacyPerInstanceCosmosignerStatus reports whether status still records the pre-group-identity

--- a/api/v1/snapshot_export_test.go
+++ b/api/v1/snapshot_export_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
 )
 
 func TestSnapshotExportStatusDeepCopyPreservesDeleteRetryState(t *testing.T) {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1
 
 import (
-	"github.com/voluzi/cosmopilot/v2/internal/tmkms"
+	"github.com/voluzi/cosmopilot/v3/internal/tmkms"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/cmd/dataexporter/cmd/delete.go
+++ b/cmd/dataexporter/cmd/delete.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
 )
 
 func newDeleteCmd() *cobra.Command {

--- a/cmd/dataexporter/cmd/gcs.go
+++ b/cmd/dataexporter/cmd/gcs.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
 )
 
 var gcsCmd = &cobra.Command{

--- a/cmd/dataexporter/cmd/root.go
+++ b/cmd/dataexporter/cmd/root.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
 )
 
 var exporter dataexporter.Exporter

--- a/cmd/dataexporter/cmd/s3.go
+++ b/cmd/dataexporter/cmd/s3.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
 )
 
 var (

--- a/cmd/dataexporter/cmd/upload.go
+++ b/cmd/dataexporter/cmd/upload.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
 )
 
 func newUploadCmd(defaultChunkSize string) *cobra.Command {

--- a/cmd/dataexporter/main.go
+++ b/cmd/dataexporter/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/voluzi/cosmopilot/v2/cmd/dataexporter/cmd"
+	"github.com/voluzi/cosmopilot/v3/cmd/dataexporter/cmd"
 )
 
 func main() {

--- a/cmd/manager/config.go
+++ b/cmd/manager/config.go
@@ -6,9 +6,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
 )
 
 func init() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,11 +23,11 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers/chainnode"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers/chainnodeset"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers/chainnode"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers/chainnodeset"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 var (

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -15,11 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers/chainnode"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers/chainnodeset"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers/chainnode"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers/chainnodeset"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestRootProtectionReadinessAllowsStandbyBeforeLeadership(t *testing.T) {

--- a/cmd/nodeutils/config.go
+++ b/cmd/nodeutils/config.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
 )
 
 var mockMode bool

--- a/cmd/nodeutils/main.go
+++ b/cmd/nodeutils/main.go
@@ -15,8 +15,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	_ "go.uber.org/automaxprocs"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 var (

--- a/cmd/nodeutils/main_test.go
+++ b/cmd/nodeutils/main_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 // testCommands fails the test if the node-utils server is ever started. Standalone subcommands run

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/voluzi/cosmopilot/v2
+module github.com/voluzi/cosmopilot/v3
 
 go 1.26.0
 

--- a/helm/cosmopilot/Chart.yaml
+++ b/helm/cosmopilot/Chart.yaml
@@ -1,4 +1,6 @@
 apiVersion: v2
 name: cosmopilot
-version: 2.3.1
+# version and appVersion are placeholders: `make helm.package` overrides both from git tags
+# (--version from the chart/v* tag, --app-version from the cosmopilot v* tag) at release time.
+version: 0.0.0
 appVersion: 0.0.0

--- a/internal/chainutils/account_test.go
+++ b/internal/chainutils/account_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const testMnemonic = "upset promote follow flag you way eagle plunge scorpion oil version afraid churn fog tiger almost noise define license pistol post raise report time"

--- a/internal/chainutils/chain.go
+++ b/internal/chainutils/chain.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils/sdkcmd"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils/sdkcmd"
 )
 
 type App struct {

--- a/internal/chainutils/config.go
+++ b/internal/chainutils/config.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 func (a *App) buildConfigGeneratorPod() *corev1.Pod {

--- a/internal/chainutils/data.go
+++ b/internal/chainutils/data.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 // BuildInitPod constructs the init pod spec without creating it.

--- a/internal/chainutils/env_test.go
+++ b/internal/chainutils/env_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func testAppEnv() []corev1.EnvVar {

--- a/internal/chainutils/genesis.go
+++ b/internal/chainutils/genesis.go
@@ -16,9 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils/sdkcmd"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils/sdkcmd"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 var (

--- a/internal/chainutils/genesis_pod_test.go
+++ b/internal/chainutils/genesis_pod_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils/sdkcmd"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils/sdkcmd"
 )
 
 func newTestGenesisApp(t *testing.T) *App {

--- a/internal/chainutils/sdkcmd/sdk.go
+++ b/internal/chainutils/sdkcmd/sdk.go
@@ -3,7 +3,7 @@ package sdkcmd
 import (
 	"fmt"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 type sdkCreator func(globalOptions ...Option) SDK

--- a/internal/chainutils/sdkcmd/v0_45.go
+++ b/internal/chainutils/sdkcmd/v0_45.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func init() {

--- a/internal/chainutils/sdkcmd/v0_47.go
+++ b/internal/chainutils/sdkcmd/v0_47.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func init() {

--- a/internal/chainutils/sdkcmd/v0_50.go
+++ b/internal/chainutils/sdkcmd/v0_50.go
@@ -3,7 +3,7 @@ package sdkcmd
 import (
 	"fmt"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func init() {

--- a/internal/chainutils/sdkcmd/v0_53.go
+++ b/internal/chainutils/sdkcmd/v0_53.go
@@ -1,7 +1,7 @@
 package sdkcmd
 
 import (
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func init() {

--- a/internal/chainutils/validator.go
+++ b/internal/chainutils/validator.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils/sdkcmd"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils/sdkcmd"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 func (a *App) buildCreateValidatorPod(

--- a/internal/controllers/chainnode/account.go
+++ b/internal/controllers/chainnode/account.go
@@ -10,9 +10,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func (r *Reconciler) migrateExistingAccountSecret(ctx context.Context, chainNode *appsv1.ChainNode) error {

--- a/internal/controllers/chainnode/config.go
+++ b/internal/controllers/chainnode/config.go
@@ -3,7 +3,7 @@ package chainnode
 import (
 	"strings"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func GetKeyFormatter(chainNode *appsv1.ChainNode) *KeyFormatter {

--- a/internal/controllers/chainnode/configmap.go
+++ b/internal/controllers/chainnode/configmap.go
@@ -22,10 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 const (

--- a/internal/controllers/chainnode/configmap_test.go
+++ b/internal/controllers/chainnode/configmap_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestConfigGenerationCacheKeyIncludesAppEnv(t *testing.T) {

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -20,14 +20,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils/sdkcmd"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/datasnapshot"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils/sdkcmd"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/datasnapshot"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 // StatsClientFactory is a function that creates a StatsClient for a given host.

--- a/internal/controllers/chainnode/cosmoguard.go
+++ b/internal/controllers/chainnode/cosmoguard.go
@@ -15,9 +15,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmoguard"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmoguard"
 )
 
 // guardPriorityClassName returns the scheduling priority for a standalone guard: the validators'

--- a/internal/controllers/chainnode/cosmoguard_test.go
+++ b/internal/controllers/chainnode/cosmoguard_test.go
@@ -23,8 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 // ensureGuard drops ensureCosmoGuard's route-pending flag for the tests that only assert on the

--- a/internal/controllers/chainnode/cosmosigner.go
+++ b/internal/controllers/chainnode/cosmosigner.go
@@ -17,12 +17,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // cosmosignerName is the base name for a standalone ChainNode's managed signer resources.

--- a/internal/controllers/chainnode/cosmosigner_gcp_import_recovery_test.go
+++ b/internal/controllers/chainnode/cosmosigner_gcp_import_recovery_test.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 const (

--- a/internal/controllers/chainnode/cosmosigner_gcp_import_test.go
+++ b/internal/controllers/chainnode/cosmosigner_gcp_import_test.go
@@ -14,10 +14,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 const gcpDestinationKey = "projects/example-project/locations/europe-west1/keyRings/validators/cryptoKeys/consensus"

--- a/internal/controllers/chainnode/cosmosigner_test.go
+++ b/internal/controllers/chainnode/cosmosigner_test.go
@@ -25,10 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 func TestReconcileCosmosignerMigrationWaitsForTerminatingPod(t *testing.T) {

--- a/internal/controllers/chainnode/durable_resources_test.go
+++ b/internal/controllers/chainnode/durable_resources_test.go
@@ -16,9 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestGeneratedKeySecretsCarryStableAttribution(t *testing.T) {

--- a/internal/controllers/chainnode/env_test.go
+++ b/internal/controllers/chainnode/env_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestNewAppPropagatesStandaloneChainNodeEnvWithoutAliasing(t *testing.T) {

--- a/internal/controllers/chainnode/gateway.go
+++ b/internal/controllers/chainnode/gateway.go
@@ -13,9 +13,9 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 const (

--- a/internal/controllers/chainnode/genesis.go
+++ b/internal/controllers/chainnode/genesis.go
@@ -12,10 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 func (r *Reconciler) ensureGenesis(ctx context.Context, app *chainutils.App, chainNode *appsv1.ChainNode) error {

--- a/internal/controllers/chainnode/genesis_test.go
+++ b/internal/controllers/chainnode/genesis_test.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestRecordGenesisDigestRefreshesForManagedSignerMigration(t *testing.T) {

--- a/internal/controllers/chainnode/ingress.go
+++ b/internal/controllers/chainnode/ingress.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func (r *Reconciler) ensureIngresses(ctx context.Context, chainNode *appsv1.ChainNode) error {

--- a/internal/controllers/chainnode/keys.go
+++ b/internal/controllers/chainnode/keys.go
@@ -10,9 +10,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func (r *Reconciler) ensureNodeKey(ctx context.Context, chainNode *appsv1.ChainNode) error {

--- a/internal/controllers/chainnode/ownership_test.go
+++ b/internal/controllers/chainnode/ownership_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestEnsureServiceRefusesForeignController(t *testing.T) {

--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -26,12 +26,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 func (r *Reconciler) isChainNodePodRunning(ctx context.Context, chainNode *appsv1.ChainNode) (bool, bool, error) {

--- a/internal/controllers/chainnode/pod_test.go
+++ b/internal/controllers/chainnode/pod_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestPodSpecHash(t *testing.T) {

--- a/internal/controllers/chainnode/predicate.go
+++ b/internal/controllers/chainnode/predicate.go
@@ -8,8 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 type GenerationChangedPredicate struct {

--- a/internal/controllers/chainnode/predicate_test.go
+++ b/internal/controllers/chainnode/predicate_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestGenerationChangedPredicateIgnoresCosmosignerJobPods(t *testing.T) {

--- a/internal/controllers/chainnode/pvc.go
+++ b/internal/controllers/chainnode/pvc.go
@@ -17,11 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 // initializeData manages the data initialization process in a non-blocking way.

--- a/internal/controllers/chainnode/pvc_test.go
+++ b/internal/controllers/chainnode/pvc_test.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestUpdatePvcDataHeightRetriesOnConflict(t *testing.T) {

--- a/internal/controllers/chainnode/reservation.go
+++ b/internal/controllers/chainnode/reservation.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 // ensureValidatorConsensusKeyReservation claims the active local or TmKMS consensus key before

--- a/internal/controllers/chainnode/reservation_lifecycle.go
+++ b/internal/controllers/chainnode/reservation_lifecycle.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 func (r *Reconciler) prepareConsensusKeyReservationOwner(ctx context.Context, chainNode *appsv1.ChainNode) (bool, error) {

--- a/internal/controllers/chainnode/reservation_lifecycle_test.go
+++ b/internal/controllers/chainnode/reservation_lifecycle_test.go
@@ -20,8 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 func TestPrepareConsensusKeyReservationOwnerFinalizesChainNodeSetRoot(t *testing.T) {

--- a/internal/controllers/chainnode/resource_cleanup.go
+++ b/internal/controllers/chainnode/resource_cleanup.go
@@ -10,10 +10,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 // finalizeResources stops every signing workload before applying durable-resource policy. Consensus

--- a/internal/controllers/chainnode/resource_cleanup_test.go
+++ b/internal/controllers/chainnode/resource_cleanup_test.go
@@ -20,12 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestFinalizeResourcesQuiescesLocalSignerAndAppliesDeletionPolicy(t *testing.T) {

--- a/internal/controllers/chainnode/resource_finalizer_test.go
+++ b/internal/controllers/chainnode/resource_finalizer_test.go
@@ -16,10 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestReconcileInstallsResourceCleanupFinalizerBeforeDurableCreation(t *testing.T) {

--- a/internal/controllers/chainnode/service.go
+++ b/internal/controllers/chainnode/service.go
@@ -18,11 +18,11 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 func (r *Reconciler) ensureServices(ctx context.Context, chainNode *appsv1.ChainNode) error {

--- a/internal/controllers/chainnode/signing_test.go
+++ b/internal/controllers/chainnode/signing_test.go
@@ -20,10 +20,10 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/internal/controllers/chainnode/snapshot_export_destination_test.go
+++ b/internal/controllers/chainnode/snapshot_export_destination_test.go
@@ -27,9 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/datasnapshot"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/datasnapshot"
 )
 
 func TestNewSnapshotExportStatusCapturesDestinationAndSafeAuthenticationReferences(t *testing.T) {

--- a/internal/controllers/chainnode/snapshot_exports.go
+++ b/internal/controllers/chainnode/snapshot_exports.go
@@ -20,9 +20,9 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/datasnapshot"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/datasnapshot"
 )
 
 type snapshotExportReferenceUnavailableError struct {

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -22,11 +22,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/datasnapshot"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/datasnapshot"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 type SnapshotIntegrityStatus string

--- a/internal/controllers/chainnode/snapshots_test.go
+++ b/internal/controllers/chainnode/snapshots_test.go
@@ -28,9 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/datasnapshot"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/datasnapshot"
 )
 
 func TestStartSnapshotIntegrityCheckPropagatesAppEnvOnlyToAppContainer(t *testing.T) {

--- a/internal/controllers/chainnode/tmkms.go
+++ b/internal/controllers/chainnode/tmkms.go
@@ -8,11 +8,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/tmkms"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/tmkms"
 )
 
 func (r *Reconciler) ensureTmKMSConfig(ctx context.Context, chainNode *appsv1.ChainNode) error {

--- a/internal/controllers/chainnode/upgrades.go
+++ b/internal/controllers/chainnode/upgrades.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 func (r *Reconciler) ensureUpgrades(ctx context.Context, chainNode *appsv1.ChainNode, nodePodRunning bool) error {

--- a/internal/controllers/chainnode/upgrades_test.go
+++ b/internal/controllers/chainnode/upgrades_test.go
@@ -3,7 +3,7 @@ package chainnode
 import (
 	"testing"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestGetUpgrade(t *testing.T) {

--- a/internal/controllers/chainnode/utils.go
+++ b/internal/controllers/chainnode/utils.go
@@ -10,9 +10,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 func WithChainNodeLabels(chainNode *appsv1.ChainNode, additional ...map[string]string) map[string]string {

--- a/internal/controllers/chainnode/utils_test.go
+++ b/internal/controllers/chainnode/utils_test.go
@@ -7,8 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestWithChainNodeLabels(t *testing.T) {

--- a/internal/controllers/chainnode/validator.go
+++ b/internal/controllers/chainnode/validator.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
 )
 
 func (r *Reconciler) createValidator(ctx context.Context, app *chainutils.App, chainNode *appsv1.ChainNode) error {

--- a/internal/controllers/chainnode/validator_test.go
+++ b/internal/controllers/chainnode/validator_test.go
@@ -6,7 +6,7 @@ import (
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/assert"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestGetValidatorStatus(t *testing.T) {

--- a/internal/controllers/chainnode/vpa.go
+++ b/internal/controllers/chainnode/vpa.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 const OneMiB = int64(1024 * 1024)

--- a/internal/controllers/chainnode/vpa_scenarios_test.go
+++ b/internal/controllers/chainnode/vpa_scenarios_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // mockStatsClient implements nodeutils.StatsClient for testing

--- a/internal/controllers/chainnode/vpa_test.go
+++ b/internal/controllers/chainnode/vpa_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestClamp(t *testing.T) {

--- a/internal/controllers/chainnodeset/constant.go
+++ b/internal/controllers/chainnodeset/constant.go
@@ -3,7 +3,7 @@ package chainnodeset
 import (
 	"time"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const (

--- a/internal/controllers/chainnodeset/controller.go
+++ b/internal/controllers/chainnodeset/controller.go
@@ -21,12 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils/sdkcmd"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils/sdkcmd"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 // Reconciler reconciles a ChainNode object

--- a/internal/controllers/chainnodeset/controller_test.go
+++ b/internal/controllers/chainnodeset/controller_test.go
@@ -22,10 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 type chainNodeSetRoundTripperFunc func(*http.Request) (*http.Response, error)

--- a/internal/controllers/chainnodeset/cosmoguard.go
+++ b/internal/controllers/chainnodeset/cosmoguard.go
@@ -18,11 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmoguard"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmoguard"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // groupCosmoGuardName returns the name of the CosmoGuard Deployment/Service fronting a node group.

--- a/internal/controllers/chainnodeset/cosmoguard_test.go
+++ b/internal/controllers/chainnodeset/cosmoguard_test.go
@@ -18,10 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmoguard"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmoguard"
 )
 
 func guardedNodeSet() (*appsv1.ChainNodeSet, appsv1.NodeGroupSpec) {

--- a/internal/controllers/chainnodeset/cosmoseed.go
+++ b/internal/controllers/chainnodeset/cosmoseed.go
@@ -23,13 +23,13 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	"github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 func (r *Reconciler) ensureSeedNodes(ctx context.Context, nodeSet *v1.ChainNodeSet) error {

--- a/internal/controllers/chainnodeset/cosmosigner.go
+++ b/internal/controllers/chainnodeset/cosmosigner.go
@@ -18,12 +18,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // cosmosignerKubernetesClient returns the clientset the one-shot signer pods run against, or nil when

--- a/internal/controllers/chainnodeset/cosmosigner_gcp_import_recovery_test.go
+++ b/internal/controllers/chainnodeset/cosmosigner_gcp_import_recovery_test.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 // gcpImportPodLogs is what a one-shot pod prints in these tests. It carries BOTH stable lines the

--- a/internal/controllers/chainnodeset/cosmosigner_gcp_import_test.go
+++ b/internal/controllers/chainnodeset/cosmosigner_gcp_import_test.go
@@ -12,9 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 const nodeSetGcpDestinationKey = "projects/example-project/locations/europe-west1/keyRings/validators/cryptoKeys/consensus"

--- a/internal/controllers/chainnodeset/cosmosigner_test.go
+++ b/internal/controllers/chainnodeset/cosmosigner_test.go
@@ -26,10 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 func TestReconcileCosmosignerMigrationsWaitsForTerminatingPod(t *testing.T) {

--- a/internal/controllers/chainnodeset/deletion_policy_test.go
+++ b/internal/controllers/chainnodeset/deletion_policy_test.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestGeneratedChainNodesCopyParentDeletionPolicy(t *testing.T) {

--- a/internal/controllers/chainnodeset/env_test.go
+++ b/internal/controllers/chainnodeset/env_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func nodeSetAppEnv() []corev1.EnvVar {

--- a/internal/controllers/chainnodeset/gateway.go
+++ b/internal/controllers/chainnodeset/gateway.go
@@ -12,9 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 const (

--- a/internal/controllers/chainnodeset/genesis.go
+++ b/internal/controllers/chainnodeset/genesis.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 func (r *Reconciler) ensureGenesis(ctx context.Context, app *chainutils.App, nodeSet *appsv1.ChainNodeSet) error {

--- a/internal/controllers/chainnodeset/genesis_test.go
+++ b/internal/controllers/chainnodeset/genesis_test.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
 )
 
 func newGenesisTestReconciler(t *testing.T, objs ...client.Object) *Reconciler {

--- a/internal/controllers/chainnodeset/ingress.go
+++ b/internal/controllers/chainnodeset/ingress.go
@@ -14,9 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func (r *Reconciler) ensureIngresses(ctx context.Context, nodeSet *appsv1.ChainNodeSet, gatewayApplied bool) error {

--- a/internal/controllers/chainnodeset/nodes.go
+++ b/internal/controllers/chainnodeset/nodes.go
@@ -21,12 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/pkg/informer"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/pkg/informer"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 func (r *Reconciler) ensureNodes(ctx context.Context, nodeSet *appsv1.ChainNodeSet) error {

--- a/internal/controllers/chainnodeset/nodes_test.go
+++ b/internal/controllers/chainnodeset/nodes_test.go
@@ -17,9 +17,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestEnsureNodePreservesCleanupFinalizerOnSpecUpdate(t *testing.T) {

--- a/internal/controllers/chainnodeset/pdb.go
+++ b/internal/controllers/chainnodeset/pdb.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 const (

--- a/internal/controllers/chainnodeset/pdb_test.go
+++ b/internal/controllers/chainnodeset/pdb_test.go
@@ -19,8 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func newPdbTestReconciler(t *testing.T, nodeSet *appsv1.ChainNodeSet) *Reconciler {

--- a/internal/controllers/chainnodeset/predicate.go
+++ b/internal/controllers/chainnodeset/predicate.go
@@ -4,7 +4,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 type GenerationChangedPredicate struct {

--- a/internal/controllers/chainnodeset/predicate_test.go
+++ b/internal/controllers/chainnodeset/predicate_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestGenerationChangedPredicateAllowsChainNodeSetDeletionTimestamp(t *testing.T) {

--- a/internal/controllers/chainnodeset/reservation_lifecycle.go
+++ b/internal/controllers/chainnodeset/reservation_lifecycle.go
@@ -16,9 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 func (r *Reconciler) prepareConsensusKeyReservationOwner(ctx context.Context, nodeSet *appsv1.ChainNodeSet) (bool, error) {

--- a/internal/controllers/chainnodeset/reservation_lifecycle_test.go
+++ b/internal/controllers/chainnodeset/reservation_lifecycle_test.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
 )
 
 func TestPrepareConsensusKeyReservationOwnerFinalizesChainNodeSet(t *testing.T) {

--- a/internal/controllers/chainnodeset/resource_cleanup.go
+++ b/internal/controllers/chainnodeset/resource_cleanup.go
@@ -14,11 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 // finalizeResources stops every signing workload before applying durable-resource policy. Consensus

--- a/internal/controllers/chainnodeset/resource_cleanup_test.go
+++ b/internal/controllers/chainnodeset/resource_cleanup_test.go
@@ -21,12 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestFinalizeResourcesCoversRegularMultiValidatorAndCosmosignerState(t *testing.T) {

--- a/internal/controllers/chainnodeset/resource_finalizer_test.go
+++ b/internal/controllers/chainnodeset/resource_finalizer_test.go
@@ -18,10 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestReconcileInstallsResourceCleanupFinalizerBeforeGeneratingChildren(t *testing.T) {

--- a/internal/controllers/chainnodeset/service.go
+++ b/internal/controllers/chainnodeset/service.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func (r *Reconciler) initializeLegacySignerServiceNames(ctx context.Context, nodeSet *appsv1.ChainNodeSet) (bool, error) {

--- a/internal/controllers/chainnodeset/upgrades.go
+++ b/internal/controllers/chainnodeset/upgrades.go
@@ -9,8 +9,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func (r *Reconciler) ensureUpgrades(ctx context.Context, nodeSet *appsv1.ChainNodeSet) error {

--- a/internal/controllers/chainnodeset/utils.go
+++ b/internal/controllers/chainnodeset/utils.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 func AddOrUpdateNodeStatus(nodeSet *v1.ChainNodeSet, status v1.ChainNodeSetNodeStatus) {

--- a/internal/controllers/chainnodeset/utils_test.go
+++ b/internal/controllers/chainnodeset/utils_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestValidatorNodeName(t *testing.T) {

--- a/internal/controllers/chainnodeset/validator.go
+++ b/internal/controllers/chainnodeset/validator.go
@@ -14,11 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func (r *Reconciler) ensureValidator(ctx context.Context, nodeSet *appsv1.ChainNodeSet) error {

--- a/internal/controllers/chainnodeset/validator_test.go
+++ b/internal/controllers/chainnodeset/validator_test.go
@@ -24,9 +24,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func newValidatorTestReconciler(t *testing.T, objs ...client.Object) *Reconciler {

--- a/internal/controllers/guard_labels.go
+++ b/internal/controllers/guard_labels.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	"strings"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // CosmoGuardLabelDomain is the label-key domain CosmoGuard owns: the guard-private selector labels

--- a/internal/cosmoguard/apply.go
+++ b/internal/cosmoguard/apply.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 // ApplyOwned creates or updates obj as a resource owned by owner. It refuses to overwrite a

--- a/internal/cosmoguard/cleanup.go
+++ b/internal/cosmoguard/cleanup.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 // Undeploy deletes the owned CosmoGuard StatefulSet, Services (client + headless peer), encryption

--- a/internal/cosmoguard/cosmoguard.go
+++ b/internal/cosmoguard/cosmoguard.go
@@ -31,10 +31,10 @@ import (
 	"k8s.io/utils/ptr"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 func intToStr(i int) string { return strconv.Itoa(i) }

--- a/internal/cosmoguard/cosmoguard_test.go
+++ b/internal/cosmoguard/cosmoguard_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/utils/ptr"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func baseParams() Params {

--- a/internal/cosmosigner/apply.go
+++ b/internal/cosmosigner/apply.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 const LifecycleDigestAnnotation = "cosmopilot.voluzi.com/cosmosigner-lifecycle-digest"

--- a/internal/cosmosigner/cleanup.go
+++ b/internal/cosmosigner/cleanup.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	cosmopilotv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	cosmopilotv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 // IsOwnedSignerStatefulSet reports whether sts is a cosmosigner deployment controlled by owner.

--- a/internal/cosmosigner/cleanup_test.go
+++ b/internal/cosmosigner/cleanup_test.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	cosmopilotv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	cosmopilotv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func TestProtectRetainedStatePVCsUpgradesOnlyVerifiedClaims(t *testing.T) {

--- a/internal/cosmosigner/cosmosigner.go
+++ b/internal/cosmosigner/cosmosigner.go
@@ -16,10 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 const (

--- a/internal/cosmosigner/cosmosigner_test.go
+++ b/internal/cosmosigner/cosmosigner_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 func testParams() Params {

--- a/internal/cosmosigner/gcp_import_recovery_test.go
+++ b/internal/cosmosigner/gcp_import_recovery_test.go
@@ -14,7 +14,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	cosmopilotv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	cosmopilotv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // A Cloud KMS import is NOT idempotent: every `cosmosigner import` run calls ImportCryptoKeyVersion

--- a/internal/cosmosigner/jobs.go
+++ b/internal/cosmosigner/jobs.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 const (

--- a/internal/cosmosigner/jobs_test.go
+++ b/internal/cosmosigner/jobs_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
 )
 
 func TestParsePublicKeyOutput(t *testing.T) {

--- a/internal/cosmosigner/migration.go
+++ b/internal/cosmosigner/migration.go
@@ -6,7 +6,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // RetainedStateRequired reports whether an established signer must still have every locked Raft PVC.

--- a/internal/cosmosigner/migration_test.go
+++ b/internal/cosmosigner/migration_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	cosmopilotv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	cosmopilotv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestReconcileStatefulSetMigrationWaitsForTerminatingPod(t *testing.T) {

--- a/internal/cosmosigner/reservation.go
+++ b/internal/cosmosigner/reservation.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // ErrConsensusKeyReservationConflict marks an ownership or identity conflict that means another

--- a/internal/cosmosigner/reservation_lifecycle.go
+++ b/internal/cosmosigner/reservation_lifecycle.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // ReservationOwnerFinalizer keeps a controller root available until its signing paths are gone and

--- a/internal/cosmosigner/reservation_lifecycle_test.go
+++ b/internal/cosmosigner/reservation_lifecycle_test.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestEnsureConsensusKeyReservationOwnerFinalizerPersistsBeforeClaim(t *testing.T) {

--- a/internal/cosmosigner/reservation_test.go
+++ b/internal/cosmosigner/reservation_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const reservationTestPublicKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/internal/datasnapshot/gcs.go
+++ b/internal/datasnapshot/gcs.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 const (

--- a/internal/datasnapshot/gcs_test.go
+++ b/internal/datasnapshot/gcs_test.go
@@ -8,7 +8,7 @@ import (
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +19,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
 )
 
 func TestGCSCreateSnapshotAuthModes(t *testing.T) {

--- a/internal/datasnapshot/s3.go
+++ b/internal/datasnapshot/s3.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 const s3Exporter = "s3-exporter"

--- a/internal/datasnapshot/s3_test.go
+++ b/internal/datasnapshot/s3_test.go
@@ -18,8 +18,8 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/pkg/dataexporter"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/pkg/dataexporter"
 )
 
 func TestS3CreateSnapshotAuthAndStorageOptions(t *testing.T) {

--- a/internal/datasnapshot/snapshot.go
+++ b/internal/datasnapshot/snapshot.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 type SnapshotStatus string

--- a/internal/resourcecleanup/cleanup.go
+++ b/internal/resourcecleanup/cleanup.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const (

--- a/internal/resourcecleanup/cleanup_test.go
+++ b/internal/resourcecleanup/cleanup_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 func TestRootOwnerForChainNodeSetChild(t *testing.T) {

--- a/internal/resourcecleanup/root_protection.go
+++ b/internal/resourcecleanup/root_protection.go
@@ -3,8 +3,8 @@ package resourcecleanup
 import (
 	"context"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/resourcecleanup/root_protection_test.go
+++ b/internal/resourcecleanup/root_protection_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 func TestProtectExistingRootsInstallsCleanupFinalizer(t *testing.T) {

--- a/internal/tmkms/hashicorp.go
+++ b/internal/tmkms/hashicorp.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 const (

--- a/internal/tmkms/tmkms.go
+++ b/internal/tmkms/tmkms.go
@@ -17,8 +17,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 type KMS struct {

--- a/pkg/dataexporter/utils.go
+++ b/pkg/dataexporter/utils.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/c2h5oh/datasize"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 // GetDirSize calculates the total size of a directory and its contents.

--- a/pkg/informer/informers.go
+++ b/pkg/informer/informers.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const (

--- a/pkg/nodeutils/http.go
+++ b/pkg/nodeutils/http.go
@@ -14,8 +14,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/statscollector"
-	"github.com/voluzi/cosmopilot/v2/pkg/utils"
+	"github.com/voluzi/cosmopilot/v3/pkg/statscollector"
+	"github.com/voluzi/cosmopilot/v3/pkg/utils"
 )
 
 func (s *NodeUtils) registerRoutes() {

--- a/pkg/nodeutils/node.go
+++ b/pkg/nodeutils/node.go
@@ -13,10 +13,10 @@ import (
 	"github.com/shirou/gopsutil/process"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/pkg/proxy"
-	"github.com/voluzi/cosmopilot/v2/pkg/statscollector"
-	"github.com/voluzi/cosmopilot/v2/pkg/tracer"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/pkg/proxy"
+	"github.com/voluzi/cosmopilot/v3/pkg/statscollector"
+	"github.com/voluzi/cosmopilot/v3/pkg/tracer"
 )
 
 const (

--- a/pkg/nodeutils/signer_discovery_test.go
+++ b/pkg/nodeutils/signer_discovery_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/proxy"
+	"github.com/voluzi/cosmopilot/v3/pkg/proxy"
 )
 
 type blockingSignerPeerResolver struct {

--- a/test/e2e/apps/allora.go
+++ b/test/e2e/apps/allora.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // Allora returns the test configuration for Allora Network blockchain.

--- a/test/e2e/apps/cosmoshub.go
+++ b/test/e2e/apps/cosmoshub.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // CosmosHub returns the test configuration for Cosmos Hub (Gaia) blockchain.

--- a/test/e2e/apps/nibiru.go
+++ b/test/e2e/apps/nibiru.go
@@ -3,7 +3,7 @@ package apps
 import (
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // Nibiru returns the test configuration for Nibiru blockchain.

--- a/test/e2e/apps/osmosis.go
+++ b/test/e2e/apps/osmosis.go
@@ -3,7 +3,7 @@ package apps
 import (
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // Osmosis returns the test configuration for Osmosis blockchain.

--- a/test/e2e/apps/registry.go
+++ b/test/e2e/apps/registry.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
 )
 
 // currentArch returns the current CPU architecture in Docker/OCI format

--- a/test/e2e/apps/types.go
+++ b/test/e2e/apps/types.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // defaultConfigOverride contains hardcoded config overrides applied to all test chains.

--- a/test/e2e/chainnode_genesis_test.go
+++ b/test/e2e/chainnode_genesis_test.go
@@ -8,8 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNode Genesis", func() {

--- a/test/e2e/chainnode_keys_test.go
+++ b/test/e2e/chainnode_keys_test.go
@@ -9,9 +9,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers/chainnode"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers/chainnode"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNode Keys", func() {

--- a/test/e2e/chainnode_snapshot_test.go
+++ b/test/e2e/chainnode_snapshot_test.go
@@ -12,8 +12,8 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("Snapshot E2E", func() {

--- a/test/e2e/chainnode_tmkms_test.go
+++ b/test/e2e/chainnode_tmkms_test.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNode TMKMS", func() {

--- a/test/e2e/chainnode_vpa_test.go
+++ b/test/e2e/chainnode_vpa_test.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
-	"github.com/voluzi/cosmopilot/v2/test/framework"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
+	"github.com/voluzi/cosmopilot/v3/test/framework"
 )
 
 // getVPAResourcesFromAnnotation extracts the resource requirements from the VPA annotation.

--- a/test/e2e/chainnodeset_basic_test.go
+++ b/test/e2e/chainnodeset_basic_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNodeSet Basic", func() {

--- a/test/e2e/chainnodeset_cosmosigner_test.go
+++ b/test/e2e/chainnodeset_cosmosigner_test.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/cometbft"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	chainnodecontroller "github.com/voluzi/cosmopilot/v2/internal/controllers/chainnode"
-	managedcosmosigner "github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/cometbft"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	chainnodecontroller "github.com/voluzi/cosmopilot/v3/internal/controllers/chainnode"
+	managedcosmosigner "github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNodeSet Cosmosigner", func() {

--- a/test/e2e/chainnodeset_multi_validator_test.go
+++ b/test/e2e/chainnodeset_multi_validator_test.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/chainutils"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/chainutils"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNodeSet Multi-Validator Genesis", func() {

--- a/test/e2e/chainnodeset_scaling_test.go
+++ b/test/e2e/chainnodeset_scaling_test.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNodeSet Scaling", func() {

--- a/test/e2e/chainnodeset_upgrade_test.go
+++ b/test/e2e/chainnodeset_upgrade_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("ChainNodeSet Governance Upgrade", func() {

--- a/test/e2e/deletion_policy_claim_test.go
+++ b/test/e2e/deletion_policy_claim_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 // These are plain Go tests rather than Ginkgo specs: the decision they cover is what the reservation

--- a/test/e2e/deletion_policy_test.go
+++ b/test/e2e/deletion_policy_test.go
@@ -19,10 +19,10 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	managedcosmosigner "github.com/voluzi/cosmopilot/v2/internal/cosmosigner"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	managedcosmosigner "github.com/voluzi/cosmopilot/v3/internal/cosmosigner"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
 )
 
 var _ = Describe("Deletion policy", func() {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -10,8 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/test/framework"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/test/framework"
 )
 
 // RandString generates a random string of the specified length

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/voluzi/cosmopilot/v2/pkg/environ"
-	"github.com/voluzi/cosmopilot/v2/test/e2e/apps"
-	"github.com/voluzi/cosmopilot/v2/test/framework"
+	"github.com/voluzi/cosmopilot/v3/pkg/environ"
+	"github.com/voluzi/cosmopilot/v3/test/e2e/apps"
+	"github.com/voluzi/cosmopilot/v3/test/framework"
 )
 
 var (

--- a/test/framework/base.go
+++ b/test/framework/base.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/voluzi/cosmopilot/v2/internal/k8s"
+	"github.com/voluzi/cosmopilot/v3/internal/k8s"
 )
 
 const (

--- a/test/framework/envtest.go
+++ b/test/framework/envtest.go
@@ -22,11 +22,11 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers/chainnode"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers/chainnodeset"
-	"github.com/voluzi/cosmopilot/v2/pkg/nodeutils"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers/chainnode"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers/chainnodeset"
+	"github.com/voluzi/cosmopilot/v3/pkg/nodeutils"
 )
 
 const (

--- a/test/framework/kind.go
+++ b/test/framework/kind.go
@@ -22,7 +22,7 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const (

--- a/test/framework/mock_nodeutils.go
+++ b/test/framework/mock_nodeutils.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cosmopilotv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	cosmopilotv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const (

--- a/test/integration/chainnode_pvc_test.go
+++ b/test/integration/chainnode_pvc_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 var _ = Describe("ChainNode PVC", func() {

--- a/test/integration/chainnode_status_test.go
+++ b/test/integration/chainnode_status_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 var _ = Describe("ChainNode Status", func() {

--- a/test/integration/chainnode_vpa_test.go
+++ b/test/integration/chainnode_vpa_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 var _ = Describe("ChainNode VPA", func() {

--- a/test/integration/chainnode_webhook_test.go
+++ b/test/integration/chainnode_webhook_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 var _ = Describe("ChainNode Webhook Validation", func() {

--- a/test/integration/chainnodeset_test.go
+++ b/test/integration/chainnodeset_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/controllers"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/controllers"
 )
 
 var _ = Describe("ChainNodeSet", func() {

--- a/test/integration/chainnodeset_webhook_test.go
+++ b/test/integration/chainnodeset_webhook_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 var _ = Describe("ChainNodeSet Webhook Validation", func() {

--- a/test/integration/cosmosigner_webhook_test.go
+++ b/test/integration/cosmosigner_webhook_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 var _ = Describe("Cosmosigner Webhook Validation", func() {

--- a/test/integration/deletion_policy_test.go
+++ b/test/integration/deletion_policy_test.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
-	"github.com/voluzi/cosmopilot/v2/internal/resourcecleanup"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
+	"github.com/voluzi/cosmopilot/v3/internal/resourcecleanup"
 )
 
 var _ = Describe("Deletion policy", func() {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/voluzi/cosmopilot/v2/api/v1"
+	appsv1 "github.com/voluzi/cosmopilot/v3/api/v1"
 )
 
 const (

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/voluzi/cosmopilot/v2/test/framework"
+	"github.com/voluzi/cosmopilot/v3/test/framework"
 )
 
 var (


### PR DESCRIPTION
Prerequisite for tagging `v3.0.0`. Go requires the major version in the module path from v2 onward, so a `v3.0.0` tag against `module github.com/voluzi/cosmopilot/v2` would leave the repo self-inconsistent and `go get …/v2@v3.0.0` broken.

Mirrors what `920a620` did for the v1 -> v2 release.

## Changes

**Module path.** Purely mechanical: `github.com/voluzi/cosmopilot/v2` -> `.../v3` across 181 `.go` files and the `module` line in `go.mod`. No other file type referenced the path. `go.sum` is untouched and `go mod tidy` pulled in no new requirements.

**Chart.yaml placeholder.** `version` was `2.3.1` while the released chart was `2.3.0` — a value that reads as intent but has no effect. `make helm.package` overrides both fields from git tags (`--version` from the `chart/v*` tag, `--app-version` from the cosmopilot `v*` tag), so the file's values never reach a published chart. Set `version: 0.0.0` to match the already-placeholder `appVersion`, with a comment explaining why.

Verified by packaging on this branch: the file reads `0.0.0`/`0.0.0`, the artifact came out `cosmopilot-2.3.0.tgz` with `version: 2.3.0` and `appVersion: 2.3.0` from the tags.

## Verification

- `make test.unit` (manifests, generate, fmt, vet, unit tests) green
- Integration suite green
- `go vet ./test/...` clean, so the e2e suite still compiles
- No codegen or manifest drift: `zz_generated.deepcopy.go` changed only on its import line

## Merge order

This must land **before** the `v3.0.0` tag is cut.

Note for whoever cuts the release: `appVersion` comes from `git describe` of the nearest non-chart tag, so `v3.0.0` must be tagged **before** `chart/v3.0.0` — otherwise the chart publishes pointing at the previous operator image. Push the two tags as separate commands; GitHub fires no events when more than three tags arrive in one push.